### PR TITLE
Unify PCBIR boundary queries in prepared regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add prepared signed-distance queries for PCBIR regions.
+- Add prepared signed-distance queries for PCBIR regions and use one boundary index across DFM.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add prepared signed-distance queries for PCBIR regions.
+
 ### Fixed
 
 - Place generated schematic content outside the page when it cannot fit, instead of failing schematic apply, and reserve space for existing text and graphics.

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -8,9 +8,7 @@
 //! or contained distinct-owner regions measure zero.
 
 use pcb_ir::geom::BBox;
-use pcb_ir::geom::dfm::{
-    RegionBoundaryIndex, region_clearance_sites_with_index, region_clearance_within,
-};
+use pcb_ir::geom::dfm::{region_clearance_sites_with_index, region_clearance_within};
 
 use crate::commands::dfm::design::{ConductorId, Design};
 use crate::commands::dfm::report::{Evidence, SourceLocator, Subject};
@@ -63,7 +61,7 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
 
         let boundaries = pieces
             .iter()
-            .map(|piece| RegionBoundaryIndex::new(&piece.region, limit_mm))
+            .map(|piece| piece.region.prepare_query())
             .collect::<Vec<_>>();
         // The pairs the bounds cannot separate, in sweep order along x.
         let pairs = pieces

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -128,7 +128,7 @@ fn disk_to_copper_clearance(
     center: Point,
     radius_mm: f64,
     copper: &pcb_ir::geom::ContourSet,
-    boundary: &pcb_ir::geom::dfm::RegionBoundaryIndex,
+    boundary: &pcb_ir::geom::PreparedRegion,
     limit_mm: f64,
 ) -> Option<Distance> {
     if copper.contains_point(center) {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
@@ -29,10 +29,8 @@
 //! electrical-conductor boundary-distance check; morphology must not
 //! reinterpret a same-net notch as spacing between conductors.
 
-use pcb_ir::geom::dfm::{
-    RegionBoundaryIndex, ThinPiece, circular_region, thin_features, thin_gaps,
-};
-use pcb_ir::geom::{BBox, ContourSet, Point, tol};
+use pcb_ir::geom::dfm::{ThinPiece, circular_region, thin_features, thin_gaps};
+use pcb_ir::geom::{BBox, ContourSet, Point, PreparedRegion, tol};
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 
@@ -116,12 +114,7 @@ pub(super) fn soldermask_web(limit_mm: f64, design: &Design) -> Evaluation {
         let boundaries = layer
             .owners
             .iter()
-            .map(|owner| {
-                (
-                    owner.image.bbox,
-                    RegionBoundaryIndex::new(&owner.image, limit_mm),
-                )
-            })
+            .map(|owner| (owner.image.bbox, owner.image.prepare_query()))
             .collect::<Vec<_>>();
         thin_gaps(&layer.image, limit_mm)
             .into_iter()
@@ -241,7 +234,7 @@ fn mask_subject(design: &Design, owner: &MaskOwner, layer: &LayerRef) -> Subject
 /// overlapping ownership of the same span remains explicitly unknown.
 fn wall_owners(
     walls: &[(Point, Point)],
-    boundaries: &[(BBox, RegionBoundaryIndex)],
+    boundaries: &[(BBox, PreparedRegion)],
 ) -> Option<Vec<usize>> {
     const BOUNDARY_EPSILON_MM: f64 = 1e-6;
     let mut owners = Vec::new();
@@ -357,10 +350,10 @@ mod tests {
         }
     }
 
-    fn boundaries(images: &[ContourSet]) -> Vec<(BBox, RegionBoundaryIndex)> {
+    fn boundaries(images: &[ContourSet]) -> Vec<(BBox, PreparedRegion)> {
         images
             .iter()
-            .map(|image| (image.bbox, RegionBoundaryIndex::new(image, 0.2)))
+            .map(|image| (image.bbox, image.prepare_query()))
             .collect()
     }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -19,10 +19,10 @@ use pcb_ir::dialects::ipc::{
     lower_layer_to_artwork_with, profile_occurrences_for,
 };
 use pcb_ir::dialects::{LayerRole, Side, artwork};
-use pcb_ir::geom::dfm::{Distance, RegionBoundaryIndex, WidthDisk, min_width_disk};
+use pcb_ir::geom::dfm::{Distance, WidthDisk, min_width_disk};
 use pcb_ir::geom::path::ContourBuf;
 use pcb_ir::geom::region::{Ring, union_rings};
-use pcb_ir::geom::{BBox, ContourSet, FillRule, Point, Polarity, Span, tol};
+use pcb_ir::geom::{BBox, ContourSet, FillRule, Point, Polarity, PreparedRegion, Span, tol};
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 
@@ -47,9 +47,9 @@ pub(super) struct Design<'a> {
     pub copper_layers: Vec<CopperLayer>,
     /// One boundary index per copper layer, for clearance and enclosure
     /// queries against the composed copper.
-    pub copper_boundaries: Vec<RegionBoundaryIndex>,
+    pub copper_boundaries: Vec<PreparedRegion>,
     /// One boundary index per attributed conductor on each copper layer.
-    pub conductor_boundaries: Vec<Vec<RegionBoundaryIndex>>,
+    pub conductor_boundaries: Vec<Vec<PreparedRegion>>,
     /// Each hole's lands, one per copper layer it owns a land on, indexed
     /// like `holes`.
     pub hole_lands: Vec<Vec<HoleLand>>,
@@ -83,17 +83,6 @@ impl<'a> Design<'a> {
         let layout = when(pools.board_outlines || pools.board_arrays, || {
             Ok(Some(&imported.geometry))
         })?;
-        // A pitch hint for the boundary grids, from the rule limits alone:
-        // queries stay correct at any pitch, and sizing cells by hole radii
-        // would let one large hole coarsen every fine-clearance query.
-        let boundary_search_mm = rules
-            .iter()
-            .filter(|rule| {
-                let pools = rule.kind.semantics().pools;
-                pools.copper_boundaries || pools.conductor_boundaries
-            })
-            .map(|rule| rule.limit.length().millimeters())
-            .fold(1.0, f64::max);
         let design = Self {
             imported,
             scope,
@@ -103,9 +92,7 @@ impl<'a> Design<'a> {
                 let layers = copper_layers.par_iter();
                 #[cfg(target_family = "wasm")]
                 let layers = copper_layers.iter();
-                Ok(layers
-                    .map(|layer| RegionBoundaryIndex::new(&layer.image, boundary_search_mm))
-                    .collect())
+                Ok(layers.map(|layer| layer.image.prepare_query()).collect())
             })?,
             conductor_boundaries: when(pools.conductor_boundaries, || {
                 #[cfg(not(target_family = "wasm"))]
@@ -117,9 +104,7 @@ impl<'a> Design<'a> {
                         layer
                             .conductors
                             .iter()
-                            .map(|conductor| {
-                                RegionBoundaryIndex::new(&conductor.image, boundary_search_mm)
-                            })
+                            .map(|conductor| conductor.image.prepare_query())
                             .collect()
                     })
                     .collect())
@@ -717,7 +702,7 @@ pub(super) struct BoardOutline {
     pub contours: Vec<Ring>,
     /// Finished board material: the filled outer profile minus every cutout.
     pub region: ContourSet,
-    pub boundary: RegionBoundaryIndex,
+    pub boundary: PreparedRegion,
     /// Native outer and cutout contours in the checked frame.
     pub native_outline: Vec<ContourBuf>,
     pub bbox: BBox,
@@ -1505,7 +1490,7 @@ fn collect_board_outlines(
                 .and_then(|step| layout.layout.steps.get(step as usize))
                 .map(|step| imported.resolve(step.source_step_ref).to_owned())
                 .unwrap_or_else(|| "board".to_owned());
-            let boundary = RegionBoundaryIndex::new(&region, 1.0);
+            let boundary = region.prepare_query();
             Some(BoardOutline {
                 name,
                 instance_index: occurrence.instance,

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -11,7 +11,7 @@ use crate::geom::bbox::BBox;
 use crate::geom::dist;
 use crate::geom::grid::CellGrid;
 use crate::geom::point::Point;
-use crate::geom::region::{ContourSet, TwoSidedResidualComponent, ring_edges};
+use crate::geom::region::{ContourSet, PreparedRegion, TwoSidedResidualComponent, ring_edges};
 use crate::geom::tol;
 
 pub use crate::geom::dist::Distance;
@@ -51,104 +51,7 @@ impl BBoxIndex {
     }
 }
 
-/// Uniform-grid index over a region's boundary segments.
-///
-/// DFM rules ask whether thousands of points and segments lie within a small
-/// clearance of the same composed layer boundary. This keeps those queries
-/// local instead of walking every polygon edge for every query. Every
-/// answer counts the region boundary as one flattened input.
-#[derive(Debug, Clone)]
-pub struct RegionBoundaryIndex {
-    segments: Vec<(Point, Point)>,
-    bounds: Vec<BBox>,
-    grid: CellGrid,
-}
-
-/// Grid pitch bounds. Queries stay correct for any pitch; these only keep the
-/// cell count proportionate when a caller's search radius is extreme.
-const MIN_CELL_MM: f64 = 0.5;
-const MAX_CELL_MM: f64 = 50.0;
-
-impl RegionBoundaryIndex {
-    /// Index a region's boundary for queries out to about `search_radius_mm`.
-    ///
-    /// The radius is a pitch hint, not a limit: queries may pass any distance.
-    pub fn new(region: &ContourSet, search_radius_mm: f64) -> Self {
-        let pitch = search_radius_mm.clamp(MIN_CELL_MM, MAX_CELL_MM);
-        let segments = region.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
-        let bounds = segments
-            .iter()
-            .map(|&(start, end)| BBox::spanning(start, end))
-            .collect();
-        let grid = CellGrid::new(
-            pitch,
-            region.bbox,
-            segments.iter().enumerate().flat_map(|(id, &(start, end))| {
-                corridor_cells(start, end, 0.0, pitch).map(move |cell| (id as u32, cell))
-            }),
-        );
-        Self {
-            segments,
-            bounds,
-            grid,
-        }
-    }
-
-    /// Nearest boundary point no farther than `max_distance_mm` from `point`.
-    pub fn nearest_within(&self, point: Point, max_distance_mm: f64) -> Option<Distance> {
-        self.near(point, point, max_distance_mm)
-            .map(|index| {
-                let (start, end) = self.segments[index as usize];
-                let (mm, boundary) = dist::point_segment(point, start, end);
-                Distance::flattened(mm, point, boundary, 1)
-            })
-            .filter(|distance| distance.mm <= max_distance_mm + tol::EPSILON_MM)
-            .min_by(|left, right| left.mm.total_cmp(&right.mm))
-    }
-
-    /// Nearest boundary point no farther than `max_distance_mm` from the
-    /// query segment. A segment crossing the boundary measures zero.
-    pub fn segment_nearest_within(
-        &self,
-        start: Point,
-        end: Point,
-        max_distance_mm: f64,
-    ) -> Option<Distance> {
-        self.near(start, end, max_distance_mm)
-            .map(|index| {
-                let (edge_start, edge_end) = self.segments[index as usize];
-                let (mm, on_query, on_boundary) = dist::segments(start, end, edge_start, edge_end);
-                Distance::flattened(mm, on_query, on_boundary, 1)
-            })
-            .filter(|distance| distance.mm <= max_distance_mm + tol::EPSILON_MM)
-            .min_by(|left, right| left.mm.total_cmp(&right.mm))
-    }
-
-    /// The indexed segments whose bounds meet `bounds`, in boundary order,
-    /// each once.
-    pub fn segments_meeting(&self, bounds: BBox) -> impl Iterator<Item = (Point, Point)> + '_ {
-        let mut ids = self.grid.rectangle(bounds).collect::<Vec<_>>();
-        ids.sort_unstable();
-        ids.dedup();
-        ids.into_iter()
-            .filter(move |&id| self.bounds[id as usize].intersects(bounds))
-            .map(|id| self.segments[id as usize])
-    }
-
-    /// Ids of the indexed segments whose bounds come within `reach` of the
-    /// query segment, in grid order: column by column, row by row, then by
-    /// id. A segment spanning several cells is yielded once per cell. The
-    /// minimum a consumer takes is unchanged by the repeats, and of equal
-    /// minima it keeps the first, which is always the first cell's copy.
-    fn near(&self, start: Point, end: Point, reach: f64) -> impl Iterator<Item = u32> + '_ {
-        let query = BBox::spanning(start, end).expand(reach + tol::EPSILON_MM);
-        corridor_columns(start, end, reach, self.grid.pitch_mm())
-            .flat_map(move |(column, min_row, max_row)| {
-                self.grid.column(column, min_row, max_row).iter().copied()
-            })
-            .filter(move |&id| self.bounds[id as usize].intersects(query))
-    }
-
+impl PreparedRegion {
     /// Parameter intervals along a segment within `distance_mm` of the
     /// indexed boundary. Unlike a nearest-point query, these certify the
     /// complete covered extent, including gaps between disjoint boundaries.
@@ -159,9 +62,12 @@ impl RegionBoundaryIndex {
         distance_mm: f64,
     ) -> Vec<(f64, f64)> {
         merge_intervals(
-            indexed_edges_near(self, start, end, distance_mm)
+            self.segment_ids_near(start, end, distance_mm)
                 .into_iter()
-                .flat_map(|(a, b)| segment_capsule_intervals(start, end, a, b, distance_mm))
+                .flat_map(|id| {
+                    let (a, b) = self.segments[id];
+                    segment_capsule_intervals(start, end, a, b, distance_mm)
+                })
                 .collect(),
         )
     }
@@ -196,51 +102,6 @@ impl RegionBoundaryIndex {
             1,
         ))
     }
-}
-
-/// Every grid column within `radius_mm` of the segment with the rows it
-/// covers there, so long diagonal segments touch a linear number of cells
-/// instead of their whole bounding box. A zero-length segment yields the
-/// cells around a point.
-fn corridor_columns(
-    start: Point,
-    end: Point,
-    radius_mm: f64,
-    cell_size_mm: f64,
-) -> impl Iterator<Item = (i64, i64, i64)> {
-    let min_column = CellGrid::cell(start.x.min(end.x) - radius_mm, cell_size_mm);
-    let max_column = CellGrid::cell(start.x.max(end.x) + radius_mm, cell_size_mm);
-    let delta = end - start;
-    (min_column..=max_column).map(move |column| {
-        let column_min = column as f64 * cell_size_mm - radius_mm;
-        let column_max = (column + 1) as f64 * cell_size_mm + radius_mm;
-        let (t_min, t_max) = if delta.x.abs() <= f64::EPSILON {
-            (0.0, 1.0)
-        } else {
-            let enter = (column_min - start.x) / delta.x;
-            let exit = (column_max - start.x) / delta.x;
-            (
-                enter.min(exit).clamp(0.0, 1.0),
-                enter.max(exit).clamp(0.0, 1.0),
-            )
-        };
-        let y_at_min = start.y + delta.y * t_min;
-        let y_at_max = start.y + delta.y * t_max;
-        let min_row = CellGrid::cell(y_at_min.min(y_at_max) - radius_mm, cell_size_mm);
-        let max_row = CellGrid::cell(y_at_min.max(y_at_max) + radius_mm, cell_size_mm);
-        (column, min_row, max_row)
-    })
-}
-
-/// Every grid cell of the corridor, column by column and row by row.
-fn corridor_cells(
-    start: Point,
-    end: Point,
-    radius_mm: f64,
-    cell_size_mm: f64,
-) -> impl Iterator<Item = (i64, i64)> {
-    corridor_columns(start, end, radius_mm, cell_size_mm)
-        .flat_map(|(column, min_row, max_row)| (min_row..=max_row).map(move |row| (column, row)))
 }
 
 /// Set distance between two closed disks: `max(0, ‖c₁ − c₂‖ − r₁ − r₂)`,
@@ -278,9 +139,9 @@ pub fn region_clearance(first: &ContourSet, second: &ContourSet) -> Option<Dista
     let reach = span.width().hypot(span.height());
     region_clearance_within(
         first,
-        &RegionBoundaryIndex::new(first, reach),
+        &first.prepare_query(),
         second,
-        &RegionBoundaryIndex::new(second, reach),
+        &second.prepare_query(),
         reach,
     )
 }
@@ -293,9 +154,9 @@ pub fn region_clearance(first: &ContourSet, second: &ContourSet) -> Option<Dista
 /// empty or the clearance is greater than `maximum_mm`.
 pub fn region_clearance_within(
     first: &ContourSet,
-    first_boundary: &RegionBoundaryIndex,
+    first_boundary: &PreparedRegion,
     second: &ContourSet,
-    second_boundary: &RegionBoundaryIndex,
+    second_boundary: &PreparedRegion,
     maximum_mm: f64,
 ) -> Option<Distance> {
     if first.is_empty() || second.is_empty() {
@@ -368,7 +229,7 @@ pub struct ClearanceSite {
 pub fn linework_clearance_sites(
     lines: &[(Point, Point)],
     material: &ContourSet,
-    index: &RegionBoundaryIndex,
+    index: &PreparedRegion,
     minimum_mm: f64,
     flattened_linework: u32,
 ) -> Vec<ClearanceSite> {
@@ -380,11 +241,14 @@ pub fn linework_clearance_sites(
     let mut pending = Vec::with_capacity(lines.len());
     let mut midpoints = Vec::new();
     for &(start, end) in lines {
-        let edges = indexed_edges_near(index, start, end, reach);
+        let edges = index.segment_ids_near(start, end, reach);
         let near = merge_intervals(
             edges
-                .iter()
-                .flat_map(|&(a, b)| segment_capsule_intervals(start, end, a, b, reach))
+                .into_iter()
+                .flat_map(|id| {
+                    let (a, b) = index.segments[id];
+                    segment_capsule_intervals(start, end, a, b, reach)
+                })
                 .collect(),
         );
         // A segment can run deep inside material, beyond every boundary
@@ -423,7 +287,7 @@ pub fn linework_clearance_sites(
         .filter_map(|group| {
             let mut nearest: Option<Distance> = None;
             let mut first_paths = Vec::new();
-            let mut second_intervals: BTreeMap<u32, Vec<(f64, f64)>> = BTreeMap::new();
+            let mut second_intervals: BTreeMap<usize, Vec<(f64, f64)>> = BTreeMap::new();
             let mut bbox = BBox::empty();
             for span_index in group {
                 let (start, end) = spans[span_index];
@@ -444,8 +308,8 @@ pub fn linework_clearance_sites(
                 {
                     nearest = Some(distance);
                 }
-                for edge_id in indexed_edge_ids_near(index, start, end, reach) {
-                    let (a, b) = index.segments[edge_id as usize];
+                for edge_id in index.segment_ids_near(start, end, reach) {
+                    let (a, b) = index.segments[edge_id];
                     second_intervals
                         .entry(edge_id)
                         .or_default()
@@ -458,7 +322,7 @@ pub fn linework_clearance_sites(
             let second_paths = second_intervals
                 .into_iter()
                 .flat_map(|(edge_id, intervals)| {
-                    let (start, end) = index.segments[edge_id as usize];
+                    let (start, end) = index.segments[edge_id];
                     let delta = end - start;
                     merge_intervals(intervals)
                         .into_iter()
@@ -489,7 +353,7 @@ pub fn region_clearance_sites(
     second: &ContourSet,
     minimum_mm: f64,
 ) -> Vec<ClearanceSite> {
-    let index = RegionBoundaryIndex::new(second, minimum_mm);
+    let index = second.prepare_query();
     region_clearance_sites_with_index(first, second, &index, minimum_mm)
 }
 
@@ -497,7 +361,7 @@ pub fn region_clearance_sites(
 pub fn region_clearance_sites_with_index(
     first: &ContourSet,
     second: &ContourSet,
-    second_boundary: &RegionBoundaryIndex,
+    second_boundary: &PreparedRegion,
     minimum_mm: f64,
 ) -> Vec<ClearanceSite> {
     let lines = first.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
@@ -518,7 +382,7 @@ pub fn region_clearance_sites_with_index(
             second_paths: Vec::new(),
             overlap,
         };
-        let overlap_boundary = RegionBoundaryIndex::new(&joined.overlap, tol::REGION_MM);
+        let overlap_boundary = joined.overlap.prepare_query();
         let mut position = 0;
         while position < sites.len() {
             let touches = sites[position].first_paths.iter().any(|path| {
@@ -581,31 +445,6 @@ pub fn circular_region(center: Point, radius_mm: f64) -> ContourSet {
     let circle =
         crate::geom::path::transform_cmds(circle.cmds, crate::geom::Affine2::translation(center));
     ContourSet::from_filled_contours(&[circle], tol::REGION_MM)
-}
-
-fn indexed_edges_near(
-    index: &RegionBoundaryIndex,
-    start: Point,
-    end: Point,
-    reach: f64,
-) -> Vec<(Point, Point)> {
-    indexed_edge_ids_near(index, start, end, reach)
-        .into_iter()
-        .map(|id| index.segments[id as usize])
-        .collect()
-}
-
-/// The distinct indexed segments near the query, by id.
-fn indexed_edge_ids_near(
-    index: &RegionBoundaryIndex,
-    start: Point,
-    end: Point,
-    reach: f64,
-) -> Vec<u32> {
-    let mut ids = index.near(start, end, reach).collect::<Vec<_>>();
-    ids.sort_unstable();
-    ids.dedup();
-    ids
 }
 
 fn linear_interval(value: f64, slope: f64, minimum: f64, maximum: f64) -> Option<(f64, f64)> {
@@ -1062,7 +901,7 @@ mod tests {
         let sites = linework_clearance_sites(
             &[(Point::new(0.0, 0.0), Point::new(10.0, 0.0))],
             &material,
-            &RegionBoundaryIndex::new(&material, 0.3),
+            &material.prepare_query(),
             0.3,
             0,
         );
@@ -1082,13 +921,7 @@ mod tests {
     fn clearance_sites_include_segments_deep_inside_material() {
         let material = rect_region(0.0, 0.0, 10.0, 10.0);
         let line = (Point::new(2.0, 5.0), Point::new(8.0, 5.0));
-        let sites = linework_clearance_sites(
-            &[line],
-            &material,
-            &RegionBoundaryIndex::new(&material, 0.2),
-            0.2,
-            0,
-        );
+        let sites = linework_clearance_sites(&[line], &material, &material.prepare_query(), 0.2, 0);
         assert_eq!(sites.len(), 1);
         assert_eq!(sites[0].distance.mm, 0.0);
         assert_eq!(sites[0].first_paths, vec![vec![line.0, line.1]]);
@@ -1098,7 +931,7 @@ mod tests {
     fn clearance_sites_merge_repeated_contacts_on_the_same_source_edge() {
         let material =
             ContourSet::from_filled_contours(&[rect_at(0.0, 0.0, 1.0, 1.0)], tol::REGION_MM);
-        let index = RegionBoundaryIndex::new(&material, 0.2);
+        let index = material.prepare_query();
         let sites = linework_clearance_sites(
             &[
                 (Point::new(0.0, -0.1), Point::new(0.5, -0.1)),
@@ -1132,7 +965,7 @@ mod tests {
         let sites = linework_clearance_sites(
             &[(point, point)],
             &material,
-            &RegionBoundaryIndex::new(&material, 0.2),
+            &material.prepare_query(),
             0.2,
             0,
         );
@@ -1195,7 +1028,7 @@ mod tests {
         assert!((between_regions.first.x - 2.0).abs() < 1e-9);
         assert!((between_regions.second.x - 3.5).abs() < 1e-9);
 
-        let index = RegionBoundaryIndex::new(&left, 1.5);
+        let index = left.prepare_query();
         let from_segment = index
             .segment_nearest_within(Point::new(-1.0, 3.0), Point::new(3.0, 3.0), 1.5)
             .unwrap();
@@ -1235,9 +1068,9 @@ mod tests {
         let clearance_within = |first: &ContourSet, second: &ContourSet, maximum_mm: f64| {
             region_clearance_within(
                 first,
-                &RegionBoundaryIndex::new(first, maximum_mm),
+                &first.prepare_query(),
                 second,
-                &RegionBoundaryIndex::new(second, maximum_mm),
+                &second.prepare_query(),
                 maximum_mm,
             )
         };
@@ -1262,7 +1095,7 @@ mod tests {
     }
 
     #[test]
-    fn corridor_indexing_covers_long_diagonal_segments() {
+    fn prepared_boundary_covers_long_diagonal_segments() {
         let diagonal = ContourSet::from_contours(
             &[ContourBuf::new(vec![
                 PathCmd::move_to(Point::new(0.0, 0.0)),
@@ -1274,7 +1107,7 @@ mod tests {
             FillRule::NonZero,
             tol::REGION_MM,
         );
-        let index = RegionBoundaryIndex::new(&diagonal, 0.5);
+        let index = diagonal.prepare_query();
         let near_middle = index
             .nearest_within(Point::new(40.3, 40.0), 0.5)
             .expect("mid-segment boundary within reach");
@@ -1288,7 +1121,7 @@ mod tests {
             FillRule::NonZero,
             tol::REGION_MM,
         );
-        let index = RegionBoundaryIndex::new(&copper, 1.475);
+        let index = copper.prepare_query();
 
         assert_eq!(
             index.circular_enclosure(Point::default(), 1.35, 0.125 - tol::FLATTEN_MM),
@@ -1308,7 +1141,7 @@ mod tests {
     #[test]
     fn circular_enclosure_handles_noncircular_lands() {
         let copper = rect_region(-3.0, -1.5, 3.0, 1.5);
-        let index = RegionBoundaryIndex::new(&copper, 1.6);
+        let index = copper.prepare_query();
 
         let measurement = index
             .circular_enclosure(Point::default(), 1.0, 0.6)

--- a/crates/pcb-ir/src/geom/dist.rs
+++ b/crates/pcb-ir/src/geom/dist.rs
@@ -67,7 +67,7 @@ impl Distance {
 pub fn point_segment(point: Point, start: Point, end: Point) -> (f64, Point) {
     let delta = end - start;
     let length_squared = delta.x * delta.x + delta.y * delta.y;
-    let closest = if length_squared <= f64::EPSILON {
+    let closest = if length_squared == 0.0 {
         start
     } else {
         let t = (((point.x - start.x) * delta.x + (point.y - start.y) * delta.y) / length_squared)

--- a/crates/pcb-ir/src/geom/grid.rs
+++ b/crates/pcb-ir/src/geom/grid.rs
@@ -99,10 +99,6 @@ impl CellGrid {
             .flat_map(move |column| (min_row..=max_row).map(move |row| (column, row)))
     }
 
-    pub fn pitch_mm(&self) -> f64 {
-        self.pitch
-    }
-
     /// The ids of the cells of one column from `min_row` through `max_row`,
     /// row by row. Cells outside the grid are empty.
     pub fn column(&self, column: i64, min_row: i64, max_row: i64) -> &[u32] {

--- a/crates/pcb-ir/src/geom/mod.rs
+++ b/crates/pcb-ir/src/geom/mod.rs
@@ -27,7 +27,9 @@ pub use bbox::BBox;
 pub use path::{ContourBuf, PathCmd, PathOp, Segment, StrokeToFillStyle};
 pub use pattern::{StrokePatternMark, stroke_pattern_marks};
 pub use point::{Mirror, Point};
-pub use region::{ContourSet, DiskGapRegularization, GapRegularizationError, PaintComposer, Ring};
+pub use region::{
+    ContourSet, DiskGapRegularization, GapRegularizationError, PaintComposer, PreparedRegion, Ring,
+};
 pub(crate) use store::validate_bbox;
 pub use store::{Contour, Path, PathArena, Span};
 pub use style::{

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -316,11 +316,12 @@ pub fn ring_signed_area(ring: &Ring) -> f64 {
     if ring.len() < 3 {
         return 0.0;
     }
+    let [origin_x, origin_y] = ring[0];
     let mut area = 0.0;
-    for index in 0..ring.len() {
-        let [x0, y0] = ring[index];
-        let [x1, y1] = ring[(index + 1) % ring.len()];
-        area += x0 * y1 - x1 * y0;
+    for edge in ring[1..].windows(2) {
+        let [x0, y0] = edge[0];
+        let [x1, y1] = edge[1];
+        area += (x0 - origin_x) * (y1 - origin_y) - (x1 - origin_x) * (y0 - origin_y);
     }
     area / 2.0
 }

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -31,7 +31,6 @@ use i_overlay::mesh::style::{LineJoin as OutlineLineJoin, OutlineStyle};
 use crate::geom::affine::Affine2;
 use crate::geom::bbox::BBox;
 use crate::geom::dist::{self, Distance};
-use crate::geom::grid::CellGrid;
 use crate::geom::path::{ContourBuf, PathCmd, contours_to_kurbo, stroke_to_fill, transform_cmds};
 use crate::geom::point::Point;
 use crate::geom::store::{Path, PathArena};
@@ -649,9 +648,13 @@ impl ContourSet {
     /// Distinct components always face across void.
     fn facing_components(&self, material_mm: f64, void_mm: f64, reach_mm: f64) -> Self {
         let (components, outers) = self.ring_components();
-        let pitch = material_mm.max(void_mm).max(reach_mm);
-        let grid = SegmentGrid::new(source_boundary_segments(self), pitch);
-        let segments = &grid.segments;
+        let segments = source_boundary_segments(self);
+        let boundary = PreparedRegion::from_segments(
+            segments
+                .iter()
+                .map(|segment| (segment.start, segment.end))
+                .collect(),
+        );
         let sees_left = |wall: &OrientedBoundarySegment, across: Point| {
             let along = wall.end - wall.start;
             let turn = along.x * across.y - along.y * across.x;
@@ -690,16 +693,14 @@ impl ContourSet {
         };
         let mut facing = vec![false; segments.len()];
         for (id, segment) in segments.iter().enumerate() {
-            for other in grid.near_ids(segment.bbox.expand(material_mm.max(void_mm))) {
-                let partner = &segments[other as usize];
-                if other as usize <= id
-                    || (facing[id] && facing[other as usize])
-                    || !faces(segment, partner)
-                {
+            for other in boundary.segment_ids_meeting(segment.bbox.expand(material_mm.max(void_mm)))
+            {
+                let partner = &segments[other];
+                if other <= id || (facing[id] && facing[other]) || !faces(segment, partner) {
                     continue;
                 }
                 facing[id] = true;
-                facing[other as usize] = true;
+                facing[other] = true;
             }
         }
         let mut kept = vec![false; self.rings.len()];
@@ -716,8 +717,8 @@ impl ContourSet {
                 [window.max.x, window.max.y],
                 [window.min.x, window.max.y],
             ]);
-            for other in grid.near_ids(window) {
-                kept[segments[other as usize].topology.ring] = true;
+            for other in boundary.segment_ids_meeting(window) {
+                kept[segments[other].topology.ring] = true;
             }
         }
         for (ring, &component) in components.iter().enumerate() {
@@ -1574,13 +1575,23 @@ fn two_sided_residual_components(
     if residual.is_empty() {
         return Vec::new();
     }
-    let segments = SegmentGrid::new(source_boundary_segments(source), reach);
+    let segments = source_boundary_segments(source);
+    let boundary = PreparedRegion::from_segments(
+        segments
+            .iter()
+            .map(|segment| (segment.start, segment.end))
+            .collect(),
+    );
     let contact_tolerance = source.tolerance.max(residual.tolerance);
     residual
         .connected_components()
         .into_iter()
         .filter_map(|component| {
-            let sites = segments.near(component.bbox.expand(reach));
+            let sites = boundary
+                .segment_ids_meeting(component.bbox.expand(reach))
+                .into_iter()
+                .map(|id| segments[id])
+                .collect::<Vec<_>>();
             component_width(&sites, &component, reach, contact_tolerance).map(|geometry| {
                 TwoSidedResidualComponent {
                     region: component,
@@ -1591,54 +1602,6 @@ fn two_sided_residual_components(
             })
         })
         .collect()
-}
-
-/// Boundary segments bucketed on a uniform grid, so the segments around one
-/// residue component are found without scanning the whole boundary.
-struct SegmentGrid {
-    segments: Vec<OrientedBoundarySegment>,
-    grid: CellGrid,
-}
-
-/// Grid pitch changes candidate lookup cost only. A fixed floor prevents a
-/// small DFM limit from dividing a board-length edge into thousands of cells.
-const MIN_SEGMENT_GRID_CELL_MM: f64 = 1.0;
-
-impl SegmentGrid {
-    fn new(segments: Vec<OrientedBoundarySegment>, cell_mm: f64) -> Self {
-        let bounds = segments
-            .iter()
-            .map(|segment| segment.bbox)
-            .fold(BBox::empty(), BBox::union);
-        let pitch = cell_mm.max(MIN_SEGMENT_GRID_CELL_MM);
-        let grid = CellGrid::new(
-            pitch,
-            bounds,
-            segments.iter().enumerate().flat_map(|(id, segment)| {
-                CellGrid::cells_of(segment.bbox, pitch).map(move |cell| (id as u32, cell))
-            }),
-        );
-        Self { segments, grid }
-    }
-
-    /// Ids of the segments whose bounds meet `query`; a segment in several
-    /// cells repeats.
-    fn near_ids(&self, query: BBox) -> impl Iterator<Item = u32> + '_ {
-        self.grid
-            .rectangle(query)
-            .filter(move |&id| self.segments[id as usize].bbox.intersects(query))
-    }
-
-    /// The segments whose bounds meet `query`, in index order, each once.
-    fn near(&self, query: BBox) -> Vec<OrientedBoundarySegment> {
-        let mut indices = self.near_ids(query).collect::<Vec<_>>();
-        indices.sort_unstable();
-        indices.dedup();
-        indices
-            .into_iter()
-            .map(|index| self.segments[index as usize])
-            .collect()
-    }
 }
 
 /// A boundary segment snapped to the tolerance grid, with its topology.
@@ -2730,18 +2693,6 @@ mod tests {
         assert!(!nearby_web.contains_point(Point::new(6.5, 2.0)));
         assert!(!nearby_web.contains_point(Point::new(5.0, 3.5)));
         assert!(webbed.facing_components(0.0, 0.15, 1.0).is_empty());
-    }
-
-    #[test]
-    fn segment_grid_uses_coarse_cells_without_losing_local_edges() {
-        let region = ContourSet::rectangle(rect(0.0, 0.0, 400.0, 10.0), tol::REGION_MM);
-        let grid = SegmentGrid::new(source_boundary_segments(&region), 0.05);
-
-        assert_eq!(grid.grid.pitch_mm(), MIN_SEGMENT_GRID_CELL_MM);
-        let near = grid.near(rect(199.9, -0.1, 200.1, 0.1));
-        assert_eq!(near.len(), 1);
-        assert_eq!(near[0].start.y, 0.0);
-        assert_eq!(near[0].end.y, 0.0);
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -6,6 +6,10 @@
 //! dilation over filled point sets, shared by every dialect so IPC, Gerber,
 //! SVG, and comparison all use the same geometry semantics.
 
+mod query;
+
+pub use query::PreparedRegion;
+
 use std::fmt;
 
 use boostvoronoi::prelude::{

--- a/crates/pcb-ir/src/geom/region/query.rs
+++ b/crates/pcb-ir/src/geom/region/query.rs
@@ -1,0 +1,192 @@
+use super::{ContourSet, horizontal_crossing, ring_edges, ring_signed_area};
+use crate::geom::dist::{self, Distance};
+use crate::geom::{BBox, Point, tol};
+use std::ops::Range;
+
+/// An owned [`ContourSet`] snapshot with a bounding-box hierarchy for nearest
+/// boundary and winding queries. Preparation takes O(n log n) time and O(n)
+/// space; queries allocate no scratch storage and take O(n) in the worst case.
+/// Coordinates and distances use the source region's frame, in millimeters.
+#[derive(Debug, Clone)]
+pub struct PreparedRegion {
+    segments: Vec<(Point, Point)>,
+    nodes: Vec<Node>,
+    uncertainty_mm: f64,
+}
+
+#[derive(Debug, Clone)]
+struct Node {
+    bounds: BBox,
+    kind: NodeKind,
+}
+
+#[derive(Debug, Clone)]
+enum NodeKind {
+    Leaf(Range<usize>),
+    Branch(usize, usize),
+}
+
+const LEAF_SEGMENTS: usize = 8;
+
+impl ContourSet {
+    /// Prepare a reusable index over the region's existing polygon boundary.
+    ///
+    /// Requires finite, regularized rings. Zero-area rings are ignored.
+    ///
+    /// ```
+    /// use pcb_ir::geom::{BBox, ContourSet, Point};
+    ///
+    /// let region = ContourSet::rectangle(
+    ///     BBox::new(Point::ZERO, Point::new(4.0, 2.0)), 0.001,
+    /// );
+    /// let prepared = region.prepare_query();
+    /// let inside = prepared.signed_distance(Point::new(2.0, 0.5)).unwrap();
+    /// assert_eq!(inside.mm, -0.5);
+    /// assert_eq!(inside.second, Point::new(2.0, 0.0));
+    /// ```
+    pub fn prepare_query(&self) -> PreparedRegion {
+        let mut prepared = PreparedRegion {
+            segments: self
+                .rings
+                .iter()
+                .filter(|ring| ring_signed_area(ring) != 0.0)
+                .flat_map(ring_edges)
+                .collect(),
+            nodes: Vec::new(),
+            uncertainty_mm: tol::FLATTEN_MM,
+        };
+        if !prepared.segments.is_empty() {
+            prepared.build(0..prepared.segments.len());
+        }
+        prepared
+    }
+}
+
+impl PreparedRegion {
+    /// Euclidean distance to the polygon boundary: negative inside,
+    /// zero on the boundary, positive outside (including inside a hole).
+    ///
+    /// `first` is the query point; `second` is a closest boundary point.
+    /// Ties may return any closest witness. Returns
+    /// `None` when the region has no filled boundary or the point is non-finite.
+    ///
+    /// Uses floating-point arithmetic without snapping to the region tolerance.
+    /// Like [`Distance::flattened`], uncertainty counts one flattened boundary;
+    /// it does not bound prior approximations, offsets, or discarded features.
+    /// The source geometry's sign is uncertain when this band includes zero.
+    pub fn signed_distance(&self, point: Point) -> Option<Distance> {
+        let root = self.nodes.first()?;
+        if !point.is_finite() {
+            return None;
+        }
+        let mut query = Query {
+            point,
+            distance: f64::INFINITY,
+            boundary: Point::ZERO,
+            winding: 0,
+            needs_winding: root.bounds.contains_point(point),
+        };
+        self.visit(0, &mut query);
+        Some(Distance {
+            mm: if query.winding == 0 {
+                query.distance
+            } else {
+                -query.distance
+            },
+            uncertainty_mm: self.uncertainty_mm,
+            first: point,
+            second: query.boundary,
+        })
+    }
+
+    /// Apply [`Self::signed_distance`] in input order, reusing the index.
+    pub fn signed_distances(&self, points: &[Point]) -> Vec<Option<Distance>> {
+        points
+            .iter()
+            .map(|&point| self.signed_distance(point))
+            .collect()
+    }
+
+    fn build(&mut self, range: Range<usize>) -> usize {
+        let bounds = self.segments[range.clone()]
+            .iter()
+            .fold(BBox::empty(), |bounds, &(start, end)| {
+                bounds.union(BBox::spanning(start, end))
+            });
+        let node = self.nodes.len();
+        self.nodes.push(Node {
+            bounds,
+            kind: NodeKind::Leaf(range.clone()),
+        });
+        if range.len() > LEAF_SEGMENTS {
+            let middle = range.start + range.len() / 2;
+            let center = |&(start, end): &(Point, Point)| {
+                let midpoint = start.midpoint(end);
+                if bounds.width() >= bounds.height() {
+                    midpoint.x
+                } else {
+                    midpoint.y
+                }
+            };
+            self.segments[range.clone()].select_nth_unstable_by(range.len() / 2, |left, right| {
+                center(left).total_cmp(&center(right))
+            });
+            let left = self.build(range.start..middle);
+            let right = self.build(middle..range.end);
+            self.nodes[node].kind = NodeKind::Branch(left, right);
+        }
+        node
+    }
+
+    fn visit(&self, index: usize, query: &mut Query) {
+        let node = &self.nodes[index];
+        let measure = node.bounds.distance_to(BBox::from_point(query.point)) <= query.distance;
+        // Half-open height matches horizontal_crossing at shared vertices.
+        let wind = query.needs_winding
+            && node.bounds.min.y <= query.point.y
+            && query.point.y < node.bounds.max.y
+            && node.bounds.min.x <= query.point.x;
+        if !measure && !wind {
+            return;
+        }
+        match &node.kind {
+            NodeKind::Leaf(range) => {
+                for &(start, end) in &self.segments[range.clone()] {
+                    if measure {
+                        let (distance, boundary) = dist::point_segment(query.point, start, end);
+                        if distance < query.distance {
+                            query.distance = distance;
+                            query.boundary = boundary;
+                        }
+                    }
+                    if wind
+                        && let Some((x, direction)) = horizontal_crossing(start, end, query.point.y)
+                        && x <= query.point.x
+                    {
+                        query.winding += direction;
+                    }
+                }
+            }
+            NodeKind::Branch(left, right) => {
+                let bounds = BBox::from_point(query.point);
+                let left_distance = self.nodes[*left].bounds.distance_to(bounds);
+                let right_distance = self.nodes[*right].bounds.distance_to(bounds);
+                let (first, second) = if left_distance <= right_distance {
+                    (*left, *right)
+                } else {
+                    (*right, *left)
+                };
+                self.visit(first, query);
+                self.visit(second, query);
+            }
+        }
+    }
+}
+
+struct Query {
+    point: Point,
+    distance: f64,
+    boundary: Point,
+    winding: i32,
+    needs_winding: bool,
+}

--- a/crates/pcb-ir/src/geom/region/query.rs
+++ b/crates/pcb-ir/src/geom/region/query.rs
@@ -5,11 +5,12 @@ use std::ops::Range;
 
 /// An owned [`ContourSet`] snapshot with a bounding-box hierarchy for nearest
 /// boundary and winding queries. Preparation takes O(n log n) time and O(n)
-/// space; queries allocate no scratch storage and take O(n) in the worst case.
+/// space; point queries allocate no scratch storage and take O(n) in the worst case.
 /// Coordinates and distances use the source region's frame, in millimeters.
 #[derive(Debug, Clone)]
 pub struct PreparedRegion {
-    segments: Vec<(Point, Point)>,
+    pub(crate) segments: Vec<(Point, Point)>,
+    order: Vec<usize>,
     nodes: Vec<Node>,
     uncertainty_mm: f64,
 }
@@ -45,13 +46,21 @@ impl ContourSet {
     /// assert_eq!(inside.second, Point::new(2.0, 0.0));
     /// ```
     pub fn prepare_query(&self) -> PreparedRegion {
-        let mut prepared = PreparedRegion {
-            segments: self
-                .rings
+        PreparedRegion::from_segments(
+            self.rings
                 .iter()
                 .filter(|ring| ring_signed_area(ring) != 0.0)
                 .flat_map(ring_edges)
                 .collect(),
+        )
+    }
+}
+
+impl PreparedRegion {
+    pub(super) fn from_segments(segments: Vec<(Point, Point)>) -> Self {
+        let mut prepared = Self {
+            order: (0..segments.len()).collect(),
+            segments,
             nodes: Vec::new(),
             uncertainty_mm: tol::FLATTEN_MM,
         };
@@ -60,9 +69,7 @@ impl ContourSet {
         }
         prepared
     }
-}
 
-impl PreparedRegion {
     /// Euclidean distance to the polygon boundary: negative inside,
     /// zero on the boundary, positive outside (including inside a hole).
     ///
@@ -75,19 +82,29 @@ impl PreparedRegion {
     /// it does not bound prior approximations, offsets, or discarded features.
     /// The source geometry's sign is uncertain when this band includes zero.
     pub fn signed_distance(&self, point: Point) -> Option<Distance> {
+        self.point_distance(point, f64::INFINITY, true)
+    }
+
+    /// Nearest boundary point within `max_distance_mm`, with unsigned distance.
+    pub fn nearest_within(&self, point: Point, max_distance_mm: f64) -> Option<Distance> {
+        self.point_distance(point, max_distance_mm + tol::EPSILON_MM, false)
+    }
+
+    fn point_distance(&self, point: Point, maximum: f64, signed: bool) -> Option<Distance> {
         let root = self.nodes.first()?;
         if !point.is_finite() {
             return None;
         }
         let mut query = Query {
             point,
-            distance: f64::INFINITY,
+            distance: maximum,
+            found: false,
             boundary: Point::ZERO,
             winding: 0,
-            needs_winding: root.bounds.contains_point(point),
+            needs_winding: signed && root.bounds.contains_point(point),
         };
         self.visit(0, &mut query);
-        Some(Distance {
+        query.found.then_some(Distance {
             mm: if query.winding == 0 {
                 query.distance
             } else {
@@ -107,10 +124,86 @@ impl PreparedRegion {
             .collect()
     }
 
+    /// Nearest points between the query segment and boundary within the limit.
+    pub fn segment_nearest_within(
+        &self,
+        start: Point,
+        end: Point,
+        max_distance_mm: f64,
+    ) -> Option<Distance> {
+        self.segment_ids_near(start, end, max_distance_mm)
+            .into_iter()
+            .map(|id| {
+                let (a, b) = self.segments[id];
+                let (mm, first, second) = dist::segments(start, end, a, b);
+                Distance {
+                    mm,
+                    first,
+                    second,
+                    uncertainty_mm: self.uncertainty_mm,
+                }
+            })
+            .filter(|distance| distance.mm <= max_distance_mm + tol::EPSILON_MM)
+            .min_by(|left, right| left.mm.total_cmp(&right.mm))
+    }
+
+    /// Boundary segments whose bounds meet `bounds`, once each in source order.
+    pub fn segments_meeting(&self, bounds: BBox) -> impl Iterator<Item = (Point, Point)> + '_ {
+        self.segment_ids_meeting(bounds)
+            .into_iter()
+            .map(|id| self.segments[id])
+    }
+
+    pub(crate) fn segment_ids_near(&self, start: Point, end: Point, reach: f64) -> Vec<usize> {
+        let query = BBox::spanning(start, end);
+        let delta = end - start;
+        self.segment_ids_where(&|bounds| {
+            let bounds = bounds.expand(reach + tol::EPSILON_MM);
+            let offset = bounds.center() - start;
+            // The segment normal is the separating axis beyond x and y.
+            query.intersects(bounds)
+                && (delta.x * offset.y - delta.y * offset.x).abs()
+                    <= (delta.x.abs() * bounds.height() + delta.y.abs() * bounds.width()) * 0.5
+        })
+    }
+
+    pub(crate) fn segment_ids_meeting(&self, bounds: BBox) -> Vec<usize> {
+        self.segment_ids_where(&|candidate| candidate.intersects(bounds))
+    }
+
+    fn segment_ids_where(&self, meets: &impl Fn(BBox) -> bool) -> Vec<usize> {
+        let mut ids = Vec::new();
+        if !self.nodes.is_empty() {
+            self.collect_meeting(0, meets, &mut ids);
+        }
+        ids.sort_unstable();
+        ids
+    }
+
+    fn collect_meeting(&self, index: usize, meets: &impl Fn(BBox) -> bool, ids: &mut Vec<usize>) {
+        let node = &self.nodes[index];
+        if !meets(node.bounds) {
+            return;
+        }
+        match &node.kind {
+            NodeKind::Leaf(range) => {
+                ids.extend(self.order[range.clone()].iter().copied().filter(|&id| {
+                    let (start, end) = self.segments[id];
+                    meets(BBox::spanning(start, end))
+                }))
+            }
+            NodeKind::Branch(left, right) => {
+                self.collect_meeting(*left, meets, ids);
+                self.collect_meeting(*right, meets, ids);
+            }
+        }
+    }
+
     fn build(&mut self, range: Range<usize>) -> usize {
-        let bounds = self.segments[range.clone()]
+        let bounds = self.order[range.clone()]
             .iter()
-            .fold(BBox::empty(), |bounds, &(start, end)| {
+            .fold(BBox::empty(), |bounds, &id| {
+                let (start, end) = self.segments[id];
                 bounds.union(BBox::spanning(start, end))
             });
         let node = self.nodes.len();
@@ -120,7 +213,8 @@ impl PreparedRegion {
         });
         if range.len() > LEAF_SEGMENTS {
             let middle = range.start + range.len() / 2;
-            let center = |&(start, end): &(Point, Point)| {
+            let center = |&id: &usize| {
+                let (start, end) = self.segments[id];
                 let midpoint = start.midpoint(end);
                 if bounds.width() >= bounds.height() {
                     midpoint.x
@@ -128,7 +222,7 @@ impl PreparedRegion {
                     midpoint.y
                 }
             };
-            self.segments[range.clone()].select_nth_unstable_by(range.len() / 2, |left, right| {
+            self.order[range.clone()].select_nth_unstable_by(range.len() / 2, |left, right| {
                 center(left).total_cmp(&center(right))
             });
             let left = self.build(range.start..middle);
@@ -151,10 +245,12 @@ impl PreparedRegion {
         }
         match &node.kind {
             NodeKind::Leaf(range) => {
-                for &(start, end) in &self.segments[range.clone()] {
+                for &id in &self.order[range.clone()] {
+                    let (start, end) = self.segments[id];
                     if measure {
                         let (distance, boundary) = dist::point_segment(query.point, start, end);
-                        if distance < query.distance {
+                        if distance <= query.distance {
+                            query.found = true;
                             query.distance = distance;
                             query.boundary = boundary;
                         }
@@ -186,6 +282,7 @@ impl PreparedRegion {
 struct Query {
     point: Point,
     distance: f64,
+    found: bool,
     boundary: Point,
     winding: i32,
     needs_winding: bool,

--- a/crates/pcb-ir/tests/region_query.rs
+++ b/crates/pcb-ir/tests/region_query.rs
@@ -280,3 +280,26 @@ fn short_nonzero_edges_remain_segments() {
     assert!((distance.mm + 1e-9).abs() < 1e-20, "{distance:?}");
     assert!(distance.second.distance_to(Point::new(0.0, 5e-9)) < 1e-20);
 }
+
+#[test]
+fn far_translated_rings_keep_area_holes_and_distances() {
+    for origin in [1e9, -1e9] {
+        let outer = rectangle(origin, origin, origin + 4.0, origin + 4.0);
+        let mut hole = rectangle(origin + 1.0, origin + 1.0, origin + 3.0, origin + 3.0);
+        hole.reverse();
+        assert_eq!(pcb_ir::geom::region::ring_signed_area(&outer), 16.0);
+        assert_eq!(pcb_ir::geom::region::ring_signed_area(&hole), -4.0);
+        for tolerance in [0.0, tol::REGION_MM] {
+            let region = ContourSet::from_regularized(vec![outer.clone(), hole.clone()], tolerance);
+            assert_eq!(region.rings.len(), 2);
+            let prepared = region.prepare_query();
+            for (offset, expected) in [(0.5, -0.5), (2.0, 1.0), (5.0, 1.0)] {
+                query(
+                    &prepared,
+                    Point::new(origin + offset, origin + 2.0),
+                    expected,
+                );
+            }
+        }
+    }
+}

--- a/crates/pcb-ir/tests/region_query.rs
+++ b/crates/pcb-ir/tests/region_query.rs
@@ -203,6 +203,39 @@ fn batches_match_exhaustive_measurements_and_repeated_queries() {
             .map(|(start, end)| dist::point_segment(distance.second, start, end).0)
             .fold(f64::INFINITY, f64::min);
         near(witness_distance, 0.0);
+        let end = point + Point::new(13.1, -9.7);
+        let segment_distance = region
+            .rings
+            .iter()
+            .flat_map(ring_edges)
+            .map(|(a, b)| dist::segments(point, end, a, b).0)
+            .fold(f64::INFINITY, f64::min);
+        for limit in [0.0, 0.3, 2.0] {
+            let nearest = prepared.nearest_within(point, limit);
+            assert_eq!(nearest.is_some(), expected <= limit + tol::EPSILON_MM);
+            if let Some(nearest) = nearest {
+                near(nearest.mm, expected);
+            }
+            let nearest = prepared.segment_nearest_within(point, end, limit);
+            assert_eq!(
+                nearest.is_some(),
+                segment_distance <= limit + tol::EPSILON_MM
+            );
+            if let Some(nearest) = nearest {
+                near(nearest.mm, segment_distance);
+                near(nearest.first.distance_to(nearest.second), segment_distance);
+            }
+        }
+        let bounds = BBox::spanning(point, end);
+        assert_eq!(
+            prepared.segments_meeting(bounds).collect::<Vec<_>>(),
+            region
+                .rings
+                .iter()
+                .flat_map(ring_edges)
+                .filter(|&(a, b)| BBox::spanning(a, b).intersects(bounds))
+                .collect::<Vec<_>>()
+        );
     }
 }
 

--- a/crates/pcb-ir/tests/region_query.rs
+++ b/crates/pcb-ir/tests/region_query.rs
@@ -1,0 +1,249 @@
+//! Public prepared-region API, including the headless placed-path consumer.
+
+use pcb_ir::geom::dist::{self, Distance};
+use pcb_ir::geom::region::{ring_edges, rings_to_contours};
+use pcb_ir::geom::{
+    Affine2, BBox, ContourSet, FillRule, Mirror, Paint, PathArena, Point, PreparedRegion, Ring,
+    shapes, tol,
+};
+
+fn rectangle(x0: f64, y0: f64, x1: f64, y1: f64) -> Ring {
+    vec![[x0, y0], [x1, y0], [x1, y1], [x0, y1]]
+}
+
+fn near(actual: f64, expected: f64) {
+    assert!(
+        (actual - expected).abs() < 1e-7,
+        "expected {expected}, got {actual}"
+    );
+}
+
+fn query(prepared: &PreparedRegion, point: Point, expected: f64) -> Distance {
+    let distance = prepared.signed_distance(point).unwrap();
+    near(distance.mm, expected);
+    assert_eq!(distance.first, point);
+    near(distance.first.distance_to(distance.second), expected.abs());
+    distance
+}
+
+#[test]
+fn boundary_and_near_boundary_points_keep_their_signed_distance() {
+    let region =
+        ContourSet::rectangle(BBox::new(Point::ZERO, Point::new(4.0, 4.0)), tol::REGION_MM);
+    let prepared = region.prepare_query();
+    for point in [
+        Point::ZERO,
+        Point::new(4.0, 4.0),
+        Point::new(0.0, 2.0),
+        Point::new(4.0, 2.0),
+        Point::new(2.0, 0.0),
+        Point::new(2.0, 4.0),
+    ] {
+        let distance = query(&prepared, point, 0.0);
+        assert_eq!(distance.second, point);
+    }
+    // Much closer than the region's containment/significance tolerance.
+    for x in [-5e-7, -1e-10, 1e-10, 5e-7] {
+        let distance = query(&prepared, Point::new(x, 2.0), -x);
+        assert_eq!(distance.mm.is_sign_negative(), x > 0.0);
+    }
+    query(&prepared, Point::new(2.0, 2.0), -2.0);
+    query(&prepared, Point::new(1e6, 2.0), 1e6 - 4.0);
+}
+
+#[test]
+fn concave_corners_return_a_euclidean_boundary_witness() {
+    let region = ContourSet::new(
+        vec![vec![
+            [0.0, 0.0],
+            [6.0, 0.0],
+            [6.0, 2.0],
+            [2.0, 2.0],
+            [2.0, 6.0],
+            [0.0, 6.0],
+        ]],
+        FillRule::NonZero,
+        tol::REGION_MM,
+    );
+    let prepared = region.prepare_query();
+    for (point, expected, witness) in [
+        (Point::new(3.0, 3.5), 1.0, Point::new(2.0, 3.5)),
+        (Point::new(1.7, 1.6), -0.5, Point::new(2.0, 2.0)),
+        (Point::new(1.7, 3.0), -0.3, Point::new(2.0, 3.0)),
+        (Point::new(-1.0, -1.0), 2.0_f64.sqrt(), Point::ZERO),
+    ] {
+        let distance = query(&prepared, point, expected);
+        near(distance.second.distance_to(witness), 0.0);
+    }
+}
+
+fn nested_rings() -> Vec<Ring> {
+    vec![
+        rectangle(0.0, 0.0, 10.0, 10.0),
+        rectangle(2.0, 2.0, 8.0, 8.0),
+        rectangle(4.0, 4.0, 6.0, 6.0),
+        rectangle(20.0, 0.0, 22.0, 2.0),
+    ]
+}
+
+#[test]
+fn holes_nested_islands_and_separate_islands_follow_the_fill_rule() {
+    let region = ContourSet::new(nested_rings(), FillRule::EvenOdd, tol::REGION_MM);
+    let prepared = region.prepare_query();
+    for (point, expected) in [
+        (Point::new(1.0, 5.0), -1.0),
+        (Point::new(3.0, 5.0), 1.0),
+        (Point::new(5.0, 5.0), -1.0),
+        (Point::new(21.0, 1.0), -1.0),
+        (Point::new(12.0, 1.0), 2.0),
+        (Point::new(2.0, 5.0), 0.0),
+    ] {
+        query(&prepared, point, expected);
+    }
+    let filled = ContourSet::new(nested_rings(), FillRule::NonZero, tol::REGION_MM);
+    query(&filled.prepare_query(), Point::new(3.0, 5.0), -3.0);
+}
+
+#[test]
+fn headless_placements_transform_holes_distances_and_witnesses() {
+    let mut arena = PathArena::default();
+    let id = arena.push_path(
+        Paint::Fill {
+            rule: FillRule::EvenOdd,
+        },
+        rings_to_contours(nested_rings()),
+    );
+    for mirror in [Mirror::NONE, Mirror::X] {
+        for rotation in [0.0, 37.0, 90.0] {
+            let scale = 2.5;
+            let transform = Affine2::placement(Point::new(17.0, -11.0), rotation, mirror, scale);
+            let region = ContourSet::from_placed_painted_paths(
+                &arena,
+                [(arena.path(id), transform)],
+                tol::REGION_MM,
+            );
+            let prepared = region.prepare_query();
+            for (point, expected, witness) in [
+                (Point::new(3.0, 2.5), 0.5, Point::new(3.0, 2.0)),
+                (Point::new(0.5, 5.0), -0.5, Point::new(0.0, 5.0)),
+                (Point::new(21.5, 1.0), -0.5, Point::new(22.0, 1.0)),
+            ] {
+                let distance = query(
+                    &prepared,
+                    transform.transform_point(point),
+                    expected * scale,
+                );
+                near(
+                    distance
+                        .second
+                        .distance_to(transform.transform_point(witness)),
+                    0.0,
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn curve_distance_bands_cover_the_source_circle() {
+    let radius = 2.0;
+    let region = ContourSet::from_contours(
+        &[shapes::circle(2.0 * radius).unwrap()],
+        FillRule::NonZero,
+        tol::REGION_MM,
+    );
+    let prepared = region.prepare_query();
+    for index in 0..128 {
+        let angle = (index as f64 + 0.37) * std::f64::consts::TAU / 128.0;
+        for offset in [-0.5, -0.001, 0.0, 0.001, 0.5] {
+            let point = Point::new(angle.cos(), angle.sin()) * (radius + offset);
+            let distance = prepared.signed_distance(point).unwrap();
+            assert!(distance.uncertainty_mm.is_finite());
+            assert!(
+                (distance.mm - offset).abs() <= distance.uncertainty_mm,
+                "angle={angle}, offset={offset}, distance={distance:?}"
+            );
+            assert!((distance.second.length() - radius).abs() <= distance.uncertainty_mm);
+        }
+    }
+}
+
+#[test]
+fn batches_match_exhaustive_measurements_and_repeated_queries() {
+    let mut rings = nested_rings();
+    for index in 0..64 {
+        let x = 30.0 + (index % 8) as f64 * 4.0;
+        let y = (index / 8) as f64 * 4.0;
+        rings.push(vec![[x, y], [x + 2.0, y], [x + 1.0, y + 3.0]]);
+    }
+    let region = ContourSet::new(rings, FillRule::EvenOdd, tol::REGION_MM);
+    let prepared = region.prepare_query();
+    let points = (0..51)
+        .flat_map(|x| {
+            (0..31).map(move |y| Point::new(x as f64 * 1.37 - 4.0, y as f64 * 1.29 - 4.0))
+        })
+        .collect::<Vec<_>>();
+    let inside = region.contains_points_batch(&points);
+    let distances = prepared.signed_distances(&points);
+    for ((&point, distance), inside) in points.iter().zip(&distances).zip(inside) {
+        assert_eq!(*distance, prepared.signed_distance(point));
+        let distance = distance.unwrap();
+        let expected = region
+            .rings
+            .iter()
+            .flat_map(ring_edges)
+            .map(|(start, end)| dist::point_segment(point, start, end).0)
+            .fold(f64::INFINITY, f64::min);
+        near(distance.mm, if inside { -expected } else { expected });
+        near(distance.first.distance_to(distance.second), expected);
+        let witness_distance = region
+            .rings
+            .iter()
+            .flat_map(ring_edges)
+            .map(|(start, end)| dist::point_segment(distance.second, start, end).0)
+            .fold(f64::INFINITY, f64::min);
+        near(witness_distance, 0.0);
+    }
+}
+
+#[test]
+fn empty_degenerate_and_invalid_queries_have_no_witness() {
+    for region in [
+        ContourSet::empty(0.0),
+        ContourSet::from_regularized(
+            vec![
+                vec![],
+                vec![[1.0, 1.0]],
+                vec![[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]],
+            ],
+            0.0,
+        ),
+    ] {
+        let prepared = region.prepare_query();
+        assert_eq!(prepared.signed_distance(Point::ZERO), None);
+    }
+    let prepared = ContourSet::new(
+        vec![rectangle(0.0, 0.0, 2.0, 2.0)],
+        FillRule::NonZero,
+        tol::REGION_MM,
+    )
+    .prepare_query();
+    let points = [
+        Point::new(f64::NAN, 1.0),
+        Point::new(1.0, f64::INFINITY),
+        Point::new(f64::NEG_INFINITY, 1.0),
+        Point::new(1.0, 1.0),
+    ];
+    let distances = prepared.signed_distances(&points);
+    assert_eq!(&distances[..3], &[None, None, None]);
+    near(distances[3].unwrap().mm, -1.0);
+}
+
+#[test]
+fn short_nonzero_edges_remain_segments() {
+    let prepared =
+        ContourSet::from_regularized(vec![rectangle(0.0, 0.0, 1e-8, 1e-8)], 0.0).prepare_query();
+    let distance = prepared.signed_distance(Point::new(1e-9, 5e-9)).unwrap();
+    assert!((distance.mm + 1e-9).abs() < 1e-20, "{distance:?}");
+    assert!(distance.second.distance_to(Point::new(0.0, 5e-9)) < 1e-20);
+}


### PR DESCRIPTION
Manufacturing planners need signed distances to filled PCB regions ([ENG-1355](https://linear.app/diodeinc/issue/ENG-1355/expose-prepared-signed-distance-queries-for-pcbir-filled-regions)). Add reusable point and batch queries, move DFM and thin-feature analysis to the same boundary index, and remove both old grid implementations.
