### PR TITLE
Add PCB service-account authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Support service-account authentication.
+
 ### Changed
 
 - Default DFM to `standard` and consolidate the bundled JLCPCB PDK.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ pcb import <KICAD_SCH|KICAD_PRO> <OUTPUT_DIR> # Import a KiCad schematic or proj
 
 Run `pcb help` or `pcb help <command>` for the full command reference.
 
+Authenticate a machine with `pcb auth login --service-account`, or import
+JSON (`client_id`, `client_secret`) with
+`pcb auth login --service-account --stdin < credentials.json`.
+For CI, set `DIODE_API_URL`, `DIODE_CLIENT_ID`, and `DIODE_CLIENT_SECRET`.
+PCB renews access tokens automatically.
+
 ## License
 
 Diode-authored code and docs are licensed under the MIT License except where

--- a/crates/pcb-diode-api/Cargo.toml
+++ b/crates/pcb-diode-api/Cargo.toml
@@ -52,7 +52,7 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true }
 urlencoding = { workspace = true }
-uuid = { workspace = true }
+uuid = { workspace = true, features = ["serde"] }
 walkdir = { workspace = true }
 zip = { workspace = true }
 zstd = { workspace = true }

--- a/crates/pcb-diode-api/src/auth.rs
+++ b/crates/pcb-diode-api/src/auth.rs
@@ -15,6 +15,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::WorkspaceContext;
 
+mod service_account;
+
 const NOT_AUTHENTICATED_MESSAGE: &str = "Not authenticated. Run `pcb auth login` to authenticate.";
 const DIODE_API_AUTH_NONE: &str = "none";
 
@@ -28,6 +30,13 @@ pub struct AuthTokens {
     pub token_endpoint: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub client_id: Option<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum StoredAuth {
+    User(AuthTokens),
+    ServiceAccount(service_account::ServiceAccountAuth),
 }
 
 impl AuthTokens {
@@ -91,13 +100,32 @@ fn get_auth_file_path(ctx: &WorkspaceContext) -> Result<PathBuf> {
     Ok(scoped_dir.join(format!("{slug}.toml")))
 }
 
-fn load_tokens_with_context(ctx: &WorkspaceContext) -> Result<Option<AuthTokens>> {
+fn load_auth(ctx: &WorkspaceContext) -> Result<Option<StoredAuth>> {
     let path = get_auth_file_path(ctx)?;
     if !path.exists() {
         return Ok(None);
     }
     let contents = fs::read_to_string(&path)?;
-    Ok(Some(toml::from_str(&contents)?))
+    // TOML errors include the input. Never include credential contents in diagnostics.
+    let value: toml::Value = toml::from_str(&contents)
+        .map_err(|_| anyhow::anyhow!("Invalid authentication file: {}", path.display()))?;
+    let auth = if value.get("kind").is_some() {
+        value.try_into()
+    } else {
+        value.try_into().map(StoredAuth::User)
+    }
+    .map_err(|_| anyhow::anyhow!("Invalid authentication file: {}", path.display()))?;
+    Ok(Some(auth))
+}
+
+fn load_tokens_with_context(ctx: &WorkspaceContext) -> Result<Option<AuthTokens>> {
+    match load_auth(ctx)? {
+        Some(StoredAuth::User(tokens)) => Ok(Some(tokens)),
+        Some(StoredAuth::ServiceAccount(_)) => {
+            anyhow::bail!("Service accounts use client credentials, not human refresh tokens")
+        }
+        None => Ok(None),
+    }
 }
 
 pub fn load_tokens() -> Result<Option<AuthTokens>> {
@@ -122,11 +150,30 @@ fn save_tokens(
         token_endpoint: token_endpoint.map(str::to_string),
         client_id: client_id.map(str::to_string),
     };
-    let contents = toml::to_string(&tokens)?;
+    save_auth(ctx, &StoredAuth::User(tokens))
+}
+
+fn lock_auth(ctx: &WorkspaceContext) -> Result<LockFile> {
+    let mut lock = LockFile::open(&get_auth_file_path(ctx)?.with_extension("toml.lock"))?;
+    lock.lock()?;
+    Ok(lock)
+}
+
+fn save_auth(ctx: &WorkspaceContext, auth: &StoredAuth) -> Result<()> {
+    // Human files retain their legacy shape for older PCB toolchains.
+    let contents = match auth {
+        StoredAuth::User(tokens) => toml::to_string(tokens),
+        StoredAuth::ServiceAccount(_) => toml::to_string(auth),
+    }?;
 
     let auth_path = get_auth_file_path(ctx)?;
     AtomicFile::new(&auth_path, OverwriteBehavior::AllowOverwrite)
         .write(|f| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                f.set_permissions(fs::Permissions::from_mode(0o600))?;
+            }
             f.write_all(contents.as_bytes())?;
             f.flush()
         })
@@ -136,6 +183,7 @@ fn save_tokens(
 }
 
 fn clear_tokens_with_context(ctx: &WorkspaceContext) -> Result<()> {
+    let _lock = lock_auth(ctx)?;
     let path = get_auth_file_path(ctx)?;
     if path.exists() {
         fs::remove_file(&path)?;
@@ -170,9 +218,7 @@ fn oauth_client() -> Result<Client> {
 }
 
 fn refresh_tokens_with_context(ctx: &WorkspaceContext) -> Result<AuthTokens> {
-    let lock_path = get_auth_file_path(ctx)?.with_extension("toml.lock");
-    let mut lock = LockFile::open(&lock_path)?;
-    lock.lock()?;
+    let _lock = lock_auth(ctx)?;
 
     let tokens = load_tokens_with_context(ctx)?.context("No tokens to refresh")?;
     if !tokens.is_expired() {
@@ -266,8 +312,16 @@ fn get_valid_token_with_sources(
 ) -> Result<String> {
     let not_authenticated = || anyhow::anyhow!(NOT_AUTHENTICATED_MESSAGE);
 
-    let Some(tokens) = load_tokens_with_context(ctx)? else {
-        return Err(not_authenticated());
+    if let Some(token) = service_account::environment_token(ctx, false)? {
+        return Ok(token.access_token);
+    }
+
+    let tokens = match load_auth(ctx)? {
+        Some(StoredAuth::User(tokens)) => tokens,
+        Some(StoredAuth::ServiceAccount(account)) => {
+            return Ok(service_account::saved_token(ctx, account, false)?.access_token);
+        }
+        None => return Err(not_authenticated()),
     };
 
     if !tokens.is_expired() {
@@ -462,6 +516,7 @@ pub fn login_with_context(ctx: &WorkspaceContext) -> Result<()> {
         .checked_add(tokens.expires_in)
         .context("Token expiry is too large")?;
 
+    let _lock = lock_auth(ctx)?;
     save_tokens(
         ctx,
         &tokens.access_token,
@@ -561,20 +616,35 @@ pub fn logout_with_context(ctx: &WorkspaceContext) -> Result<()> {
     // Bearer tokens left behind by the retired AWS credential exchange.
     let _ = fs::remove_dir_all(get_auth_dir()?.join("service-auth"));
     println!("✓ Logged out successfully");
+    if service_account::environment_configured() {
+        eprintln!(
+            "Environment credentials remain active. Unset DIODE_CLIENT_ID and DIODE_CLIENT_SECRET to stop using them."
+        );
+    }
     Ok(())
 }
 
 pub fn status_with_context(ctx: &WorkspaceContext) -> Result<()> {
     println!("Authentication Status:");
+    println!("  Endpoint: {}", ctx.api_base_url());
     if api_auth_disabled() {
         println!("  Status: API auth disabled");
         println!("  Method: DIODE_API_AUTH=none");
         return Ok(());
     }
 
-    match load_tokens_with_context(ctx)? {
-        Some(tokens) => {
+    if let Some(account) = service_account::from_environment(ctx)? {
+        account.print_status("environment");
+        return Ok(());
+    }
+    match load_auth(ctx)? {
+        Some(StoredAuth::ServiceAccount(account)) => {
+            account.validate(ctx)?;
+            account.print_status("saved login");
+        }
+        Some(StoredAuth::User(tokens)) => {
             println!("  Status: Logged in");
+            println!("  Method: human login");
             if let Some(email) = &tokens.email {
                 println!("  Email: {}", email);
             }
@@ -594,6 +664,21 @@ pub fn status_with_context(ctx: &WorkspaceContext) -> Result<()> {
 }
 
 pub fn refresh_with_context(ctx: &WorkspaceContext) -> Result<()> {
+    if let Some(token) = service_account::environment_token(ctx, true)? {
+        println!(
+            "✓ Service-account token renewed (expires in {})",
+            time_until_expiry(token.expires_at)
+        );
+        return Ok(());
+    }
+    if let Some(StoredAuth::ServiceAccount(account)) = load_auth(ctx)? {
+        let token = service_account::saved_token(ctx, account, true)?;
+        println!(
+            "✓ Service-account token renewed (expires in {})",
+            time_until_expiry(token.expires_at)
+        );
+        return Ok(());
+    }
     let tokens = refresh_tokens_with_context(ctx)?;
     println!("✓ Token refreshed successfully");
     if let Some(email) = &tokens.email {
@@ -603,16 +688,16 @@ pub fn refresh_with_context(ctx: &WorkspaceContext) -> Result<()> {
     Ok(())
 }
 
-#[derive(Args, Debug)]
+#[derive(Args)]
 #[command(about = "Manage authentication")]
 pub struct AuthArgs {
     #[command(subcommand)]
     command: Option<AuthCommand>,
 }
 
-#[derive(Subcommand, Debug)]
+#[derive(Subcommand)]
 pub enum AuthCommand {
-    Login,
+    Login(LoginArgs),
     Logout,
     Status,
     Refresh,
@@ -622,15 +707,37 @@ pub enum AuthCommand {
     Git(crate::git_auth::GitAuthArgs),
 }
 
+#[derive(Args, Default)]
+pub struct LoginArgs {
+    /// Configure a service account with client credentials
+    #[arg(long, conflicts_with = "setup_code")]
+    service_account: bool,
+    /// Read service-account credentials as JSON from stdin
+    #[arg(long = "stdin", requires = "service_account")]
+    from_stdin: bool,
+    /// Redeem a one-time setup code from the service-account console
+    #[arg(long, value_name = "CODE", conflicts_with = "service_account")]
+    setup_code: Option<String>,
+}
+
 pub fn token_with_context(ctx: &WorkspaceContext) -> Result<()> {
     let token = get_valid_token_with_context(ctx)?;
-    println!("{}", token);
+    pcb_ui::write_stdout(|out| writeln!(out, "{token}"))?;
     Ok(())
 }
 
 pub fn execute(args: AuthArgs, ctx: &WorkspaceContext) -> Result<()> {
     match args.command {
-        Some(AuthCommand::Login) | None => login_with_context(ctx),
+        Some(AuthCommand::Login(args)) => {
+            if let Some(code) = args.setup_code {
+                service_account::setup(ctx, &code)
+            } else if args.service_account {
+                service_account::login(ctx, args.from_stdin)
+            } else {
+                login_with_context(ctx)
+            }
+        }
+        None => login_with_context(ctx),
         Some(AuthCommand::Logout) => logout_with_context(ctx),
         Some(AuthCommand::Status) => status_with_context(ctx),
         Some(AuthCommand::Refresh) => refresh_with_context(ctx),
@@ -646,13 +753,13 @@ mod tests {
     use std::cell::Cell;
     use std::ffi::OsString;
 
-    struct EnvGuard {
+    pub(super) struct EnvGuard {
         key: &'static str,
         previous: Option<OsString>,
     }
 
     impl EnvGuard {
-        fn set(key: &'static str, value: &std::path::Path) -> Self {
+        pub(super) fn set(key: &'static str, value: impl AsRef<std::ffi::OsStr>) -> Self {
             let previous = std::env::var_os(key);
             unsafe {
                 std::env::set_var(key, value);
@@ -660,10 +767,10 @@ mod tests {
             Self { key, previous }
         }
 
-        fn set_str(key: &'static str, value: &str) -> Self {
+        fn unset(key: &'static str) -> Self {
             let previous = std::env::var_os(key);
             unsafe {
-                std::env::set_var(key, value);
+                std::env::remove_var(key);
             }
             Self { key, previous }
         }
@@ -688,10 +795,19 @@ mod tests {
             .as_secs() as i64
     }
 
-    fn isolated_context() -> (tempfile::TempDir, EnvGuard, WorkspaceContext) {
+    pub(super) fn isolated_context() -> (tempfile::TempDir, Vec<EnvGuard>, WorkspaceContext) {
         let tempdir = tempfile::tempdir().unwrap();
-        let guard = EnvGuard::set("PCB_CONFIG_DIR", tempdir.path());
-        (tempdir, guard, WorkspaceContext::default())
+        let mut guards: Vec<_> = [
+            "DIODE_CLIENT_ID",
+            "DIODE_CLIENT_SECRET",
+            "DIODE_API_URL",
+            "DIODE_API_AUTH",
+        ]
+        .into_iter()
+        .map(EnvGuard::unset)
+        .collect();
+        guards.push(EnvGuard::set("PCB_CONFIG_DIR", tempdir.path()));
+        (tempdir, guards, WorkspaceContext::default())
     }
 
     #[test]
@@ -714,7 +830,7 @@ mod tests {
     #[serial]
     fn api_auth_none_returns_no_api_token() {
         let (_tempdir, _config_guard, ctx) = isolated_context();
-        let _auth_guard = EnvGuard::set_str("DIODE_API_AUTH", "none");
+        let _auth_guard = EnvGuard::set("DIODE_API_AUTH", "none");
 
         assert_eq!(get_api_token_with_context(&ctx).unwrap(), None);
     }

--- a/crates/pcb-diode-api/src/auth/service_account.rs
+++ b/crates/pcb-diode-api/src/auth/service_account.rs
@@ -252,24 +252,19 @@ fn require_direct_auth() -> Result<()> {
 
 pub(super) fn login(ctx: &WorkspaceContext, from_stdin: bool) -> Result<()> {
     require_direct_auth()?;
-    let (ctx, credentials) = if from_stdin {
+    let credentials = if from_stdin {
         let import: CredentialImport =
             serde_json::from_reader(io::stdin().lock()).map_err(|_| {
                 anyhow::anyhow!("Invalid credential JSON; expected client_id and client_secret")
             })?;
-        let imported_url = import.api_base_url.as_deref().map(api_url).transpose()?;
-        if let Some(url) = &imported_url
-            && std::env::var_os("DIODE_API_URL").is_some()
-            && *url != api_url(ctx.api_base_url())?
+        if let Some(url) = &import.api_base_url
+            && api_url(url)? != api_url(ctx.api_base_url())?
         {
-            bail!("Credential JSON endpoint differs from DIODE_API_URL");
+            bail!(
+                "Credential JSON endpoint differs from the active endpoint. Set DIODE_API_URL to its api_base_url before importing."
+            );
         }
-        let import_ctx = match imported_url {
-            Some(url) if url == api_url(ctx.api_base_url())? => ctx.clone(),
-            Some(url) => WorkspaceContext::from_api_base_url(url),
-            None => ctx.clone(),
-        };
-        (import_ctx, import.credentials)
+        import.credentials
     } else {
         if !io::stdin().is_terminal() {
             bail!(
@@ -283,17 +278,14 @@ pub(super) fn login(ctx: &WorkspaceContext, from_stdin: bool) -> Result<()> {
         let client_secret = inquire::Password::new("Client secret:")
             .without_confirmation()
             .prompt()?;
-        (
-            ctx.clone(),
-            Credentials {
-                client_id,
-                client_secret: client_secret.trim().to_string(),
-                service_account_name: None,
-            },
-        )
+        Credentials {
+            client_id,
+            client_secret: client_secret.trim().to_string(),
+            service_account_name: None,
+        }
     };
     configure(
-        &ctx,
+        ctx,
         ServiceAccountAuth {
             api_base_url: api_url(ctx.api_base_url())?,
             credentials,

--- a/crates/pcb-diode-api/src/auth/service_account.rs
+++ b/crates/pcb-diode-api/src/auth/service_account.rs
@@ -1,0 +1,403 @@
+use super::{
+    StoredAuth, load_auth, lock_auth, oauth_client, save_auth, time_until_expiry, unix_now,
+};
+use crate::WorkspaceContext;
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::io::{self, IsTerminal};
+use std::sync::Mutex;
+use url::{Host, Url};
+use uuid::Uuid;
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Credentials {
+    client_id: Uuid,
+    client_secret: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    service_account_name: Option<String>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(super) struct AccessToken {
+    pub access_token: String,
+    pub expires_at: i64,
+}
+
+impl AccessToken {
+    fn is_valid(&self) -> bool {
+        unix_now().is_ok_and(|now| self.expires_at.saturating_sub(now) > 60)
+    }
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(super) struct ServiceAccountAuth {
+    api_base_url: String,
+    #[serde(flatten)]
+    credentials: Credentials,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    token: Option<AccessToken>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    setup_id: Option<Uuid>,
+}
+
+impl ServiceAccountAuth {
+    pub(super) fn validate(&self, ctx: &WorkspaceContext) -> Result<()> {
+        if api_url(&self.api_base_url)? != api_url(ctx.api_base_url())? {
+            bail!("Service-account credentials belong to a different API endpoint");
+        }
+        if self.credentials.client_secret.is_empty() {
+            bail!("Invalid service-account client secret");
+        }
+        Ok(())
+    }
+
+    pub(super) fn print_status(&self, source: &str) {
+        println!("  Status: Service account configured");
+        println!("  Source: {source}");
+        if let Some(name) = &self.credentials.service_account_name {
+            println!("  Service account: {name}");
+        }
+        println!("  Client ID: {}", self.credentials.client_id);
+        match &self.token {
+            Some(token) if token.is_valid() => {
+                println!(
+                    "  Token expires in: {}",
+                    time_until_expiry(token.expires_at)
+                );
+            }
+            _ => println!("  Token: obtained automatically on the next request"),
+        }
+        if self.setup_id.is_some() {
+            println!("  Console confirmation pending; run `pcb auth refresh` to retry");
+        }
+    }
+}
+
+fn api_url(value: &str) -> Result<String> {
+    let url = Url::parse(value).map_err(|_| anyhow::anyhow!("Invalid service-account API URL"))?;
+    let loopback = match url.host() {
+        Some(Host::Domain("localhost")) => true,
+        Some(Host::Ipv4(ip)) => ip.is_loopback(),
+        Some(Host::Ipv6(ip)) => ip.is_loopback(),
+        _ => false,
+    };
+    if !url.username().is_empty()
+        || url.password().is_some()
+        || url.query().is_some()
+        || url.fragment().is_some()
+        || url.host().is_none()
+        || !(url.scheme() == "https" || (url.scheme() == "http" && loopback))
+    {
+        bail!(
+            "Service-account API URL must use HTTPS (or HTTP on loopback), without user info, query, or fragment"
+        );
+    }
+    Ok(url.as_str().trim_end_matches('/').to_string())
+}
+
+pub(super) fn environment_configured() -> bool {
+    std::env::var_os("DIODE_CLIENT_ID").is_some()
+        || std::env::var_os("DIODE_CLIENT_SECRET").is_some()
+}
+
+pub(super) fn from_environment(ctx: &WorkspaceContext) -> Result<Option<ServiceAccountAuth>> {
+    if !environment_configured() {
+        return Ok(None);
+    }
+    let client_id = std::env::var("DIODE_CLIENT_ID")
+        .ok()
+        .and_then(|id| Uuid::parse_str(&id).ok())
+        .context("Set DIODE_CLIENT_ID to the service-account client UUID")?;
+    let client_secret = std::env::var("DIODE_CLIENT_SECRET")
+        .map_err(|_| anyhow::anyhow!("Set DIODE_CLIENT_SECRET with DIODE_CLIENT_ID"))?;
+    // An explicit URL keeps repository configuration from redirecting CI secrets.
+    let api_base_url = std::env::var("DIODE_API_URL").map_err(|_| {
+        anyhow::anyhow!("Set DIODE_API_URL when using environment client credentials")
+    })?;
+    let account = ServiceAccountAuth {
+        api_base_url: api_url(&api_base_url)?,
+        credentials: Credentials {
+            client_id,
+            client_secret,
+            service_account_name: None,
+        },
+        token: None,
+        setup_id: None,
+    };
+    account.validate(ctx)?;
+    Ok(Some(account))
+}
+
+struct EnvironmentToken {
+    key: [u8; 32],
+    token: AccessToken,
+}
+
+static ENVIRONMENT_TOKEN: Mutex<Option<EnvironmentToken>> = Mutex::new(None);
+
+pub(super) fn environment_token(
+    ctx: &WorkspaceContext,
+    force: bool,
+) -> Result<Option<AccessToken>> {
+    let Some(account) = from_environment(ctx)? else {
+        return Ok(None);
+    };
+    let key = Sha256::digest(format!(
+        "{}\0{}\0{}",
+        account.api_base_url, account.credentials.client_id, account.credentials.client_secret
+    ))
+    .into();
+    let mut cache = ENVIRONMENT_TOKEN.lock().unwrap();
+    if !force
+        && let Some(cached) = cache.as_ref()
+        && cached.key == key
+        && cached.token.is_valid()
+    {
+        return Ok(Some(cached.token.clone()));
+    }
+    let token = exchange(&account)?;
+    *cache = Some(EnvironmentToken {
+        key,
+        token: token.clone(),
+    });
+    Ok(Some(token))
+}
+
+pub(super) fn saved_token(
+    ctx: &WorkspaceContext,
+    account: ServiceAccountAuth,
+    force: bool,
+) -> Result<AccessToken> {
+    account.validate(ctx)?;
+    if !force && let Some(token) = account.token.filter(AccessToken::is_valid) {
+        return Ok(token);
+    }
+    let _lock = lock_auth(ctx)?;
+    // Re-read after locking: another process may have renewed or replaced it.
+    let Some(StoredAuth::ServiceAccount(mut account)) = load_auth(ctx)? else {
+        bail!("Authentication changed while renewing the token; retry the command");
+    };
+    account.validate(ctx)?;
+    if !force && let Some(token) = account.token.as_ref().filter(|token| token.is_valid()) {
+        return Ok(token.clone());
+    }
+    let token = exchange(&account)?;
+    account.token = Some(token.clone());
+    save_auth(ctx, &StoredAuth::ServiceAccount(account.clone()))?;
+    finish_setup(ctx, &mut account);
+    Ok(token)
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    expires_in: i64,
+}
+
+fn exchange(account: &ServiceAccountAuth) -> Result<AccessToken> {
+    let response = oauth_client()?
+        .post(format!("{}/api/auth/token", account.api_base_url))
+        .basic_auth(
+            account.credentials.client_id,
+            Some(&account.credentials.client_secret),
+        )
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        )
+        .body("grant_type=client_credentials")
+        .send()
+        .context("Service-account token exchange failed")?;
+    if response.status() == reqwest::StatusCode::UNAUTHORIZED {
+        bail!(
+            "Service-account credentials were rejected. Replace the configured client ID and secret."
+        );
+    }
+    if !response.status().is_success() {
+        bail!(
+            "Service-account token exchange failed: {}",
+            response.status()
+        );
+    }
+    let response: TokenResponse = response
+        .json()
+        .map_err(|_| anyhow::anyhow!("Invalid service-account token response"))?;
+    let now = unix_now()?;
+    if response.access_token.is_empty() || response.expires_in <= 0 {
+        bail!("Invalid service-account token response");
+    }
+    let expires_at = now
+        .checked_add(response.expires_in)
+        .context("Invalid service-account token expiry")?;
+    Ok(AccessToken {
+        access_token: response.access_token,
+        expires_at,
+    })
+}
+
+#[derive(Deserialize)]
+struct CredentialImport {
+    api_base_url: Option<String>,
+    #[serde(flatten)]
+    credentials: Credentials,
+}
+
+fn require_direct_auth() -> Result<()> {
+    if super::api_auth_disabled() {
+        bail!("Unset DIODE_API_AUTH=none before configuring service-account credentials");
+    }
+    Ok(())
+}
+
+pub(super) fn login(ctx: &WorkspaceContext, from_stdin: bool) -> Result<()> {
+    require_direct_auth()?;
+    let (ctx, credentials) = if from_stdin {
+        let import: CredentialImport =
+            serde_json::from_reader(io::stdin().lock()).map_err(|_| {
+                anyhow::anyhow!("Invalid credential JSON; expected client_id and client_secret")
+            })?;
+        let imported_url = import.api_base_url.as_deref().map(api_url).transpose()?;
+        if let Some(url) = &imported_url
+            && std::env::var_os("DIODE_API_URL").is_some()
+            && *url != api_url(ctx.api_base_url())?
+        {
+            bail!("Credential JSON endpoint differs from DIODE_API_URL");
+        }
+        let import_ctx = match imported_url {
+            Some(url) if url == api_url(ctx.api_base_url())? => ctx.clone(),
+            Some(url) => WorkspaceContext::from_api_base_url(url),
+            None => ctx.clone(),
+        };
+        (import_ctx, import.credentials)
+    } else {
+        if !io::stdin().is_terminal() {
+            bail!(
+                "Use `pcb auth login --service-account --stdin` to import credential JSON non-interactively"
+            );
+        }
+        println!("Endpoint: {}", api_url(ctx.api_base_url())?);
+        let client_id = inquire::Text::new("Client ID:").prompt()?;
+        let client_id = Uuid::parse_str(client_id.trim())
+            .map_err(|_| anyhow::anyhow!("Client ID must be a UUID"))?;
+        let client_secret = inquire::Password::new("Client secret:")
+            .without_confirmation()
+            .prompt()?;
+        (
+            ctx.clone(),
+            Credentials {
+                client_id,
+                client_secret: client_secret.trim().to_string(),
+                service_account_name: None,
+            },
+        )
+    };
+    configure(
+        &ctx,
+        ServiceAccountAuth {
+            api_base_url: api_url(ctx.api_base_url())?,
+            credentials,
+            token: None,
+            setup_id: None,
+        },
+    )
+}
+
+fn configure(ctx: &WorkspaceContext, mut account: ServiceAccountAuth) -> Result<()> {
+    account.validate(ctx)?;
+    account.token = Some(exchange(&account)?);
+    let _lock = lock_auth(ctx)?;
+    save_auth(ctx, &StoredAuth::ServiceAccount(account.clone()))?;
+    pcb_zen::git::clear_diodehub_credential_cache();
+    println!(
+        "✓ Service-account credentials saved for {}",
+        account.api_base_url
+    );
+    if environment_configured() {
+        eprintln!("DIODE_CLIENT_ID and DIODE_CLIENT_SECRET override this saved login while set.");
+    }
+    finish_setup(ctx, &mut account);
+    Ok(())
+}
+
+#[derive(Deserialize)]
+struct SetupResponse {
+    setup_id: Uuid,
+    #[serde(flatten)]
+    credentials: Credentials,
+}
+
+pub(super) fn setup(ctx: &WorkspaceContext, code: &str) -> Result<()> {
+    require_direct_auth()?;
+    let api_base_url = api_url(ctx.api_base_url())?;
+    let response = oauth_client()?
+        .post(format!("{api_base_url}/api/auth/service-account-setup/redeem"))
+        .json(&serde_json::json!({ "setup_code": code }))
+        .send()
+        .context("Setup redemption failed; the code may have been consumed. Check the console before generating a new code.")?;
+    let status = response.status();
+    if status == reqwest::StatusCode::NOT_FOUND {
+        bail!(
+            "This API does not support setup codes yet. Use `pcb auth login --service-account --stdin` to import credentials."
+        );
+    }
+    if !status.is_success() {
+        let error = response.json::<super::OAuthErrorResponse>().ok();
+        match error.as_ref().map(|error| error.error.as_str()) {
+            Some("expired_setup_code") => {
+                bail!("Setup code expired. Generate a new command in the console.")
+            }
+            Some("setup_code_used") => bail!(
+                "Setup code was already used. Check the console before generating a new command."
+            ),
+            Some("invalid_setup_code") => {
+                bail!("Invalid setup code. Copy the command again from the console.")
+            }
+            _ => bail!("Setup redemption failed: {status}"),
+        }
+    }
+    let response: SetupResponse = response.json().map_err(|_| {
+        anyhow::anyhow!("Invalid setup response; check the console before generating a new code")
+    })?;
+    configure(
+        ctx,
+        ServiceAccountAuth {
+            api_base_url,
+            credentials: response.credentials,
+            token: None,
+            setup_id: Some(response.setup_id),
+        },
+    )
+}
+
+// Caller holds the auth-file lock; keep setup_id until confirmation succeeds.
+fn finish_setup(ctx: &WorkspaceContext, account: &mut ServiceAccountAuth) {
+    let Some(setup_id) = account.setup_id else {
+        return;
+    };
+    let confirm = (|| -> Result<()> {
+        let response = oauth_client()?
+            .post(format!(
+                "{}/api/auth/service-account-setup/{setup_id}/confirm",
+                account.api_base_url
+            ))
+            .basic_auth(
+                account.credentials.client_id,
+                Some(&account.credentials.client_secret),
+            )
+            .send()?;
+        if response.status() != reqwest::StatusCode::NO_CONTENT {
+            bail!("Console confirmation failed: {}", response.status());
+        }
+        account.setup_id = None;
+        save_auth(ctx, &StoredAuth::ServiceAccount(account.clone()))
+    })();
+    if let Err(error) = confirm {
+        eprintln!(
+            "Credentials are saved and usable, but setup confirmation failed: {error}. Run `pcb auth refresh` to retry."
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pcb-diode-api/src/auth/service_account/tests.rs
+++ b/crates/pcb-diode-api/src/auth/service_account/tests.rs
@@ -1,0 +1,147 @@
+use super::*;
+use crate::auth::tests::{EnvGuard, isolated_context};
+use crate::auth::{get_auth_file_path, get_valid_token_with_context};
+use base64::Engine;
+use httpmock::prelude::*;
+use serde_json::json;
+use serial_test::serial;
+use std::fs;
+
+const CLIENT_ID: &str = "00000000-0000-4000-8000-000000000001";
+const SECRET: &str = "dsc_test-secret";
+
+fn account(endpoint: &str) -> ServiceAccountAuth {
+    ServiceAccountAuth {
+        api_base_url: endpoint.to_string(),
+        credentials: Credentials {
+            client_id: CLIENT_ID.parse().unwrap(),
+            client_secret: SECRET.to_string(),
+            service_account_name: Some("test-runner".to_string()),
+        },
+        token: None,
+        setup_id: None,
+    }
+}
+
+fn token_mock<'a>(server: &'a MockServer, secret: &str, token: &str) -> httpmock::Mock<'a> {
+    server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/auth/token")
+            .header(
+                "authorization",
+                format!(
+                    "Basic {}",
+                    base64::engine::general_purpose::STANDARD
+                        .encode(format!("{CLIENT_ID}:{secret}"))
+                ),
+            )
+            .header("content-type", "application/x-www-form-urlencoded")
+            .body("grant_type=client_credentials");
+        then.status(200).json_body(json!({
+            "access_token": token, "token_type": "Bearer", "expires_in": 900,
+            "expires_at": unix_now().unwrap() + 900,
+        }));
+    })
+}
+
+#[test]
+#[serial]
+fn saved_credentials_renew_once_across_concurrent_requests() {
+    let (_dir, _env, _) = isolated_context();
+    let server = MockServer::start();
+    let ctx = WorkspaceContext::from_api_base_url(server.base_url());
+    let token = token_mock(&server, SECRET, "machine-token");
+    let mut saved = account(ctx.api_base_url());
+    saved.token = Some(AccessToken {
+        access_token: "expiring".into(),
+        expires_at: unix_now().unwrap() + 30,
+    });
+    save_auth(&ctx, &StoredAuth::ServiceAccount(saved)).unwrap();
+
+    let barrier = std::sync::Barrier::new(4);
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = (0..4)
+            .map(|_| {
+                scope.spawn(|| {
+                    barrier.wait();
+                    get_valid_token_with_context(&ctx).unwrap()
+                })
+            })
+            .collect();
+        for handle in handles {
+            assert_eq!(handle.join().unwrap(), "machine-token");
+        }
+    });
+    assert_eq!(get_valid_token_with_context(&ctx).unwrap(), "machine-token");
+    token.assert_calls(1);
+    let path = get_auth_file_path(&ctx).unwrap();
+    let contents = fs::read_to_string(&path).unwrap();
+    assert!(!contents.contains("refresh_token"));
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            fs::metadata(path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+}
+
+#[test]
+#[serial]
+fn environment_overrides_saved_user_and_cache_tracks_secret_rotation() {
+    let (_dir, _env, _) = isolated_context();
+    let server = MockServer::start();
+    let ctx = WorkspaceContext::from_api_base_url(server.base_url());
+    crate::auth::save_tokens(
+        &ctx,
+        "human",
+        "refresh",
+        unix_now().unwrap() + 3600,
+        None,
+        None,
+        None,
+    )
+    .unwrap();
+    let path = get_auth_file_path(&ctx).unwrap();
+    let before = fs::read(&path).unwrap();
+    let _url = EnvGuard::set("DIODE_API_URL", ctx.api_base_url());
+    let _id = EnvGuard::set("DIODE_CLIENT_ID", CLIENT_ID);
+    let _secret = EnvGuard::set("DIODE_CLIENT_SECRET", SECRET);
+    let first = token_mock(&server, SECRET, "first-token");
+    assert_eq!(get_valid_token_with_context(&ctx).unwrap(), "first-token");
+    assert_eq!(get_valid_token_with_context(&ctx).unwrap(), "first-token");
+    first.assert_calls(1);
+    let _rotated = EnvGuard::set("DIODE_CLIENT_SECRET", "rotated-secret");
+    let second = token_mock(&server, "rotated-secret", "second-token");
+    assert_eq!(get_valid_token_with_context(&ctx).unwrap(), "second-token");
+    second.assert_calls(1);
+    assert_eq!(fs::read(path).unwrap(), before);
+}
+
+#[test]
+#[serial]
+fn mismatched_endpoint_and_malformed_credentials_fail_without_exposing_secrets() {
+    let (_dir, _env, _) = isolated_context();
+    let ctx = WorkspaceContext::from_api_base_url("https://api.other.example");
+    let mut stored = account("https://api.example");
+    stored.token = Some(AccessToken {
+        access_token: "cached-token".into(),
+        expires_at: unix_now().unwrap() + 900,
+    });
+    save_auth(&ctx, &StoredAuth::ServiceAccount(stored)).unwrap();
+    assert!(
+        get_valid_token_with_context(&ctx)
+            .unwrap_err()
+            .to_string()
+            .contains("different API endpoint")
+    );
+    fs::write(
+        get_auth_file_path(&ctx).unwrap(),
+        format!("kind = \"service_account\"\nclient_secret = \"{SECRET}\"\n"),
+    )
+    .unwrap();
+    let error = get_valid_token_with_context(&ctx).unwrap_err();
+    assert!(!format!("{error:#}").contains(SECRET));
+    assert!(error.to_string().contains("Invalid authentication file"));
+}

--- a/crates/pcb-diode-api/src/datasheet.rs
+++ b/crates/pcb-diode-api/src/datasheet.rs
@@ -127,7 +127,7 @@ pub fn parse_resolve_request(args: Option<&Value>) -> Result<ResolveDatasheetInp
 }
 
 pub fn resolve_datasheet(
-    auth_token: Option<&str>,
+    ctx: &crate::WorkspaceContext,
     input: &ResolveDatasheetInput,
     page_range: Option<PageRange>,
 ) -> Result<ResolveDatasheetResponse> {
@@ -136,24 +136,24 @@ pub fn resolve_datasheet(
     match input {
         ResolveDatasheetInput::DatasheetUrl(url) => {
             let canonical_url = canonicalize_url(url)?;
-            resolve_source_url_datasheet(&client, auth_token, canonical_url, page_range)
+            resolve_source_url_datasheet(&client, ctx, canonical_url, page_range)
         }
         ResolveDatasheetInput::PdfPath(path) => {
             let pdf_path = path.clone();
             let execution = ResolveExecution::from_pdf_path(pdf_path, None)?;
-            execute_resolve_execution(&client, auth_token, execution, page_range)
+            execute_resolve_execution(&client, ctx, execution, page_range)
         }
         ResolveDatasheetInput::KicadSymPath { path, symbol_name } => {
             let reference =
                 extract_datasheet_reference_from_kicad_sym(path, symbol_name.as_deref())?;
             if is_http_datasheet_url(&reference) {
                 let canonical_url = canonicalize_url(&reference)?;
-                resolve_source_url_datasheet(&client, auth_token, canonical_url, page_range)
+                resolve_source_url_datasheet(&client, ctx, canonical_url, page_range)
             } else {
                 let pdf_path = resolve_local_datasheet_path_from_kicad_sym(path, &reference)?;
                 validate_local_pdf(&pdf_path)?;
                 let execution = ResolveExecution::from_pdf_path(pdf_path, None)?;
-                execute_resolve_execution(&client, auth_token, execution, page_range)
+                execute_resolve_execution(&client, ctx, execution, page_range)
             }
         }
     }
@@ -161,18 +161,18 @@ pub fn resolve_datasheet(
 
 fn resolve_source_url_datasheet(
     client: &Client,
-    auth_token: Option<&str>,
+    ctx: &crate::WorkspaceContext,
     canonical_url: String,
     page_range: Option<PageRange>,
 ) -> Result<ResolveDatasheetResponse> {
-    let pdf_path = ensure_url_pdf_cached(client, auth_token, &canonical_url)?;
+    let pdf_path = ensure_url_pdf_cached(client, ctx, &canonical_url)?;
     let execution = ResolveExecution::from_pdf_path(pdf_path, Some(canonical_url))?;
-    execute_resolve_execution(client, auth_token, execution, page_range)
+    execute_resolve_execution(client, ctx, execution, page_range)
 }
 
 fn ensure_url_pdf_cached(
     client: &Client,
-    auth_token: Option<&str>,
+    ctx: &crate::WorkspaceContext,
     canonical_url: &str,
 ) -> Result<PathBuf> {
     let url_cache_dir = url_pdf_cache_dir(canonical_url)?;
@@ -181,12 +181,12 @@ fn ensure_url_pdf_cached(
     if let Some(cached_pdf) = first_valid_file_in_dir(&url_cache_dir, None, is_valid_cached_pdf)? {
         return Ok(cached_pdf);
     }
-    fetch_url_pdf_via_backend(client, auth_token, canonical_url, &url_cache_dir)
+    fetch_url_pdf_via_backend(client, ctx, canonical_url, &url_cache_dir)
 }
 
 fn execute_resolve_execution(
     client: &Client,
-    auth_token: Option<&str>,
+    ctx: &crate::WorkspaceContext,
     execution: ResolveExecution,
     page_range: Option<PageRange>,
 ) -> Result<ResolveDatasheetResponse> {
@@ -220,7 +220,7 @@ fn execute_resolve_execution(
     }
     reset_materialized_cache(&materialized_dir, &images_dir, &complete_marker);
 
-    let scan = ensure_datasheet_scanned(client, auth_token, &execution, page_range)?;
+    let scan = ensure_datasheet_scanned(client, ctx, &execution, page_range)?;
 
     materialize_scan_outputs(
         client,
@@ -242,11 +242,11 @@ fn execute_resolve_execution(
 
 fn fetch_url_pdf_via_backend(
     client: &Client,
-    auth_token: Option<&str>,
+    ctx: &crate::WorkspaceContext,
     canonical_url: &str,
     url_cache_dir: &Path,
 ) -> Result<PathBuf> {
-    let datasheet = create_datasheet_from_url(client, auth_token, canonical_url)?;
+    let datasheet = create_datasheet_from_url(client, ctx, canonical_url)?;
     let pdf_path = url_cache_dir.join(cached_pdf_filename(&datasheet.filename));
 
     download_file(client, &datasheet.file_url, &pdf_path)
@@ -265,20 +265,20 @@ fn fetch_url_pdf_via_backend(
 
 fn ensure_datasheet_scanned(
     client: &Client,
-    auth_token: Option<&str>,
+    ctx: &crate::WorkspaceContext,
     execution: &ResolveExecution,
     page_range: Option<PageRange>,
 ) -> Result<DatasheetScanResponse> {
     let datasheet_id = datasheet_id_for_sha256(&execution.pdf_sha256);
     if let DatasheetScanOutcome::Scanned(scan) =
-        scan_datasheet(client, auth_token, &datasheet_id, page_range)?
+        scan_datasheet(client, ctx, &datasheet_id, page_range)?
     {
         return Ok(scan);
     }
 
     // The backend has no PDF cached under this content hash yet — upload ours, then scan.
-    let datasheet = create_datasheet_from_pdf(client, auth_token, &execution.pdf_path)?;
-    match scan_datasheet(client, auth_token, &datasheet.id, page_range)? {
+    let datasheet = create_datasheet_from_pdf(client, ctx, &execution.pdf_path)?;
+    match scan_datasheet(client, ctx, &datasheet.id, page_range)? {
         DatasheetScanOutcome::Scanned(scan) => Ok(scan),
         DatasheetScanOutcome::NotCached => {
             anyhow::bail!("Datasheet {} not found after upload", datasheet.id)

--- a/crates/pcb-diode-api/src/registry/tui/search.rs
+++ b/crates/pcb-diode-api/src/registry/tui/search.rs
@@ -854,8 +854,6 @@ pub fn spawn_availability_worker(
     resp_tx: Sender<PricingResponse>,
 ) -> JoinHandle<()> {
     thread::spawn(move || {
-        let mut auth_token: Option<String> = None;
-        let mut auth_checked = false;
         while let Ok(mut queue) = req_rx.recv() {
             while let Ok(next) = req_rx.try_recv() {
                 queue = next;
@@ -865,23 +863,15 @@ pub fn spawn_availability_worker(
                 let chunk_len = queue.len().min(AVAILABILITY_WORKER_CHUNK_SIZE);
                 let chunk: Vec<_> = queue.drain(..chunk_len).collect();
 
-                let response = if !auth_checked {
-                    match crate::auth::get_api_token() {
-                        Ok(token) => {
-                            auth_token = token;
-                            auth_checked = true;
-                            fetch_pricing_chunk(auth_token.as_deref(), &chunk)
-                        }
-                        Err(e) => {
-                            log::warn!("Pricing auth failed: {}", e);
-                            chunk
-                                .into_iter()
-                                .map(|request| (request.key, PricingResult::Failed))
-                                .collect()
-                        }
+                let response = match crate::auth::get_api_token() {
+                    Ok(token) => fetch_pricing_chunk(token.as_deref(), &chunk),
+                    Err(e) => {
+                        log::warn!("Pricing auth failed: {}", e);
+                        chunk
+                            .into_iter()
+                            .map(|request| (request.key, PricingResult::Failed))
+                            .collect()
                     }
-                } else {
-                    fetch_pricing_chunk(auth_token.as_deref(), &chunk)
                 };
 
                 let _ = resp_tx.send(response);

--- a/crates/pcb-diode-api/src/release.rs
+++ b/crates/pcb-diode-api/src/release.rs
@@ -34,24 +34,14 @@ pub fn upload_release(
     workspace: &str,
     ctx: &WorkspaceContext,
 ) -> Result<ReleaseResult> {
-    let token = crate::auth::get_api_token_with_context(ctx)?;
-    let base_url = ctx.api_base_url();
-
     let client = Client::builder()
         .user_agent(format!("diode-pcb/{}", env!("CARGO_PKG_VERSION")))
         .timeout(Duration::from_secs(300))
         .build()?;
 
     let (sha256_hex, sha256_b64) = calculate_sha256(zip_path)?;
-    stage_artifact(
-        &client,
-        base_url,
-        token.as_deref(),
-        zip_path,
-        &sha256_hex,
-        &sha256_b64,
-    )?;
-    create_release(&client, base_url, token.as_deref(), workspace, &sha256_hex)
+    stage_artifact(&client, ctx, zip_path, &sha256_hex, &sha256_b64)?;
+    create_release(&client, ctx, workspace, &sha256_hex)
 }
 
 fn calculate_sha256(path: &Path) -> Result<(String, String)> {
@@ -74,14 +64,13 @@ fn calculate_sha256(path: &Path) -> Result<(String, String)> {
 
 fn stage_artifact(
     client: &Client,
-    base_url: &str,
-    token: Option<&str>,
+    ctx: &WorkspaceContext,
     zip_path: &Path,
     sha256_hex: &str,
     sha256_b64: &str,
 ) -> Result<()> {
-    let url = format!("{}/api/file/{}", base_url, sha256_hex);
-    let resp = crate::auth::apply_bearer_auth(client.post(&url), token)
+    let url = format!("{}/api/file/{}", ctx.api_base_url(), sha256_hex);
+    let resp = crate::auth::apply_api_auth_with_context(ctx, client.post(&url))?
         .send()
         .context("Failed to connect to Diode API")?;
 
@@ -113,18 +102,17 @@ fn stage_artifact(
 
 fn create_release(
     client: &Client,
-    base_url: &str,
-    token: Option<&str>,
+    ctx: &WorkspaceContext,
     workspace: &str,
     sha256_hex: &str,
 ) -> Result<ReleaseResult> {
     let url = format!(
         "{}/api/workspaces/{}/releases",
-        base_url,
+        ctx.api_base_url(),
         urlencoding::encode(workspace)
     );
 
-    let resp = crate::auth::apply_bearer_auth(client.post(&url), token)
+    let resp = crate::auth::apply_api_auth_with_context(ctx, client.post(&url))?
         .json(&serde_json::json!({ "artifactHash": sha256_hex }))
         .send()
         .context("Failed to connect to Diode API")?;

--- a/crates/pcb-diode-api/src/scan.rs
+++ b/crates/pcb-diode-api/src/scan.rs
@@ -153,12 +153,12 @@ pub(crate) fn calculate_sha256(path: &Path) -> Result<String> {
 
 pub(crate) fn create_datasheet_from_url(
     client: &Client,
-    token: Option<&str>,
+    ctx: &crate::WorkspaceContext,
     url: &str,
 ) -> Result<DatasheetResponse> {
-    let endpoint = format!("{}/api/datasheets", crate::get_api_base_url());
+    let endpoint = format!("{}/api/datasheets", ctx.api_base_url());
 
-    let response = crate::auth::apply_bearer_auth(client.post(&endpoint), token)
+    let response = crate::auth::apply_api_auth_with_context(ctx, client.post(&endpoint))?
         .json(&CreateDatasheetRequest {
             url: url.to_string(),
         })
@@ -173,10 +173,10 @@ pub(crate) fn create_datasheet_from_url(
 
 pub(crate) fn create_datasheet_from_pdf(
     client: &Client,
-    token: Option<&str>,
+    ctx: &crate::WorkspaceContext,
     pdf_path: &Path,
 ) -> Result<DatasheetResponse> {
-    let endpoint = format!("{}/api/datasheets", crate::get_api_base_url());
+    let endpoint = format!("{}/api/datasheets", ctx.api_base_url());
     let form = multipart::Form::new()
         .file("file", pdf_path)
         .with_context(|| {
@@ -186,7 +186,7 @@ pub(crate) fn create_datasheet_from_pdf(
             )
         })?;
 
-    let response = crate::auth::apply_bearer_auth(client.post(&endpoint), token)
+    let response = crate::auth::apply_api_auth_with_context(ctx, client.post(&endpoint))?
         .multipart(form)
         .send()?;
 
@@ -199,17 +199,17 @@ pub(crate) fn create_datasheet_from_pdf(
 
 pub(crate) fn scan_datasheet(
     client: &Client,
-    token: Option<&str>,
+    ctx: &crate::WorkspaceContext,
     datasheet_id: &str,
     page_range: Option<PageRange>,
 ) -> Result<DatasheetScanOutcome> {
     let endpoint = format!(
         "{}/api/datasheets/{}/scan",
-        crate::get_api_base_url(),
+        ctx.api_base_url(),
         datasheet_id
     );
 
-    let response = crate::auth::apply_bearer_auth(client.post(&endpoint), token)
+    let response = crate::auth::apply_api_auth_with_context(ctx, client.post(&endpoint))?
         .json(&ScanDatasheetRequest { page_range })
         .send()?;
 
@@ -339,7 +339,7 @@ pub struct ScanArgs {
 pub fn execute(args: ScanArgs) -> Result<()> {
     let input = parse_scan_input(&args.input)?;
 
-    let token = crate::auth::get_api_token()?;
+    let ctx = crate::WorkspaceContext::from_cwd()?;
     let (resolve_input, input_pdf_path) = match input {
         ScanInput::LocalPdf(file) => (
             crate::datasheet::ResolveDatasheetInput::PdfPath(file.clone()),
@@ -351,8 +351,7 @@ pub fn execute(args: ScanArgs) -> Result<()> {
         ),
     };
     let spinner = Spinner::builder("Resolving datasheet...").start();
-    let response =
-        crate::datasheet::resolve_datasheet(token.as_deref(), &resolve_input, args.pages)?;
+    let response = crate::datasheet::resolve_datasheet(&ctx, &resolve_input, args.pages)?;
     let pdf_path = input_pdf_path
         .unwrap_or_else(|| PathBuf::from(&response.pdf_path))
         .display()

--- a/crates/pcbc/src/lsp.rs
+++ b/crates/pcbc/src/lsp.rs
@@ -39,8 +39,8 @@ fn handle_custom_request(
     }
 
     let input = pcb_diode_api::datasheet::parse_resolve_request(Some(params))?;
-    let token = pcb_diode_api::auth::get_api_token()?;
-    let response = pcb_diode_api::datasheet::resolve_datasheet(token.as_deref(), &input, None)?;
+    let ctx = pcb_diode_api::WorkspaceContext::from_cwd()?;
+    let response = pcb_diode_api::datasheet::resolve_datasheet(&ctx, &input, None)?;
     Ok(Some(serde_json::to_value(response)?))
 }
 

--- a/crates/pcbc/tests/auth.rs
+++ b/crates/pcbc/tests/auth.rs
@@ -1,0 +1,159 @@
+use httpmock::prelude::*;
+use serde_json::json;
+use std::io::Write;
+use std::process::{Command, Output, Stdio};
+
+const CLIENT_ID: &str = "00000000-0000-4000-8000-000000000001";
+const SECRET: &str = "dsc_integration-secret";
+
+struct Fixture {
+    dir: tempfile::TempDir,
+    server: MockServer,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self {
+            dir: tempfile::tempdir().unwrap(),
+            server: MockServer::start(),
+        }
+    }
+
+    fn command(&self, args: &[&str]) -> Command {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_pcbc"));
+        command
+            .args(args)
+            .current_dir(self.dir.path())
+            .env("PCB_CONFIG_DIR", self.dir.path().join("config"))
+            .env("DIODE_API_URL", self.server.base_url())
+            .env_remove("DIODE_CLIENT_ID")
+            .env_remove("DIODE_CLIENT_SECRET")
+            .env_remove("DIODE_API_AUTH")
+            .env_remove("DIODE_APP_URL");
+        command
+    }
+
+    fn token(&self, value: &str) -> httpmock::Mock<'_> {
+        use base64::Engine;
+        self.server.mock(|when, then| {
+            when.method(POST).path("/api/auth/token")
+                .header("authorization", format!("Basic {}", base64::engine::general_purpose::STANDARD.encode(format!("{CLIENT_ID}:{SECRET}"))))
+                .body("grant_type=client_credentials");
+            then.status(200).json_body(json!({"access_token":value, "token_type":"Bearer", "expires_in":900, "expires_at":4102444800_i64}));
+        })
+    }
+
+    fn login(&self, mut command: Command) -> Output {
+        let mut child = command
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(
+                json!({
+                    "client_id":CLIENT_ID, "client_secret":SECRET,
+                    "service_account_name":"ci-runner", "api_base_url":self.server.base_url(),
+                })
+                .to_string()
+                .as_bytes(),
+            )
+            .unwrap();
+        child.wait_with_output().unwrap()
+    }
+}
+
+fn success(output: Output) -> String {
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout).unwrap()
+}
+
+#[test]
+fn service_account_import_token_refresh_and_logout() {
+    let fixture = Fixture::new();
+    let mut first = fixture.token("first-machine-token");
+    success(fixture.login(fixture.command(&["auth", "login", "--service-account", "--stdin"])));
+    assert_eq!(
+        success(fixture.command(&["auth", "token"]).output().unwrap()),
+        "first-machine-token\n"
+    );
+    let status = success(fixture.command(&["auth", "status"]).output().unwrap());
+    assert!(status.contains("ci-runner") && status.contains("saved login"));
+    assert!(!status.contains(SECRET) && !status.contains("first-machine-token"));
+    let output = fixture
+        .command(&["auth", "token"])
+        .env("DIODE_CLIENT_ID", CLIENT_ID)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("DIODE_CLIENT_SECRET"));
+    first.assert_calls(1);
+    first.delete();
+    let second = fixture.token("renewed-machine-token");
+    success(fixture.command(&["auth", "refresh"]).output().unwrap());
+    assert_eq!(
+        success(fixture.command(&["auth", "token"]).output().unwrap()),
+        "renewed-machine-token\n"
+    );
+    second.assert_calls(1);
+    success(fixture.command(&["auth", "logout"]).output().unwrap());
+    assert!(
+        !fixture
+            .command(&["auth", "token"])
+            .output()
+            .unwrap()
+            .status
+            .success()
+    );
+}
+
+#[test]
+fn component_command_uses_environment_credentials_without_a_login_file() {
+    let fixture = Fixture::new();
+    let token = fixture.token("ci-machine-token");
+    let component = fixture.server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/v2/components/search")
+            .header("authorization", "Bearer ci-machine-token");
+        then.status(200).json_body(json!([]));
+    });
+    success(
+        fixture
+            .command(&["component", "search", "STM32", "--format", "json"])
+            .env("DIODE_CLIENT_ID", CLIENT_ID)
+            .env("DIODE_CLIENT_SECRET", SECRET)
+            .output()
+            .unwrap(),
+    );
+    token.assert_calls(1);
+    component.assert_calls(1);
+    assert!(!fixture.dir.path().join("config").exists());
+}
+
+#[test]
+fn credential_export_selects_its_endpoint_and_rejects_a_conflicting_override() {
+    let fixture = Fixture::new();
+    let token = fixture.token("imported-token");
+    let mut command = fixture.command(&["auth", "login", "--service-account", "--stdin"]);
+    command.env_remove("DIODE_API_URL");
+    success(fixture.login(command));
+    assert_eq!(
+        success(fixture.command(&["auth", "token"]).output().unwrap()),
+        "imported-token\n"
+    );
+    let mut command = fixture.command(&["auth", "login", "--service-account", "--stdin"]);
+    command.env("DIODE_API_URL", "https://wrong.example");
+    let output = fixture.login(command);
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("differs from DIODE_API_URL"));
+    assert!(!String::from_utf8_lossy(&output.stderr).contains(SECRET));
+    token.assert_calls(1);
+}

--- a/crates/pcbc/tests/auth.rs
+++ b/crates/pcbc/tests/auth.rs
@@ -139,21 +139,15 @@ fn component_command_uses_environment_credentials_without_a_login_file() {
 }
 
 #[test]
-fn credential_export_selects_its_endpoint_and_rejects_a_conflicting_override() {
+fn credential_import_rejects_an_unconfigured_endpoint() {
     let fixture = Fixture::new();
     let token = fixture.token("imported-token");
     let mut command = fixture.command(&["auth", "login", "--service-account", "--stdin"]);
     command.env_remove("DIODE_API_URL");
-    success(fixture.login(command));
-    assert_eq!(
-        success(fixture.command(&["auth", "token"]).output().unwrap()),
-        "imported-token\n"
-    );
-    let mut command = fixture.command(&["auth", "login", "--service-account", "--stdin"]);
-    command.env("DIODE_API_URL", "https://wrong.example");
     let output = fixture.login(command);
     assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("differs from DIODE_API_URL"));
+    assert!(String::from_utf8_lossy(&output.stderr).contains("active endpoint"));
     assert!(!String::from_utf8_lossy(&output.stderr).contains(SECRET));
-    token.assert_calls(1);
+    assert!(!fixture.dir.path().join("config").exists());
+    token.assert_calls(0);
 }

--- a/crates/pcbc/tests/integration.rs
+++ b/crates/pcbc/tests/integration.rs
@@ -1,4 +1,5 @@
 mod apply;
+mod auth;
 mod auth_git;
 mod bom;
 mod broken_pipe;


### PR DESCRIPTION
Add service-account login, credential import, and CI credentials so machines can authenticate and renew access tokens automatically. Include the setup-code client for the Console flow planned in [ENG-1353](https://linear.app/diodeinc/issue/ENG-1353).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1164" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->