### PR TITLE
ENG-1356: Prepare curved geometry to a stated accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Keep circles and ellipses exact through placement, export, and rendering, preparing curved geometry to a stated accuracy.
+
 ### Changed
 
 - Consolidate `pcb bom` table and JSON rows by selected offer.

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -1577,8 +1577,8 @@ mod tests {
         let actual = image(
             &pcb_ir::dialects::artwork::compose_to_mask(&geometry, Resolution::default()).unwrap(),
         );
-        let symmetric_difference =
-            expected.difference(&actual).area() + actual.difference(&expected).area();
+        let symmetric_difference = expected.difference(&actual).unwrap().area()
+            + actual.difference(&expected).unwrap().area();
         assert!(symmetric_difference < 0.01, "{symmetric_difference}");
     }
 

--- a/crates/gerberx2/src/from_artwork.rs
+++ b/crates/gerberx2/src/from_artwork.rs
@@ -5,6 +5,7 @@
 //! can be emitted as a Gerber file, regardless of which source dialect
 //! produced it.
 
+use pcb_ir::geom::{AccuracyError, GeometryAccuracy, Resolution};
 use std::collections::HashMap;
 
 use crate::{
@@ -14,7 +15,7 @@ use crate::{
     sanitize_attribute_field,
 };
 use pcb_ir::dialects::artwork::{Aperture, ApertureShape, Geometry as ArtworkGeometry, PaintStage};
-use pcb_ir::geom::path::{self as geom_path, ContourBuf, PathCmd};
+use pcb_ir::geom::path::ContourBuf;
 use pcb_ir::geom::region::{self, Ring};
 use pcb_ir::geom::{Affine2, FillRule, Point, Polarity, Segment, StrokePatternMark};
 
@@ -50,9 +51,10 @@ pub type ArtworkDocument = pcb_ir::dialects::artwork::Document<LayerAttributes, 
 /// carry its X2 attributes across, and lower it back to idiomatic Gerber.
 /// Source flashes survive as flashes unless explicit copper feature semantics
 /// require region output; block instances are expanded.
-pub fn normalize_layer(gerber: &crate::GerberX2) -> Result<String> {
-    let annotated = annotate_for_export(gerber, crate::geometry::extract_document(gerber));
-    crate::write_layer(&lower_artwork_layer(&annotated)?)
+pub fn normalize_layer(gerber: &crate::GerberX2, accuracy: GeometryAccuracy) -> Result<String> {
+    let annotated =
+        annotate_for_export(gerber, crate::geometry::extract_document(gerber, accuracy)?);
+    crate::write_layer(&lower_artwork_layer(&annotated, accuracy)?)
 }
 
 /// Convert an extracted layer's interned Gerber metadata into the resolved
@@ -160,7 +162,10 @@ fn resolve_fields(gerber: &crate::GerberX2, attribute: &crate::types::Attribute)
         .collect()
 }
 
-pub fn lower_artwork_layer(layer: &ArtworkDocument) -> Result<GerberLayer> {
+pub fn lower_artwork_layer(
+    layer: &ArtworkDocument,
+    accuracy: GeometryAccuracy,
+) -> Result<GerberLayer> {
     let mut layer = pcb_ir::dialects::artwork::expand_instances_preserving_grids(layer);
     pcb_ir::dialects::artwork::legalize::legalize_for_jlcpcb(&mut layer);
     let mut apertures = ApertureTable::default();
@@ -187,6 +192,7 @@ pub fn lower_artwork_layer(layer: &ArtworkDocument) -> Result<GerberLayer> {
                     object.polarity,
                     &mut apertures,
                     &mut plan,
+                    accuracy,
                 )?;
             }
             _ => {
@@ -196,6 +202,7 @@ pub fn lower_artwork_layer(layer: &ArtworkDocument) -> Result<GerberLayer> {
                     Affine2::IDENTITY,
                     object.polarity,
                     &mut apertures,
+                    accuracy,
                 )?;
                 plan.push_group(object.order.stage, object.polarity, objects);
             }
@@ -213,6 +220,7 @@ pub fn lower_artwork_layer(layer: &ArtworkDocument) -> Result<GerberLayer> {
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn lower_grid_objects(
     layer: &ArtworkDocument,
     block: u32,
@@ -221,11 +229,14 @@ fn lower_grid_objects(
     polarity: Polarity,
     apertures: &mut ApertureTable,
     plan: &mut GerberPlan,
+    accuracy: GeometryAccuracy,
 ) -> Result<()> {
     if let Some((base, step_repeat)) = gerber_step_repeat(placement, grid) {
         let repeat =
             (step_repeat.x_repeats > 1 || step_repeat.y_repeats > 1).then_some(step_repeat);
-        lower_grid_occurrence(layer, block, base, polarity, repeat, apertures, plan)
+        lower_grid_occurrence(
+            layer, block, base, polarity, repeat, apertures, plan, accuracy,
+        )
     } else {
         for offset in grid.offsets() {
             let occurrence = Affine2 {
@@ -233,12 +244,15 @@ fn lower_grid_objects(
                 m12: placement.m12 + offset.y,
                 ..placement
             };
-            lower_grid_occurrence(layer, block, occurrence, polarity, None, apertures, plan)?;
+            lower_grid_occurrence(
+                layer, block, occurrence, polarity, None, apertures, plan, accuracy,
+            )?;
         }
         Ok(())
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn lower_grid_occurrence(
     layer: &ArtworkDocument,
     block: u32,
@@ -247,10 +261,12 @@ fn lower_grid_occurrence(
     repeat: Option<crate::StepRepeat>,
     apertures: &mut ApertureTable,
     plan: &mut GerberPlan,
+    accuracy: GeometryAccuracy,
 ) -> Result<()> {
     for child in &layer.blocks[block as usize].objects {
         let child_polarity = polarity.compose(child.polarity);
-        let mut objects = lower_artwork_object(layer, child, base, child_polarity, apertures)?;
+        let mut objects =
+            lower_artwork_object(layer, child, base, child_polarity, apertures, accuracy)?;
         for object in &mut objects {
             object.repeat = repeat;
         }
@@ -314,6 +330,7 @@ fn lower_artwork_object(
     transform: Affine2,
     polarity: Polarity,
     apertures: &mut ApertureTable,
+    accuracy: GeometryAccuracy,
 ) -> Result<Vec<WriterObject>> {
     let attributes = lower_object_attributes(&object.meta);
     let aperture_attributes = lower_aperture_attributes(&object.meta);
@@ -327,6 +344,7 @@ fn lower_artwork_object(
                 polarity,
                 &aperture_attributes,
                 &attributes,
+                accuracy,
             )?);
         }
         ArtworkGeometry::Stroke { path } => {
@@ -344,9 +362,9 @@ fn lower_artwork_object(
                 .arena
                 .path_contours(artwork_path)
                 .into_iter()
-                .map(|contour| geom_path::transform_cmds(contour.cmds, transform))
+                .map(|contour| contour.transformed(transform))
             {
-                let segments = contour_segments(&contour.cmds);
+                let segments = contour_segments(&contour, accuracy)?;
                 for mark in
                     pcb_ir::geom::stroke_pattern_marks(&segments, stroke.pattern, stroke_width)
                 {
@@ -369,6 +387,7 @@ fn lower_artwork_object(
                                     polarity,
                                     &region_aperture_attributes,
                                     &attributes,
+                                    accuracy,
                                 )?);
                             } else {
                                 objects.push(WriterObject {
@@ -424,9 +443,11 @@ fn lower_artwork_object(
                     polarity,
                     &region_aperture_attributes,
                     &attributes,
+                    accuracy,
                 );
             }
-            let aperture = apertures.artwork_aperture(artwork_aperture, aperture_function)?;
+            let aperture =
+                apertures.artwork_aperture(artwork_aperture, aperture_function, accuracy)?;
             objects.push(WriterObject {
                 kind: ObjectKind::Flash {
                     at: lower_point(Point::new(transform.m02, transform.m12)),
@@ -463,7 +484,9 @@ fn lower_stroke_segment(segment: Segment, aperture: i32) -> ObjectKind {
             clockwise: arc.clockwise,
             aperture,
         },
-        Segment::Cubic { .. } => unreachable!("contour_segments flattens cubics"),
+        Segment::Cubic { .. } | Segment::Ellipse(_) => {
+            unreachable!("contour_segments flattens curves")
+        }
     }
 }
 
@@ -612,7 +635,12 @@ impl ApertureTable {
         )
     }
 
-    fn artwork_aperture(&mut self, aperture: Aperture, function: &[String]) -> Result<i32> {
+    fn artwork_aperture(
+        &mut self,
+        aperture: Aperture,
+        function: &[String],
+        accuracy: GeometryAccuracy,
+    ) -> Result<i32> {
         let hole_diameter = (aperture.hole_diameter > 0.0).then_some(aperture.hole_diameter);
         match aperture.shape {
             ApertureShape::Contour { outline, fill_rule } => {
@@ -620,11 +648,8 @@ impl ApertureTable {
                 // rule so winding is canonical: each shape is an outer ring
                 // followed by its holes, wound opposite. Larger shapes paint
                 // first so an island inside a hole survives the hole's erase.
-                let mut shapes = region::simplify_shapes_on_grid(
-                    region::rings_from_contours(std::slice::from_ref(&outline)),
-                    fill_rule,
-                    GERBER_GEOMETRY_GRID_MM,
-                );
+                let mut shapes =
+                    prepare_on_grid(std::slice::from_ref(&outline), fill_rule, accuracy)?;
                 shapes.sort_by(|a, b| {
                     let area = |shape: &region::Shape| {
                         shape
@@ -796,6 +821,7 @@ impl ApertureTable {
                         fill_rule: FillRule::NonZero,
                     }),
                     function,
+                    accuracy,
                 )
             }
         }
@@ -999,6 +1025,7 @@ fn lower_region_objects(
     polarity: Polarity,
     aperture_attributes: &[AttributeValue],
     attributes: &[AttributeValue],
+    accuracy: GeometryAccuracy,
 ) -> Result<Vec<WriterObject>> {
     let artwork_path = &layer.arena.paths[path_index as usize];
     lower_contours_as_regions(
@@ -1008,6 +1035,7 @@ fn lower_region_objects(
         polarity,
         aperture_attributes,
         attributes,
+        accuracy,
     )
 }
 
@@ -1017,6 +1045,7 @@ fn lower_aperture_as_regions(
     polarity: Polarity,
     aperture_attributes: &[AttributeValue],
     attributes: &[AttributeValue],
+    accuracy: GeometryAccuracy,
 ) -> Result<Vec<WriterObject>> {
     lower_contours_as_regions(
         aperture.contours(),
@@ -1025,6 +1054,7 @@ fn lower_aperture_as_regions(
         polarity,
         aperture_attributes,
         attributes,
+        accuracy,
     )
 }
 
@@ -1035,12 +1065,13 @@ fn lower_contours_as_regions(
     polarity: Polarity,
     aperture_attributes: &[AttributeValue],
     attributes: &[AttributeValue],
+    accuracy: GeometryAccuracy,
 ) -> Result<Vec<WriterObject>> {
     let payloads = contours
         .into_iter()
-        .map(|contour| geom_path::transform_cmds(contour.cmds, transform))
+        .map(|contour| contour.transformed(transform))
         .collect::<Vec<_>>();
-    Ok(lower_region_image_contours(&payloads, fill_rule)?
+    Ok(lower_region_image_contours(&payloads, fill_rule, accuracy)?
         .into_iter()
         .map(|contour| WriterObject {
             kind: ObjectKind::Region {
@@ -1055,12 +1086,27 @@ fn lower_contours_as_regions(
         .collect())
 }
 
+fn prepare_on_grid(
+    payloads: &[ContourBuf],
+    fill_rule: FillRule,
+    accuracy: GeometryAccuracy,
+) -> Result<Vec<region::Shape>> {
+    let region =
+        region::ContourSet::from_contours(payloads, fill_rule, Resolution::new(0.0, accuracy))?;
+    accuracy.check(region.uncertainty_mm + GERBER_GEOMETRY_GRID_MM / std::f64::consts::SQRT_2)?;
+    Ok(region::simplify_shapes_on_grid(
+        region.rings,
+        fill_rule,
+        GERBER_GEOMETRY_GRID_MM,
+    ))
+}
+
 fn lower_region_image_contours(
     payloads: &[ContourBuf],
     fill_rule: FillRule,
+    accuracy: GeometryAccuracy,
 ) -> Result<Vec<Contour>> {
-    let rings = region::rings_from_contours(payloads);
-    region::simplify_shapes_on_grid(rings, fill_rule, GERBER_GEOMETRY_GRID_MM)
+    prepare_on_grid(payloads, fill_rule, accuracy)?
         .into_iter()
         .filter_map(region_shape_contour)
         .collect::<Result<Vec<_>>>()
@@ -1073,8 +1119,8 @@ fn lower_region_contour(contour: &ContourBuf) -> Result<Contour> {
         ));
     }
     Ok(Contour {
-        segments: contour_segments(&contour.cmds)
-            .into_iter()
+        segments: contour
+            .segments()
             .map(|segment| match segment {
                 Segment::Line { start, end } => ContourSegment::Line {
                     start: lower_point(start),
@@ -1089,7 +1135,9 @@ fn lower_region_contour(contour: &ContourBuf) -> Result<Contour> {
                     )),
                     clockwise: arc.clockwise,
                 },
-                Segment::Cubic { .. } => unreachable!("contour_segments flattens cubics"),
+                Segment::Cubic { .. } | Segment::Ellipse(_) => {
+                    unreachable!("region rings are polygonal")
+                }
             })
             .collect(),
     })
@@ -1108,30 +1156,13 @@ fn region_shape_contour(shape: Vec<Ring>) -> Option<Result<Contour>> {
     Some(lower_region_contour(&payload))
 }
 
-const CUBIC_FLATTEN_STEPS: usize = 16;
-
-/// Decode a command stream into resolved line/arc segments, flattening cubic
-/// curves into line runs.
-fn contour_segments(cmds: &[PathCmd]) -> Vec<Segment> {
-    let mut segments = Vec::new();
-    for segment in geom_path::segments(cmds) {
-        match segment {
-            Segment::Cubic { start, .. } => {
-                let mut points = Vec::with_capacity(CUBIC_FLATTEN_STEPS);
-                segment.sample_points(CUBIC_FLATTEN_STEPS, &mut points);
-                let mut current = start;
-                for end in points {
-                    segments.push(Segment::Line {
-                        start: current,
-                        end,
-                    });
-                    current = end;
-                }
-            }
-            segment => segments.push(segment),
-        }
-    }
-    segments
+/// Decode a contour into the line and circular-arc segments Gerber can draw,
+/// flattening cubic and elliptical curves within the accuracy budget.
+fn contour_segments(
+    contour: &ContourBuf,
+    accuracy: GeometryAccuracy,
+) -> std::result::Result<Vec<Segment>, AccuracyError> {
+    Ok(contour.flattened_curves(accuracy)?.segments().collect())
 }
 
 fn lower_object_attributes(attributes: &ObjectAttributes) -> Vec<AttributeValue> {
@@ -1193,6 +1224,7 @@ fn quantize_hole(hole_diameter: Option<f64>) -> i64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pcb_ir::geom::path::PathCmd;
 
     /// Independent syntax oracle: the MakerPnP `gerber_parser` crate must
     /// accept everything our writer emits.
@@ -1207,6 +1239,19 @@ mod tests {
     };
     use pcb_ir::dialects::{LayerRole, Side};
     use pcb_ir::geom::{BBox, Mirror, Paint, Span};
+
+    #[test]
+    fn grid_preparation_rejects_subgrid_budgets() {
+        let contour = rect_payload(0.0001, 0.0001, 0.0002, 0.0002);
+        assert!(
+            prepare_on_grid(
+                &[contour],
+                FillRule::NonZero,
+                GeometryAccuracy::new(0.0001).unwrap()
+            )
+            .is_err()
+        );
+    }
 
     #[test]
     fn sanitizes_net_names_for_gerber_attribute_fields() {
@@ -1253,6 +1298,8 @@ mod tests {
 
     #[test]
     fn lowering_bakes_off_origin_aperture_rotation() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let aperture = artwork.push_aperture(Aperture::solid(ApertureShape::Contour {
             outline: ContourBuf::new(vec![
@@ -1294,7 +1341,7 @@ mod tests {
         );
         pcb_ir::dialects::artwork::normalize_bounds(&mut artwork);
 
-        let gerber = crate::write_layer(&lower_artwork_layer(&artwork).unwrap()).unwrap();
+        let gerber = crate::write_layer(&lower_artwork_layer(&artwork, accuracy).unwrap()).unwrap();
 
         assert!(!gerber.contains("%LR"));
         assert!(!gerber.contains("%LM"));
@@ -1305,6 +1352,8 @@ mod tests {
 
     #[test]
     fn repeated_translated_regions_remain_expanded() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -1333,7 +1382,7 @@ mod tests {
             );
         }
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower repeated regions");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower repeated regions");
         assert!(
             gerber
                 .objects
@@ -1346,13 +1395,17 @@ mod tests {
         assert!(!contents.contains("%AM"));
         assert_external_parser_accepts(&contents);
         let parsed = crate::GerberX2::parse(&contents).expect("parse repeated regions");
-        let geometry = crate::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
+        let summary =
+            pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default())
+                .unwrap();
         assert!((summary.area_mm2 - 200.0).abs() < 0.001);
     }
 
     #[test]
     fn overlapping_clear_regions_remain_independent() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -1397,15 +1450,18 @@ mod tests {
             );
         }
 
-        let expected_mask = pcb_ir::dialects::artwork::compose_to_mask(&artwork);
+        let expected_mask =
+            pcb_ir::dialects::artwork::compose_to_mask(&artwork, Resolution::default()).unwrap();
         let expected_layer = &expected_mask.layers[0];
         let expected_area = pcb_ir::geom::ContourSet::from_painted_paths(
             &expected_mask.arena,
             expected_mask.shapes(expected_layer),
-            pcb_ir::geom::tol::REGION_MM,
+            Resolution::new(pcb_ir::geom::tol::REGION_MM, accuracy),
         )
+        .unwrap()
         .area();
-        let gerber = lower_artwork_layer(&artwork).expect("lower overlapping clear regions");
+        let gerber =
+            lower_artwork_layer(&artwork, accuracy).expect("lower overlapping clear regions");
         let clear_regions = gerber
             .objects
             .iter()
@@ -1419,13 +1475,17 @@ mod tests {
         let contents = crate::write_layer(&gerber).expect("write overlapping clear regions");
         assert_external_parser_accepts(&contents);
         let parsed = crate::GerberX2::parse(&contents).expect("parse overlapping clear regions");
-        let geometry = crate::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
+        let summary =
+            pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default())
+                .unwrap();
         assert!((summary.area_mm2 - expected_area).abs() < 0.001);
     }
 
     #[test]
     fn nested_clear_regions_expand_without_aperture_blocks() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -1484,7 +1544,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower repeated clear arcs");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower repeated clear arcs");
         assert!(gerber.objects.iter().all(|object| {
             matches!(
                 &object.kind,
@@ -1499,17 +1559,24 @@ mod tests {
         assert!(!contents.contains("%ABD"));
         assert_external_parser_accepts(&contents);
         let parsed = crate::GerberX2::parse(&contents).expect("parse repeated clear arcs");
-        let geometry = crate::geometry::extract_document(&parsed);
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
         fn image<M>(mask: &pcb_ir::dialects::mask::Document<M>) -> pcb_ir::geom::ContourSet {
+            let accuracy = GeometryAccuracy::default();
+
             let layer = &mask.layers[0];
             pcb_ir::geom::ContourSet::from_painted_paths(
                 &mask.arena,
                 mask.shapes(layer),
-                pcb_ir::geom::tol::REGION_MM,
+                Resolution::new(pcb_ir::geom::tol::REGION_MM, accuracy),
             )
+            .unwrap()
         }
-        let expected = image(&pcb_ir::dialects::artwork::compose_to_mask(&artwork));
-        let actual = image(&pcb_ir::dialects::artwork::compose_to_mask(&geometry));
+        let expected = image(
+            &pcb_ir::dialects::artwork::compose_to_mask(&artwork, Resolution::default()).unwrap(),
+        );
+        let actual = image(
+            &pcb_ir::dialects::artwork::compose_to_mask(&geometry, Resolution::default()).unwrap(),
+        );
         let symmetric_difference =
             expected.difference(&actual).area() + actual.difference(&expected).area();
         assert!(symmetric_difference < 0.01, "{symmetric_difference}");
@@ -1517,6 +1584,8 @@ mod tests {
 
     #[test]
     fn single_flash_instances_expand_without_losing_placement_or_polarity() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let aperture = artwork.push_aperture(Aperture::circle(1.0));
         let block = artwork.push_block();
@@ -1558,7 +1627,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower aliased placement");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower aliased placement");
         assert!(
             !gerber
                 .apertures
@@ -1580,6 +1649,8 @@ mod tests {
 
     #[test]
     fn empty_blocks_do_not_reach_gerber() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let empty = artwork.push_block();
         let layer = artwork.push_layer(IrArtworkDocument {
@@ -1604,7 +1675,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower empty block");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower empty block");
         assert!(gerber.objects.is_empty());
         assert!(
             !gerber
@@ -1619,6 +1690,8 @@ mod tests {
 
     #[test]
     fn lowers_compound_region_holes_as_local_cut_ins() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {
             name: "F.SilkS".to_string(),
@@ -1648,7 +1721,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower artwork");
 
         assert_eq!(gerber.objects.len(), 1);
         assert_eq!(gerber.objects[0].polarity, Polarity::Dark);
@@ -1665,6 +1738,8 @@ mod tests {
 
     #[test]
     fn deep_nested_even_odd_compound_regions_preserve_topology() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -1696,7 +1771,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower artwork");
 
         assert_eq!(gerber.objects.len(), 2);
         assert!(
@@ -1709,8 +1784,10 @@ mod tests {
         let contents = crate::write_layer(&gerber).expect("write Gerber");
         assert_external_parser_accepts(&contents);
         let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
-        let geometry = crate::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
+        let summary =
+            pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default())
+                .unwrap();
         assert!(
             (summary.area_mm2 - 56.0).abs() < 0.001,
             "deep even-odd topology exported wrong area: {}",
@@ -1720,6 +1797,8 @@ mod tests {
 
     #[test]
     fn non_pad_copper_contours_lower_to_regions() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -1783,7 +1862,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower artwork");
         let contents = crate::write_layer(&gerber).expect("write Gerber");
         assert_external_parser_accepts(&contents);
         assert_eq!(contents.matches("%ABD").count(), 0);
@@ -1791,8 +1870,10 @@ mod tests {
         assert_eq!(contents.matches("G36*").count(), 1);
         assert!(contents.contains("%TA.AperFunction,Conductor*%"));
         let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
-        let geometry = crate::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
+        let summary =
+            pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default())
+                .unwrap();
         assert!(
             (summary.area_mm2 - 64.0).abs() < 0.01,
             "the hole ring must survive inside the aperture macro: {}",
@@ -1802,6 +1883,8 @@ mod tests {
 
     #[test]
     fn full_copper_balance_cells_remain_shared_flashes() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -1834,7 +1917,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower balance cell");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower balance cell");
         // The exact rounded hex flattens once into a concrete one-primitive
         // outline macro; legacy CAM importers never evaluate compound
         // parameterized macros per flash.
@@ -1848,8 +1931,11 @@ mod tests {
         let contents = crate::write_layer(&gerber).expect("write balance cell");
         assert_external_parser_accepts(&contents);
         let parsed = crate::GerberX2::parse(&contents).expect("parse balance cell");
-        let geometry = crate::geometry::extract_document(&parsed);
-        let actual_area = pcb_ir::dialects::artwork::compare::summarize(&geometry).area_mm2;
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
+        let actual_area =
+            pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default())
+                .unwrap()
+                .area_mm2;
         let expected_area = 3.0 * 3.0_f64.sqrt() / 2.0
             - (2.0 * 3.0_f64.sqrt() - std::f64::consts::PI) * 0.15_f64.powi(2);
         assert!(
@@ -1860,6 +1946,8 @@ mod tests {
 
     #[test]
     fn zero_count_grids_emit_nothing() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -1898,12 +1986,14 @@ mod tests {
             ),
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower empty grid");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower empty grid");
         assert!(gerber.objects.is_empty());
     }
 
     #[test]
     fn contour_apertures_honor_even_odd_fill() {
+        let accuracy = GeometryAccuracy::default();
+
         // Two same-winding nested loops: NonZero fills solid, EvenOdd carves
         // the inner loop out. The aperture's fill rule must decide.
         let mut artwork = ArtworkDocument::new();
@@ -1946,12 +2036,14 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower artwork");
         let contents = crate::write_layer(&gerber).expect("write Gerber");
         assert_external_parser_accepts(&contents);
         let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
-        let geometry = crate::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
+        let summary =
+            pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default())
+                .unwrap();
         assert!(
             (summary.area_mm2 - 64.0).abs() < 0.01,
             "even-odd fill must carve the nested loop out: {}",
@@ -1961,6 +2053,8 @@ mod tests {
 
     #[test]
     fn contour_apertures_normalize_material_winding() {
+        let accuracy = GeometryAccuracy::default();
+
         // A clockwise-wound solitary loop is still material under NonZero;
         // winding normalization must not turn it into an exposure-off ring.
         let mut artwork = ArtworkDocument::new();
@@ -2013,12 +2107,14 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower artwork");
         let contents = crate::write_layer(&gerber).expect("write Gerber");
         assert_external_parser_accepts(&contents);
         let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
-        let geometry = crate::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
+        let summary =
+            pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default())
+                .unwrap();
         assert!(
             (summary.area_mm2 - 100.0).abs() < 0.01,
             "a clockwise material loop must keep its full area: {}",
@@ -2028,6 +2124,8 @@ mod tests {
 
     #[test]
     fn contour_apertures_survive_mirrored_bases() {
+        let accuracy = GeometryAccuracy::default();
+
         // A mirrored basis reverses ring winding when it is baked into the
         // aperture outline; normalization happens after baking, so the
         // material must survive with its full area.
@@ -2088,12 +2186,14 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower artwork");
         let contents = crate::write_layer(&gerber).expect("write Gerber");
         assert_external_parser_accepts(&contents);
         let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
-        let geometry = crate::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
+        let summary =
+            pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default())
+                .unwrap();
         assert!(
             (summary.area_mm2 - 100.0).abs() < 0.01,
             "a mirrored basis must not invert the loop into a hole: {}",
@@ -2103,6 +2203,8 @@ mod tests {
 
     #[test]
     fn lowers_single_self_cut_even_odd_region_before_emitting_gerber() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -2129,7 +2231,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower artwork");
 
         assert_eq!(gerber.objects[0].polarity, Polarity::Dark);
         assert!(
@@ -2143,6 +2245,8 @@ mod tests {
 
     #[test]
     fn local_compound_region_holes_do_not_clear_prior_base_copper() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -2192,7 +2296,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower artwork");
 
         assert!(
             gerber
@@ -2204,8 +2308,10 @@ mod tests {
         let contents = crate::write_layer(&gerber).expect("write Gerber");
         assert_external_parser_accepts(&contents);
         let parsed = crate::GerberX2::parse(&contents).expect("parse Gerber");
-        let geometry = crate::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = crate::geometry::extract_document(&parsed, accuracy).unwrap();
+        let summary =
+            pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default())
+                .unwrap();
         assert!(
             (summary.area_mm2 - 100.0).abs() < 0.001,
             "donut hole cleared prior base copper; area was {}",
@@ -2215,6 +2321,8 @@ mod tests {
 
     #[test]
     fn places_compound_regions_before_overlay_objects() {
+        let accuracy = GeometryAccuracy::default();
+
         let mut artwork = ArtworkDocument::new();
         let layer_id = artwork.push_layer(IrArtworkDocument {
             name: "F.Cu".to_string(),
@@ -2270,7 +2378,7 @@ mod tests {
             },
         );
 
-        let gerber = lower_artwork_layer(&artwork).expect("lower artwork");
+        let gerber = lower_artwork_layer(&artwork, accuracy).expect("lower artwork");
 
         let pour_index = gerber
             .objects

--- a/crates/gerberx2/src/geometry/extract.rs
+++ b/crates/gerberx2/src/geometry/extract.rs
@@ -446,7 +446,7 @@ fn push_flattened_paths(
             )?,
         );
     }
-    let contours = composer.finish().to_contours();
+    let contours = composer.finish()?.to_contours();
     if contours.is_empty() {
         return Ok(());
     }
@@ -543,7 +543,7 @@ fn swept_aperture(
             region::ContourSet::from_contours(&path.contours, FillRule::NonZero, resolution)?,
         );
     }
-    let aperture = composer.finish();
+    let aperture = composer.finish()?;
     let edge_count: usize = aperture.rings.iter().map(Vec::len).sum();
     if points.len().saturating_mul(edge_count) > 1_000_000 {
         return Err(AccuracyError::SubdivisionLimit);

--- a/crates/gerberx2/src/geometry/extract.rs
+++ b/crates/gerberx2/src/geometry/extract.rs
@@ -4,16 +4,15 @@
 //! round trips keep both pad identity and reusable hierarchy. Macro flashes
 //! and shaped draws are flattened only where pcb-ir has no native equivalent.
 
+use pcb_ir::geom::{AccuracyError, GeometryAccuracy, Resolution};
 use std::collections::HashMap;
 
 use crate::GerberX2;
 use crate::types as gerber;
 use pcb_ir::dialects::artwork::{self, Aperture, ApertureShape, Document, Geometry, Layer, Object};
-use pcb_ir::geom::path::{ContourBuf, PathCmd, transform_cmds};
+use pcb_ir::geom::path::{ContourBuf, PathCmd};
 use pcb_ir::geom::region::{self, PaintComposer};
 use pcb_ir::geom::{Affine2, Arc, BBox, FillRule, Paint, Point, Polarity, Span, StrokeStyle};
-
-const SWEEP_SAMPLE_MM: f64 = 0.025;
 
 pub type GerberArtworkDocument = Document<Vec<String>, GerberObjectMeta>;
 
@@ -49,7 +48,10 @@ pub struct GerberObjectMeta {
     pub scaling: f64,
 }
 
-pub fn extract_document(gerber: &GerberX2) -> GerberArtworkDocument {
+pub fn extract_document(
+    gerber: &GerberX2,
+    accuracy: GeometryAccuracy,
+) -> std::result::Result<GerberArtworkDocument, AccuracyError> {
     let file_function = file_function(gerber);
     let mut doc = Document::new();
     let layer = doc.push_layer(Layer {
@@ -77,7 +79,8 @@ pub fn extract_document(gerber: &GerberX2) -> GerberArtworkDocument {
             objects,
             &apertures,
             &blocks,
-        );
+            accuracy,
+        )?;
         blocks.insert(definition.code, block);
     }
     extract_objects(
@@ -86,10 +89,11 @@ pub fn extract_document(gerber: &GerberX2) -> GerberArtworkDocument {
         gerber.objects(),
         &apertures,
         &blocks,
-    );
+        accuracy,
+    )?;
 
     artwork::normalize_bounds(&mut doc);
-    doc
+    Ok(doc)
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -113,10 +117,20 @@ fn extract_objects(
     objects: &[gerber::GraphicalObject],
     apertures: &HashMap<i32, &gerber::ApertureDefinition>,
     blocks: &HashMap<i32, u32>,
-) {
+    accuracy: GeometryAccuracy,
+) -> std::result::Result<(), AccuracyError> {
     for (object_index, object) in objects.iter().enumerate() {
-        extract_object(doc, target, object_index, object, apertures, blocks);
+        extract_object(
+            doc,
+            target,
+            object_index,
+            object,
+            apertures,
+            blocks,
+            accuracy,
+        )?;
     }
+    Ok(())
 }
 
 fn extract_object(
@@ -126,12 +140,13 @@ fn extract_object(
     object: &gerber::GraphicalObject,
     apertures: &HashMap<i32, &gerber::ApertureDefinition>,
     blocks: &HashMap<i32, u32>,
-) {
+    accuracy: GeometryAccuracy,
+) -> std::result::Result<(), AccuracyError> {
     match &object.kind {
         gerber::ObjectKind::Flash { at, aperture } => {
             let Some(definition) = apertures.get(aperture) else {
                 doc.warn(format!("flash references undefined aperture D{aperture}"));
-                return;
+                return Ok(());
             };
             let transform = object_transform(object, point(*at));
             let mut meta = meta_from_object(object, object_index, SourceKind::Flash);
@@ -164,7 +179,13 @@ fn extract_object(
                     },
                 );
             } else if let Some(geometry) = &definition.geometry {
-                push_flattened_paths(doc, target, meta, aperture_paths(geometry, transform));
+                push_flattened_paths(
+                    doc,
+                    target,
+                    meta,
+                    aperture_paths(geometry, transform),
+                    accuracy,
+                )?;
             } else {
                 doc.warn(format!(
                     "flash aperture D{aperture} has no lowered geometry"
@@ -188,14 +209,22 @@ fn extract_object(
                         point(*end),
                         width * object.scaling.abs(),
                     )],
-                );
+                    accuracy,
+                )?;
             } else if let Some(geometry) = aperture_geometry(apertures, *aperture) {
                 push_flattened_paths(
                     doc,
                     target,
                     meta,
-                    sampled_line_sweep(point(*start), point(*end), object, geometry),
-                );
+                    swept_aperture(
+                        &[point(*start), point(*end)],
+                        0.0,
+                        object,
+                        geometry,
+                        accuracy,
+                    )?,
+                    accuracy,
+                )?;
             } else {
                 doc.warn(format!("D{aperture} draw aperture has no lowered geometry"));
             }
@@ -223,23 +252,34 @@ fn extract_object(
                         *clockwise,
                         width * object.scaling.abs(),
                     )],
-                );
+                    accuracy,
+                )?;
             } else if let Some(geometry) = aperture_geometry(apertures, *aperture) {
                 push_flattened_paths(
                     doc,
                     target,
                     meta,
-                    sampled_arc_sweep(start, point(*end), center, *clockwise, object, geometry),
-                );
+                    arc_sweep(
+                        start,
+                        point(*end),
+                        center,
+                        *clockwise,
+                        object,
+                        geometry,
+                        accuracy,
+                    )?,
+                    accuracy,
+                )?;
             } else {
                 doc.warn(format!("D{aperture} arc aperture has no lowered geometry"));
             }
         }
         gerber::ObjectKind::Region { contours } => {
             let meta = meta_from_object(object, object_index, SourceKind::Region);
-            push_flattened_paths(doc, target, meta, region_paths(contours));
+            push_flattened_paths(doc, target, meta, region_paths(contours), accuracy)?;
         }
-    }
+    };
+    Ok(())
 }
 
 /// Convert a standard aperture template into an artwork aperture. Macro and
@@ -367,9 +407,10 @@ fn push_flattened_paths(
     target: ArtworkTarget,
     meta: GerberObjectMeta,
     paths: Vec<ExtractedPath>,
-) {
+    accuracy: GeometryAccuracy,
+) -> std::result::Result<(), AccuracyError> {
     if paths.is_empty() {
-        return;
+        return Ok(());
     }
 
     if paths.len() == 1 && paths[0].polarity == Polarity::Dark {
@@ -390,23 +431,24 @@ fn push_flattened_paths(
                 meta,
             },
         );
-        return;
+        return Ok(());
     }
 
-    let mut composer = PaintComposer::default();
+    let resolution = Resolution::new(0.0, accuracy);
+    let mut composer = PaintComposer::new(resolution);
     for extracted in paths {
-        let rings = region::simplify_rings(
-            region::rings_from_contours(&extracted.contours),
-            extracted.paint.fill_rule().unwrap_or(FillRule::NonZero),
+        composer.push(
+            extracted.polarity,
+            region::ContourSet::from_contours(
+                &extracted.contours,
+                extracted.paint.fill_rule().unwrap_or(FillRule::NonZero),
+                resolution,
+            )?,
         );
-        if rings.is_empty() {
-            continue;
-        }
-        composer.push(extracted.polarity, rings);
     }
-    let contours = region::rings_to_contours(composer.finish());
+    let contours = composer.finish().to_contours();
     if contours.is_empty() {
-        return;
+        return Ok(());
     }
 
     let path = doc.push_path(
@@ -425,6 +467,8 @@ fn push_flattened_paths(
             meta,
         },
     );
+
+    Ok(())
 }
 
 fn aperture_paths(geometry: &gerber::ApertureGeometry, transform: Affine2) -> Vec<ExtractedPath> {
@@ -459,7 +503,7 @@ fn transform_contour(commands: &[gerber::PathCommand], transform: Affine2) -> Co
             gerber::PathCommand::Close => PathCmd::close(),
         })
         .collect::<Vec<_>>();
-    transform_cmds(cmds, transform)
+    ContourBuf::new(cmds).transformed(transform)
 }
 
 fn line_path(start: Point, end: Point, width: f64) -> ExtractedPath {
@@ -484,44 +528,93 @@ fn arc_path(start: Point, end: Point, center: Point, clockwise: bool, width: f64
     }
 }
 
-fn sampled_line_sweep(
-    start: Point,
-    end: Point,
+fn swept_aperture(
+    points: &[Point],
+    path_error: f64,
     object: &gerber::GraphicalObject,
     geometry: &gerber::ApertureGeometry,
-) -> Vec<ExtractedPath> {
-    let length = start.distance_to(end);
-    let steps = sample_steps(length);
-    (0..=steps)
-        .flat_map(|index| {
-            let t = index as f64 / steps.max(1) as f64;
-            let at = start + (end - start) * t;
-            aperture_paths(geometry, object_transform(object, at))
-        })
-        .collect()
+    accuracy: GeometryAccuracy,
+) -> std::result::Result<Vec<ExtractedPath>, AccuracyError> {
+    let resolution = Resolution::new(0.0, accuracy);
+    let mut composer = PaintComposer::new(resolution);
+    for path in aperture_paths(geometry, object_transform(object, Point::ZERO)) {
+        composer.push(
+            path.polarity,
+            region::ContourSet::from_contours(&path.contours, FillRule::NonZero, resolution)?,
+        );
+    }
+    let aperture = composer.finish();
+    let edge_count: usize = aperture.rings.iter().map(Vec::len).sum();
+    if points.len().saturating_mul(edge_count) > 1_000_000 {
+        return Err(AccuracyError::SubdivisionLimit);
+    }
+    let mut rings = Vec::new();
+    for at in points {
+        rings.extend(
+            aperture
+                .rings
+                .iter()
+                .map(|ring| ring.iter().map(|[x, y]| [x + at.x, y + at.y]).collect()),
+        );
+    }
+    // Sweep each boundary edge continuously, including the boundaries of holes.
+    for pair in points.windows(2) {
+        for ring in &aperture.rings {
+            for (a, b) in ring
+                .iter()
+                .zip(ring.iter().cycle().skip(1))
+                .take(ring.len())
+            {
+                let mut quad = vec![
+                    [a[0] + pair[0].x, a[1] + pair[0].y],
+                    [b[0] + pair[0].x, b[1] + pair[0].y],
+                    [b[0] + pair[1].x, b[1] + pair[1].y],
+                    [a[0] + pair[1].x, a[1] + pair[1].y],
+                ];
+                if region::ring_signed_area(&quad) < 0.0 {
+                    quad.reverse();
+                }
+                rings.push(quad);
+            }
+        }
+    }
+    let mut swept = region::ContourSet::from_rings(rings, FillRule::NonZero, resolution);
+    swept.uncertainty_mm += aperture.uncertainty_mm + path_error;
+    accuracy.check(swept.uncertainty_mm)?;
+    Ok(vec![ExtractedPath {
+        polarity: Polarity::Dark,
+        paint: Paint::Fill {
+            rule: FillRule::NonZero,
+        },
+        contours: swept.to_contours(),
+    }])
 }
 
-fn sampled_arc_sweep(
+fn arc_sweep(
     start: Point,
     end: Point,
     center: Point,
     clockwise: bool,
     object: &gerber::GraphicalObject,
     geometry: &gerber::ApertureGeometry,
-) -> Vec<ExtractedPath> {
+    accuracy: GeometryAccuracy,
+) -> std::result::Result<Vec<ExtractedPath>, AccuracyError> {
     let arc = Arc::new(start, end, center, clockwise);
     let radius = arc.radius();
     let sweep = arc.sweep_radians();
-    let steps = sample_steps(radius * sweep);
+    let path_error = accuracy.max_error_mm() / 4.0;
+    let angle = 4.0 * (path_error / (2.0 * radius)).min(1.0).sqrt().asin();
+    let steps = (sweep / angle).ceil().max(1.0);
+    if !steps.is_finite() || steps > 1_000_000.0 {
+        return Err(AccuracyError::SubdivisionLimit);
+    }
+    let steps = steps as usize;
     let signed_sweep = if clockwise { -sweep } else { sweep };
     let start_angle = start.angle_from(center);
-    (0..=steps)
-        .flat_map(|index| {
-            let t = index as f64 / steps.max(1) as f64;
-            let at = arc.point_at(start_angle + signed_sweep * t);
-            aperture_paths(geometry, object_transform(object, at))
-        })
-        .collect()
+    let points = (0..=steps)
+        .map(|index| arc.point_at(start_angle + signed_sweep * index as f64 / steps as f64))
+        .collect::<Vec<_>>();
+    swept_aperture(&points, path_error, object, geometry, accuracy)
 }
 
 fn object_transform(object: &gerber::GraphicalObject, at: Point) -> Affine2 {
@@ -531,10 +624,6 @@ fn object_transform(object: &gerber::GraphicalObject, at: Point) -> Affine2 {
         object.mirroring.into(),
         object.scaling,
     )
-}
-
-fn sample_steps(length: f64) -> usize {
-    (length / SWEEP_SAMPLE_MM).ceil().max(1.0) as usize
 }
 
 fn region_paths(contours: &[gerber::Contour]) -> Vec<ExtractedPath> {

--- a/crates/gerberx2/src/geometry/extract.rs
+++ b/crates/gerberx2/src/geometry/extract.rs
@@ -578,7 +578,7 @@ fn swept_aperture(
             }
         }
     }
-    let mut swept = region::ContourSet::from_rings(rings, FillRule::NonZero, resolution);
+    let mut swept = region::ContourSet::from_rings(rings, FillRule::NonZero, resolution)?;
     swept.uncertainty_mm += aperture.uncertainty_mm + path_error;
     accuracy.check(swept.uncertainty_mm)?;
     Ok(vec![ExtractedPath {

--- a/crates/gerberx2/src/lib.rs
+++ b/crates/gerberx2/src/lib.rs
@@ -5,6 +5,7 @@ pub mod types;
 pub mod write;
 
 pub use pcb_intern::{Interner, Symbol};
+use pcb_ir::geom::AccuracyError;
 pub use types::*;
 pub use write::{
     AttributeValue, GerberLayer, WriterAperture, WriterApertureMacro, WriterApertureTemplate,
@@ -19,6 +20,8 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum GerberError {
+    #[error(transparent)]
+    Accuracy(#[from] AccuracyError),
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/crates/gerberx2/tests/basic.rs
+++ b/crates/gerberx2/tests/basic.rs
@@ -5,6 +5,7 @@ use gerberx2::{
     WriterObject,
 };
 use pcb_ir::geom::Polarity;
+use pcb_ir::geom::{GeometryAccuracy, Resolution};
 
 #[test]
 fn parses_basic_x2_layer() {
@@ -335,6 +336,8 @@ fn writes_modal_coordinates_with_explicit_operations() {
 
 #[test]
 fn writes_macro_and_block_apertures_without_flattening() {
+    let accuracy = GeometryAccuracy::default();
+
     let layer = GerberLayer {
         aperture_macros: vec![WriterApertureMacro {
             name: "ROUNDRECT".to_string(),
@@ -439,7 +442,7 @@ fn writes_macro_and_block_apertures_without_flattening() {
     ));
     assert_eq!(parsed.objects()[1].polarity, Polarity::Dark);
     assert_eq!(parsed.objects()[2].polarity, Polarity::Dark);
-    let artwork = gerberx2::geometry::extract_document(&parsed);
+    let artwork = gerberx2::geometry::extract_document(&parsed, accuracy).unwrap();
     assert_eq!(artwork.blocks.len(), 1);
     assert!(matches!(
         artwork.objects[1].geometry,
@@ -503,6 +506,8 @@ fn lowers_standard_apertures_to_geometry_paths() {
 
 #[test]
 fn normalizes_inch_coordinates_and_standard_apertures_to_mm() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber =
         GerberX2::parse("%FSLAX26Y26*%\n%MOIN*%\n%ADD10C,0.1X0.02*%\nD10*\nX1000000Y0D03*\nM02*\n")
             .unwrap();
@@ -519,7 +524,7 @@ fn normalizes_inch_coordinates_and_standard_apertures_to_mm() {
         ObjectKind::Flash { at, .. } if close(at.x, 25.4) && close(at.y, 0.0)
     ));
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
     let object = &geometry.objects[0];
     assert!(close(object.bbox.min.x, 25.4 - 1.27));
     assert!(close(object.bbox.max.x, 25.4 + 1.27));
@@ -559,6 +564,8 @@ fn normalizes_inch_macro_aperture_geometry_to_mm() {
 
 #[test]
 fn preserves_block_apertures_when_flashed() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10C,0.1*%\n%ABD20*%\nD10*\n%LPC*%\nX1000000Y0D03*\n%AB*%\nD20*\n%LPC*%\nX2000000Y3000000D03*\nM02*\n",
     )
@@ -579,7 +586,7 @@ fn preserves_block_apertures_when_flashed() {
     ));
     assert_eq!(gerber.objects()[0].polarity, Polarity::Clear);
 
-    let artwork = gerberx2::geometry::extract_document(&gerber);
+    let artwork = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
     assert_eq!(artwork.blocks.len(), 1);
     assert_eq!(artwork.blocks[0].objects.len(), 1);
     assert!(matches!(
@@ -592,6 +599,8 @@ fn preserves_block_apertures_when_flashed() {
 
 #[test]
 fn preserves_block_apertures_with_flash_transform() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10C,0.1*%\n%ABD20*%\nD10*\nX1000000Y0D03*\n%AB*%\n%LR90*%\n%LS2*%\nD20*\nX2000000Y3000000D03*\nM02*\n",
     )
@@ -608,7 +617,7 @@ fn preserves_block_apertures_with_flash_transform() {
     ));
     assert!(close(object.rotation_degrees, 90.0));
     assert!(close(object.scaling, 2.0));
-    let artwork = gerberx2::geometry::extract_document(&gerber);
+    let artwork = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
     assert!(matches!(
         artwork.objects[0].geometry,
         pcb_ir::dialects::artwork::Geometry::Instance { block: 0, transform }
@@ -646,12 +655,14 @@ fn rejects_unclosed_region_contours() {
 
 #[test]
 fn extracts_render_artwork() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%TF.FileFunction,Copper,L1,Top*%\n%ADD10C,0.2*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nX1000000Y1000000D03*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
     assert_eq!(geometry.layers[0].meta, vec!["Copper", "L1", "Top"]);
     assert_eq!(geometry.objects.len(), 2);
     assert!(geometry.arena.paths.iter().any(|path| path.is_stroked()));
@@ -660,13 +671,16 @@ fn extracts_render_artwork() {
 
 #[test]
 fn artwork_composition_applies_clear_polarity_cutouts() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10R,2.0X2.0*%\n%ADD11C,1.0*%\nD10*\nX0Y0D03*\n%LPC*%\nD11*\nX0Y0D03*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
-    let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
+    let summary =
+        pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default()).unwrap();
     let expected_area = 4.0 - std::f64::consts::PI * 0.25;
     assert!(
         (summary.area_mm2 - expected_area).abs() < 0.02,
@@ -677,13 +691,16 @@ fn artwork_composition_applies_clear_polarity_cutouts() {
 
 #[test]
 fn region_contour_orientation_does_not_create_holes() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\nG36*\nG01*\nX0Y0D02*\nX4000000Y0D01*\nX4000000Y4000000D01*\nX0Y4000000D01*\nX0Y0D01*\nX1000000Y1000000D02*\nX1000000Y3000000D01*\nX3000000Y3000000D01*\nX3000000Y1000000D01*\nX1000000Y1000000D01*\nG37*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
-    let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
+    let summary =
+        pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default()).unwrap();
     assert!(
         close(summary.area_mm2, 16.0),
         "region contours are filled independently; area was {}",
@@ -693,13 +710,16 @@ fn region_contour_orientation_does_not_create_holes() {
 
 #[test]
 fn artwork_composition_keeps_clear_polarity_semantics_after_overlapping_dark_runs() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10R,4.0X4.0*%\n%ADD11R,2.0X2.0*%\nD10*\nX0Y0D03*\nX0Y0D03*\n%LPC*%\nD11*\nX0Y0D03*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
-    let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
+    let summary =
+        pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default()).unwrap();
 
     assert!(
         close(summary.area_mm2, 12.0),
@@ -710,13 +730,16 @@ fn artwork_composition_keeps_clear_polarity_semantics_after_overlapping_dark_run
 
 #[test]
 fn extraction_preserves_ordered_aperture_path_polarity() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%AMORDERED*\n21,1,4,4,0,0,0*\n21,0,2,2,0,0,0*\n21,1,1,1,0,0,0*\n%\n%ADD10ORDERED*%\nD10*\nX0Y0D03*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
-    let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
+    let summary =
+        pcb_ir::dialects::artwork::compare::summarize(&geometry, Resolution::default()).unwrap();
 
     assert!(
         close(summary.area_mm2, 13.0),
@@ -727,12 +750,14 @@ fn extraction_preserves_ordered_aperture_path_polarity() {
 
 #[test]
 fn extraction_applies_scaling_to_circular_draw_width() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10C,0.2*%\n%LS2*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
     let path = geometry
         .arena
         .paths
@@ -744,17 +769,20 @@ fn extraction_applies_scaling_to_circular_draw_width() {
 
 #[test]
 fn extraction_flips_mirrored_aperture_arc_direction() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10O,2.0X1.0*%\n%LMX*%\nD10*\nX0Y0D03*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
     assert!(matches!(
         geometry.objects[0].geometry,
         pcb_ir::dialects::artwork::Geometry::Flash { .. }
     ));
-    let expanded = pcb_ir::dialects::artwork::expand_native_geometry_to_regions(geometry);
+    let expanded =
+        pcb_ir::dialects::artwork::expand_native_geometry_to_regions(geometry, accuracy).unwrap();
     let arc = expanded
         .arena
         .cmds
@@ -766,12 +794,14 @@ fn extraction_flips_mirrored_aperture_arc_direction() {
 
 #[test]
 fn extracts_non_circular_aperture_sweeps_without_diagnostics() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%ADD10R,0.2X0.4*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
     assert!(geometry.diagnostics.is_empty());
     assert_eq!(geometry.objects.len(), 1);
     assert!(geometry.arena.paths[0].is_filled());
@@ -779,13 +809,16 @@ fn extracts_non_circular_aperture_sweeps_without_diagnostics() {
 
 #[test]
 fn renders_svg_and_png_from_artwork() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%TF.FileFunction,Paste,Top*%\n%ADD10R,1.0X1.0*%\nD10*\nX0Y0D03*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
-    let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
+    let mask =
+        pcb_ir::dialects::artwork::compose_to_mask(&geometry, Resolution::default()).unwrap();
     let svg = pcb_ir::render::svg(&mask, &pcb_ir::render::RenderOptions::default());
     assert!(svg.contains("<svg"));
     assert!(svg.contains("<path"));
@@ -801,13 +834,16 @@ fn renders_svg_and_png_from_artwork() {
 
 #[test]
 fn renders_profile_gerber_as_black_board_outline() {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = GerberX2::parse(
         "%FSLAX26Y26*%\n%MOMM*%\n%TF.FileFunction,Profile,NP*%\n%ADD10C,0.1*%\nD10*\nG01*\nX0Y0D02*\nX1000000Y0D01*\nX1000000Y1000000D01*\nX0Y1000000D01*\nX0Y0D01*\nM02*\n",
     )
     .unwrap();
 
-    let geometry = gerberx2::geometry::extract_document(&gerber);
-    let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry);
+    let geometry = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
+    let mask =
+        pcb_ir::dialects::artwork::compose_to_mask(&geometry, Resolution::default()).unwrap();
     let svg = pcb_ir::render::svg(&mask, &pcb_ir::render::RenderOptions::default());
 
     assert!(svg.contains("fill='none' stroke='#000000'"));
@@ -861,4 +897,48 @@ fn assert_external_parser_accepts(content: &str) {
 
 fn close(a: f64, b: f64) -> bool {
     (a - b).abs() <= 1e-9
+}
+
+#[test]
+fn shaped_draws_sweep_continuously_with_recorded_accuracy() {
+    use pcb_ir::geom::{ContourSet, FillRule, Point};
+    for (draw, witness) in [
+        ("G01*X0Y0D02*X100000Y0D01*", Point::new(0.0125, 0.0)),
+        (
+            "G75*X100000Y0D02*G03*X0Y100000I-100000J0D01*",
+            Point::new(0.1 / 2.0_f64.sqrt(), 0.1 / 2.0_f64.sqrt()),
+        ),
+    ] {
+        let gerber = GerberX2::parse(&format!(
+            "%FSLAX26Y26*%%MOMM*%%AMthin*21,1,0.002,0.002,0,0,0*%%ADD10thin*%D10*{draw}M02*"
+        ))
+        .unwrap();
+        for budget in [0.001, 0.0001] {
+            let accuracy = GeometryAccuracy::new(budget).unwrap();
+            let doc = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
+            let path = &doc.arena.paths[0];
+            let region = ContourSet::from_contours(
+                &doc.arena.path_contours(path),
+                FillRule::NonZero,
+                Resolution::new(0.0, accuracy),
+            )
+            .unwrap();
+            assert_eq!(region.connected_components().len(), 1);
+            assert!(region.contains_point(witness));
+            assert!(region.uncertainty_mm > 0.0 && region.uncertainty_mm <= budget);
+        }
+    }
+    let gerber = GerberX2::parse(
+        "%FSLAX26Y26*%%MOMM*%%AMhole*21,1,0.1,0.1,0,0,0*21,0,0.05,0.05,0,0,0*%%ADD10hole*%D10*G01*X0Y0D02*X10000Y0D01*M02*"
+    ).unwrap();
+    let accuracy = GeometryAccuracy::default();
+    let doc = gerberx2::geometry::extract_document(&gerber, accuracy).unwrap();
+    let region = ContourSet::from_contours(
+        &doc.arena.path_contours(&doc.arena.paths[0]),
+        FillRule::NonZero,
+        Resolution::new(0.0, accuracy),
+    )
+    .unwrap();
+    assert!(!region.contains_point(Point::new(0.005, 0.0)));
+    assert!(region.contains_point(Point::new(0.005, 0.04)));
 }

--- a/crates/pcb-ipc-wasm/src/lib.rs
+++ b/crates/pcb-ipc-wasm/src/lib.rs
@@ -5,6 +5,7 @@ mod options;
 #[wasm_bindgen::prelude::wasm_bindgen(typescript_custom_section)]
 const TYPESCRIPT: &str = include_str!("api.d.ts");
 
+use pcb_ir::geom::Resolution;
 use std::cell::OnceCell;
 use std::io::{Cursor, Read};
 
@@ -69,7 +70,7 @@ impl IpcDocument {
     /// The native IPC info JSON summary.
     #[wasm_bindgen(unchecked_return_type = "IpcInfo")]
     pub fn info(&self) -> Result<JsValue, JsError> {
-        to_js(&commands::info::info_json(&self.accessor()))
+        to_js(&commands::info::info_json(&self.accessor()).map_err(js_error)?)
     }
 
     /// Source layer names accepted by SVG and PNG export.
@@ -102,6 +103,8 @@ impl IpcDocument {
         &self,
         #[wasm_bindgen(unchecked_optional_param_type = "DfmOptions")] options: Option<JsValue>,
     ) -> Result<JsValue, JsError> {
+        let resolution = Resolution::default();
+
         let options: DfmOptions = read_options(options)?;
         let generated_at = match options.generated_at {
             Some(ref value) => chrono::DateTime::parse_from_rfc3339(value)
@@ -130,6 +133,7 @@ impl IpcDocument {
                     layout_target: options.layout_target,
                     generated_at,
                 },
+                resolution,
             )
             .map_err(js_error)?,
         )
@@ -166,6 +170,8 @@ impl IpcDocument {
     }
 
     fn export_data(&self, options: ExportOptions) -> Result<Vec<ExportFile>> {
+        let resolution = Resolution::default();
+
         let file = match options {
             ExportOptions::Ipc2581 { mode } => ExportFile::new(
                 "board.xml",
@@ -176,9 +182,13 @@ impl IpcDocument {
                 },
             ),
             ExportOptions::Gerber { layout_target, zip } => {
-                let package = manufacturing::build_manufacturing_package_from_design(
+                let package = manufacturing::build_manufacturing_package(
                     self.design()?,
-                    layout_target.artwork_scope(),
+                    &manufacturing::ManufacturingExportOptions {
+                        view: layout_target.artwork_scope(),
+                        relief_debug_dir: None,
+                    },
+                    resolution,
                 )?;
                 if zip {
                     ExportFile::new("manufacturing.zip", "application/zip", package.to_zip()?)
@@ -195,11 +205,17 @@ impl IpcDocument {
                 layout_target,
             } => {
                 let scope = layout_target.artwork_scope();
-                let geometry = geometry::render::prepare_layer(self.design()?, &layer, scope)?;
+                let geometry =
+                    geometry::render::prepare_layer(self.design()?, &layer, scope, resolution)?;
                 ExportFile::new(
                     format!("{}.svg", safe_name(&layer)),
                     "image/svg+xml",
-                    geometry::render::render_layer_svg(&geometry, true, scope.profile_set()),
+                    geometry::render::render_layer_svg(
+                        &geometry,
+                        true,
+                        scope.profile_set(),
+                        resolution.accuracy,
+                    )?,
                 )
             }
             ExportOptions::Png {
@@ -207,12 +223,18 @@ impl IpcDocument {
                 layout_target,
             } => {
                 let scope = layout_target.artwork_scope();
-                let geometry = geometry::render::prepare_layer(self.design()?, &layer, scope)?;
+                let geometry =
+                    geometry::render::prepare_layer(self.design()?, &layer, scope, resolution)?;
                 ExportFile::new(
                     format!("{}.png", safe_name(&layer)),
                     "image/png",
-                    geometry::render::render_layer_png(&geometry, true, scope.profile_set())
-                        .map_err(anyhow::Error::msg)?,
+                    geometry::render::render_layer_png(
+                        &geometry,
+                        true,
+                        scope.profile_set(),
+                        resolution.accuracy,
+                    )
+                    .map_err(anyhow::Error::msg)?,
                 )
             }
             ExportOptions::Dxf { layout_target } => ExportFile::new(
@@ -226,8 +248,7 @@ impl IpcDocument {
                 serde_json::to_vec_pretty(&commands::bom::extract_bom_lines(&self.accessor()))?,
             ),
             ExportOptions::Cpl { side, exclude_dnp } => {
-                let placements =
-                    placement::extract_single_board_placements_from_design(self.design()?)?;
+                let placements = placement::extract_single_board_placements(self.design()?)?;
                 ExportFile::new(
                     "placements.csv",
                     "text/csv",
@@ -245,14 +266,14 @@ impl IpcDocument {
                 "ict.csv",
                 "text/csv",
                 commands::ict::emit_ict_csv(
-                    &commands::ict::extract_contacts_from_design(&self.ipc, self.design()?)?,
+                    &commands::ict::extract_contacts(&self.ipc, self.design()?, resolution)?,
                     side,
                 ),
             ),
             ExportOptions::Html {} => ExportFile::new(
                 "board.html",
                 "text/html",
-                commands::html_export::generate_html(&self.accessor(), UnitFormat::Mm)?,
+                commands::html_export::generate_html(&self.accessor(), UnitFormat::Mm, resolution)?,
             ),
         };
         Ok(vec![file])

--- a/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
+++ b/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
@@ -348,7 +348,7 @@ fn main() -> Result<()> {
         resolution,
     )
     .context("failed to collect board-array balancing inputs")?;
-    let balancing_input = collection.input_for_layer(selected_copper.name);
+    let balancing_input = collection.input_for_layer(selected_copper.name)?;
     let options = BalancingRegionOptions {
         clearance_mm: args.clearance_mm,
         regularization_radius_mm: args.regularization_radius_mm,
@@ -368,7 +368,7 @@ fn main() -> Result<()> {
         .into_iter()
         .zip(support_geometry)
         .map(|(source, geometry)| support_layer(source, geometry, selected_copper.name))
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>>>()?;
     let BoardArrayBalancingResult {
         safe_region,
         intermediates,
@@ -605,8 +605,8 @@ fn support_layer(
     source: ArraySupportLayerSource,
     geometry: BoardArraySupportLayerGeometry<Symbol>,
     copper_layer: Symbol,
-) -> SupportLayer {
-    SupportLayer {
+) -> Result<SupportLayer> {
+    Ok(SupportLayer {
         name: source.name,
         function: layer_function_name(source.layer_function),
         source_feature_count: geometry.source_feature_count,
@@ -615,8 +615,8 @@ fn support_layer(
         path_count: geometry.path_count,
         excluded_documentation_path_count: geometry.excluded_documentation_path_count,
         unpainted_path_count: geometry.unpainted_path_count,
-        region: geometry.region_for_layer(copper_layer),
-    }
+        region: geometry.region_for_layer(copper_layer)?,
+    })
 }
 
 fn layer_function_name(function: LayerFunction) -> String {

--- a/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
+++ b/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
@@ -3,6 +3,7 @@
 //! This is intentionally an example target rather than a user-facing
 //! `pcb ipc` command while the geometry contract is still being explored.
 
+use pcb_ir::geom::Resolution;
 use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -21,9 +22,8 @@ use pcb_ipc2581_tools::utils::file::load_ipc_file;
 use pcb_ir::dialects::ipc::{
     BalancingRegionOptions, BoardArrayBalancingResult, BoardArraySupportDocument,
     BoardArraySupportLayerGeometry, DEFAULT_BALANCING_CLEARANCE_MM,
-    DEFAULT_BALANCING_GAP_RADIUS_MM, DEFAULT_BALANCING_NUMERICAL_GUARD_MM,
-    DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM, board_array_balancing_region,
-    inspect_board_array_balancing_input, root_panel_step,
+    DEFAULT_BALANCING_GAP_RADIUS_MM, DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM,
+    board_array_balancing_region, inspect_board_array_balancing_input, root_panel_step,
 };
 use pcb_ir::geom::{BBox, ContourSet};
 use serde::Serialize;
@@ -57,10 +57,6 @@ struct Args {
     /// Rolling-disk radius for two-sided void gaps; minimum gap is twice this.
     #[arg(long, default_value_t = DEFAULT_BALANCING_GAP_RADIUS_MM)]
     gap_radius_mm: f64,
-
-    /// Extra construction clearance reserved for polygonization/offset error.
-    #[arg(long, default_value_t = DEFAULT_BALANCING_NUMERICAL_GUARD_MM)]
-    numerical_guard_mm: f64,
 
     /// Maximum tolerated area for each set-theoretic validation violation.
     #[arg(long, default_value_t = DEFAULT_CHECK_AREA_TOLERANCE_MM2)]
@@ -294,6 +290,8 @@ fn component_areas(region: &ContourSet) -> Vec<f64> {
 }
 
 fn main() -> Result<()> {
+    let resolution = Resolution::default();
+
     let args = Args::parse();
     // The radius and clearance options are validated by
     // `board_array_balancing_region` itself.
@@ -332,13 +330,14 @@ fn main() -> Result<()> {
         bail!("input is not a board array: the IPC root step is not a panel");
     }
 
-    let score_lines =
-        board_array_vscore_lines(&ipc).context("failed to extract board-array V-score lines")?;
+    let imported = pcb_ir::import::ipc2581::import_design(&ipc)?;
+    let score_lines = board_array_vscore_lines(&imported)
+        .context("failed to extract board-array V-score lines")?;
     let (fabrication_profile, relief_debug) =
-        board_array_fabrication_profile_with_debug(&ipc, &layout, &score_lines)
+        board_array_fabrication_profile_with_debug(&imported, &layout, &score_lines, resolution)
             .context("failed to compose board-array fabrication profile")?;
 
-    let support_sources = extract_array_support_layers(&ipc)?;
+    let support_sources = extract_array_support_layers(&imported)?;
     let collection = inspect_board_array_balancing_input(
         &layout,
         &fabrication_profile,
@@ -346,6 +345,7 @@ fn main() -> Result<()> {
         support_sources
             .iter()
             .map(|source| BoardArraySupportDocument::new(&source.document, source.policy)),
+        resolution,
     )
     .context("failed to collect board-array balancing inputs")?;
     let balancing_input = collection.input_for_layer(selected_copper.name);
@@ -353,11 +353,10 @@ fn main() -> Result<()> {
         clearance_mm: args.clearance_mm,
         regularization_radius_mm: args.regularization_radius_mm,
         gap_radius_mm: args.gap_radius_mm,
-        numerical_guard_mm: args.numerical_guard_mm,
     };
     let result = board_array_balancing_region(&balancing_input, options)
         .context("failed to compute board-array balancing region")?;
-    let construction_clearance_mm = options.construction_clearance_mm();
+    let construction_clearance_mm = options.clearance_mm + 2.0 * resolution.accuracy.max_error_mm();
     let certificate_passed = result.certificate.passes(args.check_area_tolerance_mm2);
     let support_features = balancing_input.support_features;
     let panel_outer = collection.panel_outer;
@@ -381,11 +380,12 @@ fn main() -> Result<()> {
         .filter(|component| {
             component
                 .disk_erode(args.regularization_radius_mm)
+                .unwrap()
                 .is_empty()
         })
         .cloned()
         .fold(
-            ContourSet::empty(safe_region.tolerance),
+            ContourSet::empty(safe_region.resolution),
             |undersized, component| undersized.union(&component),
         );
     let removed_by_regularization = intermediates
@@ -393,7 +393,8 @@ fn main() -> Result<()> {
         .union(&intermediates.removed_by_gap_regularization);
     let narrow_voids = intermediates
         .opened_candidates
-        .disk_gap_violations(args.gap_radius_mm);
+        .disk_gap_violations(args.gap_radius_mm)
+        .unwrap();
     let regions = Regions {
         panel_outer,
         board_footprints,
@@ -476,7 +477,7 @@ fn main() -> Result<()> {
         nominal_clearance_mm: args.clearance_mm,
         regularization_radius_mm: args.regularization_radius_mm,
         gap_radius_mm: args.gap_radius_mm,
-        numerical_guard_mm: args.numerical_guard_mm,
+        numerical_guard_mm: 2.0 * resolution.accuracy.max_error_mm(),
         construction_clearance_mm,
         check_area_tolerance_mm2: args.check_area_tolerance_mm2,
         panelization,

--- a/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
+++ b/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
@@ -375,22 +375,21 @@ fn main() -> Result<()> {
         certificate,
     } = result;
     let final_components = safe_region.connected_components();
-    let undersized_final_components = final_components
-        .iter()
-        .filter(|component| {
-            component
-                .disk_erode(args.regularization_radius_mm)
-                .unwrap()
-                .is_empty()
-        })
-        .cloned()
-        .fold(
-            ContourSet::empty(safe_region.resolution),
-            |undersized, component| undersized.union(&component),
-        );
+    let undersized_final_components = ContourSet::union_all(
+        safe_region.resolution,
+        final_components
+            .iter()
+            .filter(|component| {
+                component
+                    .disk_erode(args.regularization_radius_mm)
+                    .unwrap()
+                    .is_empty()
+            })
+            .cloned(),
+    )?;
     let removed_by_regularization = intermediates
         .removed_by_opening
-        .union(&intermediates.removed_by_gap_regularization);
+        .union(&intermediates.removed_by_gap_regularization)?;
     let narrow_voids = intermediates
         .opened_candidates
         .disk_gap_violations(args.gap_radius_mm)

--- a/crates/pcb-ipc2581-tools/examples/gerber_copper_svg.rs
+++ b/crates/pcb-ipc2581-tools/examples/gerber_copper_svg.rs
@@ -50,7 +50,7 @@ fn main() -> Result<()> {
         rings,
         FillRule::NonZero,
         Resolution::new(1e-4, resolution.accuracy),
-    );
+    )?;
 
     // A containing ring always has the larger unsigned area, so painting in
     // descending area order layers islands over holes over boundaries.

--- a/crates/pcb-ipc2581-tools/examples/gerber_copper_svg.rs
+++ b/crates/pcb-ipc2581-tools/examples/gerber_copper_svg.rs
@@ -9,17 +9,19 @@
 //! rasterizers accept, even for planes perforated by tens of thousands of
 //! voids.
 
+use pcb_ir::geom::Resolution;
 use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
-use pcb_ir::geom::region::rings_from_contours;
 use pcb_ir::geom::{ContourSet, FillRule};
 
 const COPPER: &str = "#d87822";
 const BACKGROUND: &str = "#ffffff";
 
 fn main() -> Result<()> {
+    let resolution = Resolution::default();
+
     let mut args = std::env::args().skip(1);
     let usage = "usage: gerber_copper_svg <input.gbr> <output.svg>";
     let input = PathBuf::from(args.next().context(usage)?);
@@ -28,15 +30,27 @@ fn main() -> Result<()> {
     let contents = std::fs::read_to_string(&input)
         .with_context(|| format!("failed to read {}", input.display()))?;
     let gerber = gerberx2::GerberX2::parse(&contents)?;
-    let doc = gerberx2::geometry::extract_document(&gerber);
-    let mask = pcb_ir::dialects::artwork::compose_to_mask(&doc);
+    let doc = gerberx2::geometry::extract_document(&gerber, resolution.accuracy).unwrap();
+    let mask = pcb_ir::dialects::artwork::compose_to_mask(&doc, resolution).unwrap();
     let mut rings = Vec::new();
     for layer in &mask.layers {
         for shape in mask.shapes(layer) {
-            rings.extend(rings_from_contours(&mask.arena.path_contours(shape)));
+            rings.extend(
+                pcb_ir::geom::ContourSet::from_contours(
+                    &mask.arena.path_contours(shape),
+                    pcb_ir::geom::FillRule::NonZero,
+                    resolution.strict(),
+                )
+                .unwrap()
+                .rings,
+            );
         }
     }
-    let region = ContourSet::new(rings, FillRule::NonZero, 1e-4);
+    let region = ContourSet::from_rings(
+        rings,
+        FillRule::NonZero,
+        Resolution::new(1e-4, resolution.accuracy),
+    );
 
     // A containing ring always has the larger unsigned area, so painting in
     // descending area order layers islands over holes over boundaries.

--- a/crates/pcb-ipc2581-tools/src/accessors/drills.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/drills.rs
@@ -55,23 +55,25 @@ pub struct DrillSize {
 
 impl<'a> IpcAccessor<'a> {
     /// Get board-local drill hole statistics with per-type distribution.
-    pub fn board_drill_stats(&self) -> Option<DrillStats> {
+    pub fn board_drill_stats(&self) -> anyhow::Result<Option<DrillStats>> {
         self.drill_stats_for_view(ArtworkScope::Board)
     }
 
     /// Get array-local drill hole statistics, excluding repeated board drills.
-    pub fn board_array_drill_stats(&self) -> Option<DrillStats> {
+    pub fn board_array_drill_stats(&self) -> anyhow::Result<Option<DrillStats>> {
         self.drill_stats_for_view(ArtworkScope::ArrayLocal)
     }
 
     /// Get flattened board-array drill statistics, including repeated board drills
     /// and array-local drill features.
-    pub fn board_array_flattened_drill_stats(&self) -> Option<DrillStats> {
+    pub fn board_array_flattened_drill_stats(&self) -> anyhow::Result<Option<DrillStats>> {
         self.drill_stats_for_view(ArtworkScope::ArrayFlattened)
     }
 
-    fn drill_stats_for_view(&self, view: ArtworkScope) -> Option<DrillStats> {
-        let ecad = self.ecad()?;
+    fn drill_stats_for_view(&self, view: ArtworkScope) -> anyhow::Result<Option<DrillStats>> {
+        let Some(ecad) = self.ecad() else {
+            return Ok(None);
+        };
         let mut collector = DrillStatsCollector::default();
         let mut has_drill_layer = false;
 
@@ -81,13 +83,11 @@ impl<'a> IpcAccessor<'a> {
             }
             has_drill_layer = true;
             let layer_name = self.ipc.resolve(layer.name);
-            let Ok(doc) = geometry::extract_layer_for_view(self.ipc, layer_name, view) else {
-                continue;
-            };
+            let doc = geometry::extract_layer_for_view(self.ipc, layer_name, view)?;
             collect_drill_info(&doc, &mut collector);
         }
 
-        has_drill_layer.then(|| collector.finish())
+        Ok(has_drill_layer.then(|| collector.finish()))
     }
 }
 
@@ -236,15 +236,18 @@ mod tests {
         .unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let board = accessor.board_drill_stats().unwrap();
+        let board = accessor.board_drill_stats().unwrap().unwrap();
         assert_eq!(board.total_holes, 1);
         assert_eq!(board.distribution[0].hole_type, DrillHoleType::Via);
 
-        let array = accessor.board_array_drill_stats().unwrap();
+        let array = accessor.board_array_drill_stats().unwrap().unwrap();
         assert_eq!(array.total_holes, 1);
         assert_eq!(array.distribution[0].hole_type, DrillHoleType::NonPlated);
 
-        let flattened = accessor.board_array_flattened_drill_stats().unwrap();
+        let flattened = accessor
+            .board_array_flattened_drill_stats()
+            .unwrap()
+            .unwrap();
         assert_eq!(flattened.total_holes, 3);
         assert_eq!(
             flattened

--- a/crates/pcb-ipc2581-tools/src/assembly/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/mod.rs
@@ -1,5 +1,6 @@
 //! Deterministic PCBA assembly reports over the canonical imported design.
 
+use pcb_ir::geom::Resolution;
 use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Result, bail};
@@ -30,13 +31,17 @@ pub use report::AssemblyReport;
 /// The report uses source-backed assembly IR and conservative physical
 /// relationships. Geometry can establish only a unique exact overlap; the
 /// report applies no quote or shop policy.
-pub fn build_report(imported: &ImportedDesign, target: LayoutTarget) -> Result<AssemblyReport> {
+pub fn build_report(
+    imported: &ImportedDesign,
+    target: LayoutTarget,
+    resolution: Resolution,
+) -> Result<AssemblyReport> {
     let scope = match target {
         LayoutTarget::Board => ir::Scope::Board,
         LayoutTarget::BoardArray => ir::Scope::BoardArray,
     };
     let assembly = imported.assembly_document(scope)?;
-    let physical = imported.physical_view(target.artwork_scope())?;
+    let physical = imported.physical_view(target.artwork_scope(), resolution)?;
     let mut ids = IdAllocator::default();
     let (profiles, profile_ids) = physical_profiles(&assembly, &mut ids);
     let (scope_bounds, scope_area) = assembly
@@ -1553,6 +1558,17 @@ fn path_command(value: PathCmd) -> report::PathCommand {
             control_2_y: canonical_number(value.p1.y),
             x: canonical_number(value.p2.x),
             y: canonical_number(value.p2.y),
+        },
+        PathOp::EllipseTo => report::PathCommand::EllipseTo {
+            x: canonical_number(value.p0.x),
+            y: canonical_number(value.p0.y),
+            center_x: canonical_number(value.p1.x),
+            center_y: canonical_number(value.p1.y),
+            x_axis_x: canonical_number(value.p2.x),
+            x_axis_y: canonical_number(value.p2.y),
+            y_axis_x: canonical_number(value.p3.x),
+            y_axis_y: canonical_number(value.p3.y),
+            clockwise: value.clockwise,
         },
         PathOp::Close => report::PathCommand::Close,
     }

--- a/crates/pcb-ipc2581-tools/src/assembly/report.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/report.rs
@@ -718,6 +718,19 @@ pub enum PathCommand {
         x: f64,
         y: f64,
     },
+    /// An elliptical arc: `center` plus the images of the unit x and y axes
+    /// describe the ellipse, `clockwise` its geometric winding.
+    EllipseTo {
+        x: f64,
+        y: f64,
+        center_x: f64,
+        center_y: f64,
+        x_axis_x: f64,
+        x_axis_y: f64,
+        y_axis_x: f64,
+        y_axis_y: f64,
+        clockwise: bool,
+    },
     Close,
 }
 

--- a/crates/pcb-ipc2581-tools/src/assembly/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/tests.rs
@@ -1,3 +1,4 @@
+use pcb_ir::geom::Resolution;
 use std::io::Cursor;
 
 use ipc2581::Ipc2581;
@@ -14,10 +15,12 @@ fn report(target: LayoutTarget) -> report::AssemblyReport {
 }
 
 fn report_xml(xml: &str, target: LayoutTarget) -> report::AssemblyReport {
+    let resolution = Resolution::default();
+
     ipc2581::validate(xml).expect("assembly report fixture conforms to IPC-2581C");
     let ipc = Ipc2581::parse(xml).unwrap();
     let imported = import_design(&ipc).unwrap();
-    build_report(&imported, target).unwrap()
+    build_report(&imported, target, resolution).unwrap()
 }
 
 #[test]
@@ -775,6 +778,8 @@ fn board_scope_is_one_canonical_board() {
 
 #[test]
 fn reports_missing_style_references_without_guessing() {
+    let resolution = Resolution::default();
+
     let ipc = Ipc2581::parse(FIXTURE).unwrap();
     let mut imported = import_design(&ipc).unwrap();
     let void = imported
@@ -791,7 +796,7 @@ fn reports_missing_style_references_without_guessing() {
         .entries
         .retain(|entry| entry.id != void);
 
-    let report = build_report(&imported, LayoutTarget::BoardArray).unwrap();
+    let report = build_report(&imported, LayoutTarget::BoardArray, resolution).unwrap();
     let package = report
         .packages
         .iter()
@@ -810,6 +815,8 @@ fn reports_missing_style_references_without_guessing() {
 
 #[test]
 fn panel_without_root_profile_does_not_invent_an_envelope() {
+    let resolution = Resolution::default();
+
     let mut xml = FIXTURE.to_owned();
     let panel = xml.find("      <Step name=\"panel\"").unwrap();
     let profile_start = panel + xml[panel..].find("        <Profile>").unwrap();
@@ -821,7 +828,7 @@ fn panel_without_root_profile_does_not_invent_an_envelope() {
     let ipc = Ipc2581::parse(&xml).unwrap();
     let imported = import_design(&ipc).unwrap();
 
-    let report = build_report(&imported, LayoutTarget::BoardArray).unwrap();
+    let report = build_report(&imported, LayoutTarget::BoardArray, resolution).unwrap();
 
     assert!(report.scope.profile_ids.is_empty());
     assert_eq!(report.scope.bounds_mm, None);
@@ -885,11 +892,13 @@ fn pad_shape_with_reference<'a>(
 
 #[test]
 fn rejects_non_finite_report_numbers() {
+    let resolution = Resolution::default();
+
     let ipc = Ipc2581::parse(FIXTURE).unwrap();
     let mut imported = import_design(&ipc).unwrap();
     imported.packages[0].source.height = Some(f64::NAN);
 
-    let error = build_report(&imported, LayoutTarget::BoardArray).unwrap_err();
+    let error = build_report(&imported, LayoutTarget::BoardArray, resolution).unwrap_err();
 
     assert_eq!(
         error.to_string(),
@@ -899,12 +908,14 @@ fn rejects_non_finite_report_numbers() {
 
 #[test]
 fn dm0002_excludes_document_objects_from_assembly_work() {
+    let resolution = Resolution::default();
+
     let compressed = include_bytes!("../../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");
     let xml = zstd::decode_all(Cursor::new(compressed)).unwrap();
     let ipc = Ipc2581::parse(std::str::from_utf8(&xml).unwrap()).unwrap();
     let imported = import_design(&ipc).unwrap();
 
-    let report = build_report(&imported, LayoutTarget::BoardArray).unwrap();
+    let report = build_report(&imported, LayoutTarget::BoardArray, resolution).unwrap();
 
     assert_eq!(report.summary.components.total, 59);
     assert_eq!(report.summary.components.included, 53);

--- a/crates/pcb-ipc2581-tools/src/board_array.rs
+++ b/crates/pcb-ipc2581-tools/src/board_array.rs
@@ -1,11 +1,12 @@
+use pcb_ir::geom::Resolution;
 use std::fmt::Write;
 
 use anyhow::{Context, Result};
-use ipc2581::Ipc2581;
 use ipc2581::types::LayerFunction;
 use pcb_ir::dialects::ipc::{ArtworkScope, LayoutStep, LayoutStepKind};
-use pcb_ir::geom::path::{PathCmd, PathOp};
-use pcb_ir::geom::{Affine2, Arc, BBox, ContourBuf, Point};
+use pcb_ir::geom::{Affine2, BBox, ContourBuf, Point};
+use pcb_ir::import::ipc2581::{ImportedDesign, LayerId, import_design};
+use pcb_ir::render::svg_path_data;
 
 use crate::accessors::{BoardArrayGridInfo, BoardArrayInfo, IpcAccessor};
 use crate::utils::format::fmt_num;
@@ -15,9 +16,11 @@ type GeometryDocument =
 
 const OVERVIEW_STROKE_WIDTH_MM: f64 = 0.1;
 const OVERVIEW_VIEWBOX_PADDING_MM: f64 = 1.0;
-const POINT_EPSILON_MM: f64 = 1e-9;
 
-pub fn render_board_array_overview_svg(accessor: &IpcAccessor<'_>) -> Result<Option<String>> {
+pub fn render_board_array_overview_svg(
+    accessor: &IpcAccessor<'_>,
+    resolution: Resolution,
+) -> Result<Option<String>> {
     let Some(layout) = accessor.board_layout_info() else {
         return Ok(None);
     };
@@ -30,15 +33,17 @@ pub fn render_board_array_overview_svg(accessor: &IpcAccessor<'_>) -> Result<Opt
         return Ok(None);
     };
     let array_height = dimensions.height_mm();
-    let layer_overlays = board_array_layer_overlays(accessor, array_height);
-    render_board_array_svg(accessor.ipc(), board_array, &doc, &layer_overlays)
+    let imported = import_design(accessor.ipc())?;
+    let layer_overlays = board_array_layer_overlays(&imported, array_height, resolution)?;
+    render_board_array_svg(&imported, board_array, &doc, &layer_overlays, resolution)
 }
 
 fn render_board_array_svg(
-    ipc: &Ipc2581,
+    imported: &ImportedDesign,
     board_array: &BoardArrayInfo,
     doc: &GeometryDocument,
     layer_overlays: &[BoardArrayLayerOverlay],
+    resolution: Resolution,
 ) -> Result<Option<String>> {
     let Some(dimensions) = board_array.dimensions.as_ref() else {
         return Ok(None);
@@ -59,12 +64,12 @@ fn render_board_array_svg(
         return Ok(None);
     }
 
-    let board_fill_paths = board_instance_paths(doc, array_height, true);
-    let board_outline_paths = board_instance_paths(doc, array_height, false);
+    let board_fill_paths = board_instance_paths(doc, array_height, true)?;
+    let board_outline_paths = board_instance_paths(doc, array_height, false)?;
     if board_outline_paths.is_empty() {
         return Ok(None);
     }
-    let profile_paths = board_array_profile_paths(ipc, doc, array_height)?;
+    let profile_paths = board_array_profile_paths(imported, doc, array_height, resolution)?;
     let viewbox = overview_viewbox(array_width, array_height, layer_overlays);
     let viewbox_width = viewbox.width();
     let viewbox_height = viewbox.height();
@@ -161,34 +166,31 @@ struct BoardArrayLayerStyle {
 }
 
 fn board_array_layer_overlays(
-    accessor: &IpcAccessor<'_>,
+    imported: &ImportedDesign,
     array_height: f64,
-) -> Vec<BoardArrayLayerOverlay> {
-    let Some(ecad) = accessor.ipc().ecad() else {
-        return Vec::new();
-    };
-
-    ecad.cad_data
-        .layers
+    resolution: Resolution,
+) -> anyhow::Result<Vec<BoardArrayLayerOverlay>> {
+    Ok(imported
+        .layer_definitions
         .iter()
-        .filter_map(|layer| {
-            let layer_name = accessor.ipc().resolve(layer.name);
-            let Ok(doc) = crate::geometry::extract_layer_for_view(
-                accessor.ipc(),
-                layer_name,
-                ArtworkScope::ArraySupport,
-            ) else {
-                return None;
+        .enumerate()
+        .map(|(layer_index, layer)| {
+            let doc = imported
+                .materialize_layer(LayerId(layer_index as u32), ArtworkScope::ArraySupport)?;
+            let Some(mut native) = crate::geometry::render::native_layer_document(&doc)? else {
+                return Ok(None);
             };
-            let mut native = crate::geometry::render::native_layer_document(&doc)?;
-            pcb_ir::dialects::ipc::process::compose_for_rendering(&mut native);
-            let paths = layer_paths(&native, array_height);
-            (!paths.is_empty()).then_some(BoardArrayLayerOverlay {
+            pcb_ir::dialects::ipc::process::compose_for_rendering(&mut native, resolution)?;
+            let paths = layer_paths(&native, array_height, resolution)?;
+            Ok::<_, anyhow::Error>((!paths.is_empty()).then_some(BoardArrayLayerOverlay {
                 function: layer.layer_function,
                 paths,
-            })
+            }))
         })
-        .collect()
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect())
 }
 
 struct BoardArrayProfileSvgPaths {
@@ -197,32 +199,44 @@ struct BoardArrayProfileSvgPaths {
 }
 
 fn board_array_profile_paths(
-    ipc: &Ipc2581,
+    imported: &ImportedDesign,
     doc: &GeometryDocument,
     array_height: f64,
+    resolution: Resolution,
 ) -> Result<BoardArrayProfileSvgPaths> {
-    let score_lines = crate::geometry::board_array_vscore_lines(ipc)?;
-    let profile = crate::geometry::board_array_fabrication_profile(ipc, doc, &score_lines)?;
+    let score_lines = crate::geometry::board_array_vscore_lines(imported)?;
+    let profile =
+        crate::geometry::board_array_fabrication_profile(imported, doc, &score_lines, resolution)?;
     let transform = y_flip_transform(array_height);
 
     Ok(BoardArrayProfileSvgPaths {
-        array_outlines: payload_groups_path_data(&profile.array_outlines, transform),
-        material_removal: payloads_path_data(&profile.material_removal, transform)
+        array_outlines: payload_groups_path_data(&profile.array_outlines, transform)?,
+        material_removal: payloads_path_data(&profile.material_removal, transform)?
             .into_iter()
             .collect(),
     })
 }
 
-fn payload_groups_path_data(payload_groups: &[Vec<ContourBuf>], transform: Affine2) -> Vec<String> {
-    payload_groups
+fn payload_groups_path_data(
+    payload_groups: &[Vec<ContourBuf>],
+    transform: Affine2,
+) -> anyhow::Result<Vec<String>> {
+    Ok(payload_groups
         .iter()
-        .filter_map(|payloads| payloads_path_data(payloads, transform))
-        .collect()
+        .map(|payloads| payloads_path_data(payloads, transform))
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect())
 }
 
-fn layer_paths(doc: &GeometryDocument, panel_height: f64) -> Vec<BoardArrayLayerPath> {
+fn layer_paths(
+    doc: &GeometryDocument,
+    panel_height: f64,
+    resolution: Resolution,
+) -> anyhow::Result<Vec<BoardArrayLayerPath>> {
     let Some(layer) = doc.layers.first() else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     let transform = y_flip_transform(panel_height);
 
@@ -232,7 +246,10 @@ fn layer_paths(doc: &GeometryDocument, panel_height: f64) -> Vec<BoardArrayLayer
     let mut paths = features
         .iter()
         .filter(|feature| feature.is_vscore())
-        .flat_map(|feature| feature_paths(doc, feature, transform))
+        .map(|feature| feature_paths(doc, feature, transform))
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
         .collect::<Vec<_>>();
 
     let image_features = features
@@ -248,49 +265,53 @@ fn layer_paths(doc: &GeometryDocument, panel_height: f64) -> Vec<BoardArrayLayer
             &image,
             false,
             pcb_ir::dialects::ipc::ProfileSet::RootOnly,
-        );
-        paths.extend(mask_paths(&mask, transform));
+            resolution,
+        )?;
+        paths.extend(mask_paths(&mask, transform)?);
     }
 
-    paths
+    Ok(paths)
 }
 
 fn mask_paths(
     mask: &pcb_ir::dialects::mask::Document<LayerFunction>,
     transform: Affine2,
-) -> Vec<BoardArrayLayerPath> {
+) -> anyhow::Result<Vec<BoardArrayLayerPath>> {
     let Some(layer) = mask.layers.first() else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
-    mask.shapes(layer)
+    Ok(mask
+        .shapes(layer)
         .iter()
-        .filter_map(|shape| {
-            let mut data = String::new();
-            for contour in mask.arena.contours(shape.contours) {
-                let transformed = pcb_ir::geom::path::transform_cmds(
-                    mask.arena.cmds(*contour).iter().copied(),
-                    transform,
-                );
-                append_path_cmds(&mut data, &transformed.cmds);
-            }
-            (!data.is_empty()).then_some(BoardArrayLayerPath {
+        .map(|shape| {
+            let contours = mask
+                .arena
+                .contour_bufs(shape.contours)
+                .into_iter()
+                .map(|contour| contour.transformed(transform))
+                .collect::<Vec<_>>();
+            let data = svg_path_data(&contours);
+            Ok::<_, anyhow::Error>((!data.is_empty()).then_some(BoardArrayLayerPath {
                 data,
                 bbox: transform_bbox(shape.bbox, transform),
                 stroke_width: 0.0,
                 filled: true,
                 stroked: false,
                 vscore: false,
-            })
+            }))
         })
-        .collect()
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect())
 }
 
 fn board_instance_paths(
     doc: &GeometryDocument,
     panel_height: f64,
     include_cutouts: bool,
-) -> Vec<String> {
+) -> anyhow::Result<Vec<String>> {
     let flip_y = y_flip_transform(panel_height);
     let mut paths = Vec::new();
 
@@ -303,12 +324,12 @@ fn board_instance_paths(
         }
 
         let transform = flip_y.concat(instance.transform);
-        if let Some(path) = step_profile_path_data(doc, step, transform, include_cutouts) {
+        if let Some(path) = step_profile_path_data(doc, step, transform, include_cutouts)? {
             paths.push(path);
         }
     }
 
-    paths
+    Ok(paths)
 }
 
 fn y_flip_transform(panel_height: f64) -> Affine2 {
@@ -327,10 +348,12 @@ fn step_profile_path_data(
     step: &LayoutStep<ipc2581::Symbol>,
     transform: Affine2,
     include_cutouts: bool,
-) -> Option<String> {
+) -> anyhow::Result<Option<String>> {
     let mut path_data = String::new();
     for profile_index in step.profiles.indices() {
-        let profile = doc.profiles.get(profile_index as usize)?;
+        let Some(profile) = doc.profiles.get(profile_index as usize) else {
+            return Ok(None);
+        };
         append_transformed_path_data(&mut path_data, doc, profile.outer_path, transform)?;
         if !include_cutouts {
             continue;
@@ -340,7 +363,7 @@ fn step_profile_path_data(
         }
     }
 
-    (!path_data.is_empty()).then_some(path_data)
+    Ok((!path_data.is_empty()).then_some(path_data))
 }
 
 fn overview_viewbox(
@@ -366,24 +389,29 @@ fn feature_paths(
     doc: &GeometryDocument,
     feature: &pcb_ir::dialects::ipc::Feature<ipc2581::Symbol>,
     transform: Affine2,
-) -> Vec<BoardArrayLayerPath> {
-    feature
+) -> anyhow::Result<Vec<BoardArrayLayerPath>> {
+    Ok(feature
         .paths
         .indices()
-        .filter_map(|path_index| {
-            let path = doc.arena.paths.get(path_index as usize)?;
+        .map(|path_index| {
+            let Some(path) = doc.arena.paths.get(path_index as usize) else {
+                return Ok(None);
+            };
             let mut data = String::new();
             append_transformed_path_data(&mut data, doc, path_index, transform)?;
-            (!data.is_empty()).then_some(BoardArrayLayerPath {
+            Ok::<_, anyhow::Error>((!data.is_empty()).then_some(BoardArrayLayerPath {
                 data,
                 bbox: transform_bbox(path.bbox, transform),
                 stroke_width: path.stroke().map(|stroke| stroke.width).unwrap_or(0.0),
                 filled: path.is_filled(),
                 stroked: path.is_stroked(),
                 vscore: feature.is_vscore(),
-            })
+            }))
         })
-        .collect()
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect())
 }
 
 fn transform_bbox(bbox: BBox, transform: Affine2) -> BBox {
@@ -409,100 +437,33 @@ fn append_transformed_path_data(
     doc: &GeometryDocument,
     path_index: u32,
     transform: Affine2,
-) -> Option<()> {
-    let path = doc.arena.paths.get(path_index as usize)?;
-    for contour in doc.arena.contours(path.contours) {
-        let transformed =
-            pcb_ir::geom::path::transform_cmds(doc.arena.cmds(*contour).iter().copied(), transform);
-        append_path_cmds(path_data, &transformed.cmds);
+) -> anyhow::Result<Option<()>> {
+    let Some(path) = doc.arena.paths.get(path_index as usize) else {
+        return Ok(None);
+    };
+    let contours = doc
+        .arena
+        .path_contours(path)
+        .into_iter()
+        .map(|contour| contour.transformed(transform))
+        .collect::<Vec<_>>();
+    if !path_data.is_empty() {
+        path_data.push(' ');
     }
-    Some(())
+    path_data.push_str(&svg_path_data(&contours));
+    Ok(Some(()))
 }
 
-fn payloads_path_data(payloads: &[ContourBuf], transform: Affine2) -> Option<String> {
-    let mut path_data = String::new();
-    for payload in payloads {
-        let transformed =
-            pcb_ir::geom::path::transform_cmds(payload.cmds.iter().copied(), transform);
-        append_path_cmds(&mut path_data, &transformed.cmds);
-    }
-    (!path_data.is_empty()).then_some(path_data)
-}
-
-fn append_path_cmds(data: &mut String, cmds: &[PathCmd]) {
-    let mut current = Point::default();
-    for cmd in cmds {
-        match cmd.op {
-            PathOp::MoveTo => {
-                current = cmd.p0;
-                if !data.is_empty() {
-                    data.push(' ');
-                }
-                write!(data, "M{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap();
-            }
-            PathOp::LineTo => {
-                current = cmd.p0;
-                write!(data, " L{} {}", fmt_num(cmd.p0.x), fmt_num(cmd.p0.y)).unwrap();
-            }
-            PathOp::ArcTo => {
-                write_arc_to_path_data(data, current, cmd.p0, cmd.p1, cmd.clockwise);
-                current = cmd.p0;
-            }
-            PathOp::CubicTo => {
-                current = cmd.p2;
-                write!(
-                    data,
-                    " C{} {},{} {},{} {}",
-                    fmt_num(cmd.p0.x),
-                    fmt_num(cmd.p0.y),
-                    fmt_num(cmd.p1.x),
-                    fmt_num(cmd.p1.y),
-                    fmt_num(cmd.p2.x),
-                    fmt_num(cmd.p2.y)
-                )
-                .unwrap();
-            }
-            PathOp::Close => data.push_str(" Z"),
-        }
-    }
-}
-
-fn write_arc_to_path_data(
-    data: &mut String,
-    start: Point,
-    end: Point,
-    center: Point,
-    clockwise: bool,
-) {
-    let radius = start.distance_to(center);
-    if radius <= POINT_EPSILON_MM {
-        write!(data, " L{} {}", fmt_num(end.x), fmt_num(end.y)).unwrap();
-        return;
-    }
-
-    let sweep_flag = if clockwise { 0 } else { 1 };
-    if start.distance_to(end) <= POINT_EPSILON_MM {
-        let midpoint = Point::new(2.0 * center.x - start.x, 2.0 * center.y - start.y);
-        write_svg_arc(data, radius, 0, sweep_flag, midpoint);
-        write_svg_arc(data, radius, 0, sweep_flag, end);
-        return;
-    }
-
-    let large_arc =
-        u8::from(Arc::new(start, end, center, clockwise).sweep_radians() > std::f64::consts::PI);
-    write_svg_arc(data, radius, large_arc, sweep_flag, end);
-}
-
-fn write_svg_arc(data: &mut String, radius: f64, large_arc: u8, sweep_flag: u8, end: Point) {
-    write!(
-        data,
-        " A{} {} 0 {large_arc} {sweep_flag} {} {}",
-        fmt_num(radius),
-        fmt_num(radius),
-        fmt_num(end.x),
-        fmt_num(end.y)
-    )
-    .unwrap();
+fn payloads_path_data(
+    payloads: &[ContourBuf],
+    transform: Affine2,
+) -> anyhow::Result<Option<String>> {
+    let transformed = payloads
+        .iter()
+        .map(|payload| payload.clone().transformed(transform))
+        .collect::<Vec<_>>();
+    let path_data = svg_path_data(&transformed);
+    Ok((!path_data.is_empty()).then_some(path_data))
 }
 
 fn write_board_paths(
@@ -685,6 +646,8 @@ mod tests {
 
     #[test]
     fn renders_simple_board_array_overview_svg() {
+        let resolution = Resolution::default();
+
         let ipc = ipc2581::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -729,7 +692,9 @@ mod tests {
         .unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let svg = render_board_array_overview_svg(&accessor).unwrap().unwrap();
+        let svg = render_board_array_overview_svg(&accessor, resolution)
+            .unwrap()
+            .unwrap();
 
         assert!(svg.contains("data-board-array-overview='true'"));
         assert!(svg.contains("viewBox='-1 -1 46 26'"));
@@ -749,6 +714,8 @@ mod tests {
 
     #[test]
     fn renders_board_array_overview_from_array_profile() {
+        let resolution = Resolution::default();
+
         let ipc = ipc2581::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -792,7 +759,9 @@ mod tests {
         .unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let svg = render_board_array_overview_svg(&accessor).unwrap().unwrap();
+        let svg = render_board_array_overview_svg(&accessor, resolution)
+            .unwrap()
+            .unwrap();
 
         assert!(svg.contains("class='board-array-outline'"));
         assert!(svg.contains(" A3 3"));
@@ -801,6 +770,8 @@ mod tests {
 
     #[test]
     fn renders_board_array_overview_vcuts_from_vcut_layer_only() {
+        let resolution = Resolution::default();
+
         let ipc = ipc2581::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -856,7 +827,9 @@ mod tests {
         .unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let svg = render_board_array_overview_svg(&accessor).unwrap().unwrap();
+        let svg = render_board_array_overview_svg(&accessor, resolution)
+            .unwrap()
+            .unwrap();
 
         assert_eq!(svg.matches("vcut-guide").count(), 2);
         assert!(svg.contains("d='M5 24 L5 0'"));
@@ -873,6 +846,8 @@ mod tests {
 
     #[test]
     fn renders_board_array_overview_vcut_relief_contours() {
+        let resolution = Resolution::default();
+
         let ipc = ipc2581::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -953,7 +928,9 @@ mod tests {
         .unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let svg = render_board_array_overview_svg(&accessor).unwrap().unwrap();
+        let svg = render_board_array_overview_svg(&accessor, resolution)
+            .unwrap()
+            .unwrap();
 
         assert!(svg.contains("class='board-array-profile-cutout'"));
         assert!(svg.contains("fill='#ffffff'"));
@@ -968,6 +945,8 @@ mod tests {
 
     #[test]
     fn renders_nested_board_cell_support_geometry_without_board_features() {
+        let resolution = Resolution::default();
+
         let ipc = ipc2581::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -1036,7 +1015,9 @@ mod tests {
         .unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let svg = render_board_array_overview_svg(&accessor).unwrap().unwrap();
+        let svg = render_board_array_overview_svg(&accessor, resolution)
+            .unwrap()
+            .unwrap();
 
         assert_eq!(svg.matches("array-layer-copper").count(), 1);
         assert!(!svg.contains("M7 5.5 L15 5.5"));
@@ -1044,6 +1025,8 @@ mod tests {
 
     #[test]
     fn renders_clear_features_as_holes_in_the_layer_overlay() {
+        let resolution = Resolution::default();
+
         let ipc = ipc2581::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -1116,7 +1099,9 @@ mod tests {
         .unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let svg = render_board_array_overview_svg(&accessor).unwrap().unwrap();
+        let svg = render_board_array_overview_svg(&accessor, resolution)
+            .unwrap()
+            .unwrap();
 
         assert_eq!(
             svg.matches("array-layer-copper").count(),

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -85,13 +85,15 @@ pub fn generate_automatic_board_array_copper_balance(
                     && collection.has_same_support_scope(candidate.layer, layer.name)
             })
             .map(|candidate| candidate.region);
-        let input_index = representative.unwrap_or_else(|| {
-            let index = inputs.len();
-            let mut input = collection.input_for_layer(layer.name);
-            input.support_features = input.support_features.union(&frame_copper);
-            inputs.push((layer_name.clone(), input));
-            index
-        });
+        let input_index = match representative {
+            Some(index) => index,
+            None => {
+                let mut input = collection.input_for_layer(layer.name)?;
+                input.support_features = input.support_features.union(&frame_copper);
+                inputs.push((layer_name.clone(), input));
+                inputs.len() - 1
+            }
+        };
         prepared.push(LayerCopper {
             layer: layer.name,
             name: layer_name,

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -10,9 +10,12 @@ use pcb_ir::dialects::ipc::{
     ArtworkScope, BalancingRegionOptions, BoardArraySupportDocument, BoardArraySupportLayerPolicy,
     board_array_balancing_region, collect_board_array_balancing_input,
 };
+use pcb_ir::geom::copper_balance::map_layers;
+use pcb_ir::geom::{ContourSet, Resolution};
+use pcb_ir::import::ipc2581::{ImportedDesign, LayerId, import_design};
 
 use crate::copper_balance::{
-    CERTIFICATE_AREA_TOLERANCE_MM2, CopperBalancePlan, PreparedCopperLayer, composed_copper_image,
+    CERTIFICATE_AREA_TOLERANCE_MM2, CopperBalancePlan, PreparedCopperLayer,
     physical_copper_stack_weights, solve_copper_balance,
 };
 use crate::geometry;
@@ -27,23 +30,28 @@ use crate::ipc2581::{Ipc2581, Symbol};
 /// `ipc` must describe the completed, not-yet-balanced array so that generated
 /// rails, V-scores, tooling holes, and fiducials participate in safe-region
 /// discovery while balance copper itself does not.
-pub fn generate_automatic_board_array_copper_balance(ipc: &Ipc2581) -> Result<CopperBalancePlan> {
-    let layout = geometry::extract_layout(ipc)
-        .context("failed to extract board-array layout for copper balancing")?;
-    let score_lines = geometry::board_array_vscore_lines(ipc)
+pub fn generate_automatic_board_array_copper_balance(
+    ipc: &Ipc2581,
+    resolution: Resolution,
+) -> Result<CopperBalancePlan> {
+    let imported = import_design(ipc)?;
+    let layout = &imported.geometry;
+    let score_lines = geometry::board_array_vscore_lines(&imported)
         .context("failed to extract board-array V-scores for copper balancing")?;
-    let fabrication_profile = geometry::board_array_fabrication_profile(ipc, &layout, &score_lines)
-        .context("failed to derive board-array fabrication profile for copper balancing")?;
+    let fabrication_profile =
+        geometry::board_array_fabrication_profile(&imported, layout, &score_lines, resolution)
+            .context("failed to derive board-array fabrication profile for copper balancing")?;
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let copper_layers = crate::layers::copper_layers(ecad);
-    let support_layers = extract_array_support_layers(ipc)?;
+    let support_layers = extract_array_support_layers(&imported)?;
     let collection = collect_board_array_balancing_input(
-        &layout,
+        layout,
         &fabrication_profile,
         &copper_layers,
         support_layers
             .iter()
             .map(|source| BoardArraySupportDocument::new(&source.document, source.policy)),
+        resolution,
     )
     .context("failed to collect board-array balancing obstacles")?;
     let panel_outer = &collection.panel_outer;
@@ -51,79 +59,89 @@ pub fn generate_automatic_board_array_copper_balance(ipc: &Ipc2581) -> Result<Co
     let board_area_mm2 = board_footprints.area();
     let stack_weights = physical_copper_stack_weights(ipc);
     let stack_weights_available = stack_weights.is_some();
-    let mut prepared: Vec<PreparedLayerBalance> = Vec::with_capacity(copper_layers.len());
+    let mut prepared: Vec<LayerCopper> = Vec::with_capacity(copper_layers.len());
+    let mut inputs = Vec::new();
     for layer in &copper_layers {
         let layer_name = ipc.resolve(layer.name).to_string();
-        let existing_copper = composed_copper_image(ipc, &layer_name)?.intersection(panel_outer);
-        let board_target_density = (existing_copper.intersection(board_footprints).area()
-            / board_area_mm2)
-            .clamp(0.0, 1.0);
+        let existing_copper = imported
+            .composed_layer_image(
+                imported
+                    .layer_id(&layer_name)
+                    .context("missing copper layer")?,
+                ArtworkScope::ArrayFlattened,
+                resolution,
+            )?
+            .intersection(panel_outer);
         // Existing copper outside the board footprints participates as an
         // obstacle, so copper the array-support geometry does not capture
         // shrinks the certified safe region instead of failing the solve.
         let frame_copper = existing_copper.difference(board_footprints);
         let frame_copper_empty = frame_copper.is_empty();
-        let stack_weight_mm2 = stack_weights
-            .as_ref()
-            .and_then(|weights| weights.get(&layer_name).copied())
-            .unwrap_or(0.0);
-        let safe_region = if frame_copper_empty
-            && let Some(representative) = prepared.iter().find(|candidate| {
-                candidate.frame_copper_empty
+        let representative = prepared
+            .iter()
+            .find(|candidate| {
+                frame_copper_empty
+                    && candidate.frame.is_empty()
                     && collection.has_same_support_scope(candidate.layer, layer.name)
-            }) {
-            representative.inner.safe_region.clone()
-        } else {
-            let mut balancing_input = collection.input_for_layer(layer.name);
-            balancing_input.support_features =
-                balancing_input.support_features.union(&frame_copper);
-            let balancing_region =
-                board_array_balancing_region(&balancing_input, BalancingRegionOptions::default());
-            let balancing_region = balancing_region.context(format!(
-                "failed to compute balancing region for layer '{layer_name}'"
-            ))?;
-            if !balancing_region
-                .certificate
-                .passes(CERTIFICATE_AREA_TOLERANCE_MM2)
-            {
-                bail!(
-                    "computed board-array balancing region for layer '{layer_name}' failed clearance certification"
-                );
-            }
-            balancing_region.safe_region
-        };
-        // The panel material the solver may fill, plus the boards whose
-        // density set the target and any frame copper already present.
-        // Everything else inside the array — board clearance, rails, V-score
-        // relief, tooling holes — can never hold generated copper and so
-        // stays out of the density denominator.
-        let density_domain = board_footprints.union(&frame_copper).union(&safe_region);
-        prepared.push(PreparedLayerBalance {
+            })
+            .map(|candidate| candidate.region);
+        let input_index = representative.unwrap_or_else(|| {
+            let index = inputs.len();
+            let mut input = collection.input_for_layer(layer.name);
+            input.support_features = input.support_features.union(&frame_copper);
+            inputs.push((layer_name.clone(), input));
+            index
+        });
+        prepared.push(LayerCopper {
             layer: layer.name,
-            frame_copper_empty,
-            inner: PreparedCopperLayer {
-                layer_name,
-                target_density: board_target_density,
-                stack_weight_mm2,
-                existing_copper,
-                safe_region,
-                density_domain,
-            },
+            name: layer_name,
+            existing: existing_copper,
+            frame: frame_copper,
+            region: input_index,
         });
     }
+    let regions = map_layers(inputs, |(layer_name, input)| {
+        let region = board_array_balancing_region(&input, BalancingRegionOptions::default())
+            .with_context(|| format!("failed to compute balancing region for layer '{layer_name}'"))?;
+        if !region.certificate.passes(CERTIFICATE_AREA_TOLERANCE_MM2) {
+            bail!("computed board-array balancing region for layer '{layer_name}' failed clearance certification");
+        }
+        Ok(region.safe_region)
+    }).into_iter().collect::<Result<Vec<_>>>()?;
+    let prepared = prepared
+        .into_iter()
+        .map(|layer| {
+            let safe_region = regions[layer.region].clone();
+            PreparedCopperLayer {
+                target_density: (layer.existing.intersection(board_footprints).area()
+                    / board_area_mm2)
+                    .clamp(0.0, 1.0),
+                stack_weight_mm2: stack_weights
+                    .as_ref()
+                    .and_then(|weights| weights.get(&layer.name).copied())
+                    .unwrap_or(0.0),
+                density_domain: board_footprints.union(&layer.frame).union(&safe_region),
+                layer_name: layer.name,
+                existing_copper: layer.existing,
+                safe_region,
+            }
+        })
+        .collect();
 
     solve_copper_balance(
         panel_outer,
         board_footprints.clone(),
         stack_weights_available,
-        prepared.into_iter().map(|layer| layer.inner).collect(),
+        prepared,
     )
 }
 
-struct PreparedLayerBalance {
+struct LayerCopper {
     layer: Symbol,
-    frame_copper_empty: bool,
-    inner: PreparedCopperLayer,
+    name: String,
+    existing: ContourSet,
+    frame: ContourSet,
+    region: usize,
 }
 
 /// One ECAD layer's `ArraySupport` view plus its physical-obstacle policy.
@@ -142,14 +160,17 @@ type SupportDocument = pcb_ir::dialects::ipc::Document<Symbol, LayerFunction>;
 
 /// Extract every ECAD layer as an `ArraySupport` document for safe-region
 /// discovery.
-pub fn extract_array_support_layers(ipc: &Ipc2581) -> Result<Vec<ArraySupportLayerSource>> {
-    let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
-    ecad.cad_data
-        .layers
+pub fn extract_array_support_layers(
+    imported: &ImportedDesign,
+) -> Result<Vec<ArraySupportLayerSource>> {
+    imported
+        .layer_definitions
         .iter()
-        .map(|layer| {
-            let name = ipc.resolve(layer.name).to_string();
-            let document = geometry::extract_layer_for_view(ipc, &name, ArtworkScope::ArraySupport)
+        .enumerate()
+        .map(|(index, layer)| {
+            let name = imported.resolve(layer.name).to_string();
+            let document = imported
+                .materialize_layer(LayerId(index as u32), ArtworkScope::ArraySupport)
                 .with_context(|| {
                     format!("failed to extract IPC-2581 array-support layer '{name}'")
                 })?;

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -10,7 +10,7 @@ use pcb_ir::dialects::ipc::{
     ArtworkScope, BalancingRegionOptions, BoardArraySupportDocument, BoardArraySupportLayerPolicy,
     board_array_balancing_region, collect_board_array_balancing_input,
 };
-use pcb_ir::geom::copper_balance::map_layers;
+use pcb_ir::geom::copper_balance::{DenseCopperBalanceProfile, map_layers};
 use pcb_ir::geom::{ContourSet, Resolution};
 use pcb_ir::import::ipc2581::{ImportedDesign, LayerId, import_design};
 
@@ -29,11 +29,14 @@ use crate::ipc2581::{Ipc2581, Symbol};
 ///
 /// `ipc` must describe the completed, not-yet-balanced array so that generated
 /// rails, V-scores, tooling holes, and fiducials participate in safe-region
-/// discovery while balance copper itself does not.
+/// discovery while balance copper itself does not. Balance geometry is
+/// prepared to the profile's own accuracy; `tolerance_mm` only sets which
+/// features are significant.
 pub fn generate_automatic_board_array_copper_balance(
     ipc: &Ipc2581,
-    resolution: Resolution,
+    tolerance_mm: f64,
 ) -> Result<CopperBalancePlan> {
+    let resolution = Resolution::new(tolerance_mm, DenseCopperBalanceProfile::V1.accuracy);
     let imported = import_design(ipc)?;
     let layout = &imported.geometry;
     let score_lines = geometry::board_array_vscore_lines(&imported)

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -71,11 +71,11 @@ pub fn generate_automatic_board_array_copper_balance(
                 ArtworkScope::ArrayFlattened,
                 resolution,
             )?
-            .intersection(panel_outer);
+            .intersection(panel_outer)?;
         // Existing copper outside the board footprints participates as an
         // obstacle, so copper the array-support geometry does not capture
         // shrinks the certified safe region instead of failing the solve.
-        let frame_copper = existing_copper.difference(board_footprints);
+        let frame_copper = existing_copper.difference(board_footprints)?;
         let frame_copper_empty = frame_copper.is_empty();
         let representative = prepared
             .iter()
@@ -89,7 +89,7 @@ pub fn generate_automatic_board_array_copper_balance(
             Some(index) => index,
             None => {
                 let mut input = collection.input_for_layer(layer.name)?;
-                input.support_features = input.support_features.union(&frame_copper);
+                input.support_features = input.support_features.union(&frame_copper)?;
                 inputs.push((layer_name.clone(), input));
                 inputs.len() - 1
             }
@@ -114,21 +114,21 @@ pub fn generate_automatic_board_array_copper_balance(
         .into_iter()
         .map(|layer| {
             let safe_region = regions[layer.region].clone();
-            PreparedCopperLayer {
-                target_density: (layer.existing.intersection(board_footprints).area()
+            Ok(PreparedCopperLayer {
+                target_density: (layer.existing.intersection(board_footprints)?.area()
                     / board_area_mm2)
                     .clamp(0.0, 1.0),
                 stack_weight_mm2: stack_weights
                     .as_ref()
                     .and_then(|weights| weights.get(&layer.name).copied())
                     .unwrap_or(0.0),
-                density_domain: board_footprints.union(&layer.frame).union(&safe_region),
+                density_domain: board_footprints.union(&layer.frame)?.union(&safe_region)?,
                 layer_name: layer.name,
                 existing_copper: layer.existing,
                 safe_region,
-            }
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
     solve_copper_balance(
         panel_outer,

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -665,7 +665,10 @@ fn write_board_array_creation(
     let provisional_xml = board_array_edited_xml(xml, &spec)?;
     let provisional = Ipc2581::parse(&provisional_xml)
         .context("Failed to parse provisional IPC-2581 board array")?;
-    let balance = balance::generate_automatic_board_array_copper_balance(&provisional, resolution)?;
+    let balance = balance::generate_automatic_board_array_copper_balance(
+        &provisional,
+        resolution.tolerance_mm,
+    )?;
     let copper_balance = balance.report();
 
     for layer in balance.layers {

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -1,3 +1,4 @@
+use pcb_ir::geom::Resolution;
 use std::collections::HashSet;
 #[cfg(feature = "cli")]
 use std::path::Path;
@@ -411,8 +412,10 @@ pub fn execute(
     options: &BoardArrayCreateOptions,
     balance_copper: bool,
 ) -> Result<()> {
+    let resolution = Resolution::default();
+
     let content = file_utils::load_ipc_file(input)?;
-    let creation = create_board_array(&content, options, balance_copper)?;
+    let creation = create_board_array(&content, options, balance_copper, resolution)?;
     print_copper_balance_summary(creation.copper_balance.as_ref());
     write_board_array_output(output, &creation.xml)?;
     Ok(())
@@ -424,9 +427,10 @@ pub fn execute_auto(
     output: &Path,
     sheet: Option<AutoSheetSize>,
     balance_copper: bool,
+    resolution: Resolution,
 ) -> Result<()> {
     let content = file_utils::load_ipc_file(input)?;
-    let creation = create_auto_board_array(&content, sheet, balance_copper)?;
+    let creation = create_auto_board_array(&content, sheet, balance_copper, resolution)?;
     print_copper_balance_summary(creation.copper_balance.as_ref());
     write_board_array_output(output, &creation.xml)?;
     Ok(())
@@ -459,6 +463,7 @@ pub fn create_board_array(
     xml: &str,
     options: &BoardArrayCreateOptions,
     balance_copper: bool,
+    resolution: Resolution,
 ) -> Result<BoardArrayCreation> {
     let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
     let spec = build_board_array_spec(
@@ -471,7 +476,7 @@ pub fn create_board_array(
             sheet_target_mm: None,
         },
     )?;
-    write_board_array_creation(xml, spec, balance_copper)
+    write_board_array_creation(xml, spec, balance_copper, resolution)
 }
 
 #[cfg(test)]
@@ -480,7 +485,9 @@ pub fn create_board_array(
 /// it ask for it.
 #[cfg(test)]
 fn create_board_array_xml(xml: &str, options: &BoardArrayCreateOptions) -> Result<String> {
-    Ok(create_board_array(xml, options, false)?.xml)
+    let resolution = Resolution::default();
+
+    Ok(create_board_array(xml, options, false, resolution)?.xml)
 }
 
 #[cfg(test)]
@@ -493,11 +500,12 @@ pub fn create_auto_board_array(
     xml: &str,
     sheet: Option<AutoSheetSize>,
     balance_copper: bool,
+    resolution: Resolution,
 ) -> Result<BoardArrayCreation> {
     let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
     let (options, validation_mode, panelization) = auto_board_array_options(&ipc, sheet)?;
     let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization)?;
-    write_board_array_creation(xml, spec, balance_copper)
+    write_board_array_creation(xml, spec, balance_copper, resolution)
 }
 
 #[cfg(test)]
@@ -505,7 +513,9 @@ fn create_auto_board_array_xml_with_sheet(
     xml: &str,
     sheet: Option<AutoSheetSize>,
 ) -> Result<String> {
-    Ok(create_auto_board_array(xml, sheet, false)?.xml)
+    let resolution = Resolution::default();
+
+    Ok(create_auto_board_array(xml, sheet, false, resolution)?.xml)
 }
 
 fn auto_board_array_options(
@@ -641,6 +651,7 @@ fn write_board_array_creation(
     xml: &str,
     mut spec: BoardArraySpec,
     balance_copper: bool,
+    resolution: Resolution,
 ) -> Result<BoardArrayCreation> {
     if !balance_copper {
         return Ok(BoardArrayCreation {
@@ -654,7 +665,7 @@ fn write_board_array_creation(
     let provisional_xml = board_array_edited_xml(xml, &spec)?;
     let provisional = Ipc2581::parse(&provisional_xml)
         .context("Failed to parse provisional IPC-2581 board array")?;
-    let balance = balance::generate_automatic_board_array_copper_balance(&provisional)?;
+    let balance = balance::generate_automatic_board_array_copper_balance(&provisional, resolution)?;
     let copper_balance = balance.report();
 
     for layer in balance.layers {

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -239,7 +239,9 @@ fn board_array_balancing_solves_every_copper_layer() {
     let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization).unwrap();
     let provisional_xml = write_board_array_xml(&input, &spec).unwrap();
     let provisional = Ipc2581::parse(&provisional_xml).unwrap();
-    let balance = generate_automatic_board_array_copper_balance(&provisional, resolution).unwrap();
+    let balance =
+        generate_automatic_board_array_copper_balance(&provisional, resolution.tolerance_mm)
+            .unwrap();
 
     assert!(balance.panel_area_mm2 > 0.0);
     assert_eq!(balance.layers.len(), 2);

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -1,10 +1,13 @@
 use crate::copper_balance::balance_features;
+use pcb_ir::geom::Resolution;
 
 use super::balance::{extract_array_support_layers, generate_automatic_board_array_copper_balance};
 use super::*;
 use crate::accessors::IpcAccessor;
 use crate::ipc2581::types::LayerFunction;
-use crate::manufacturing::{ManufacturingPackage, build_manufacturing_package};
+use crate::manufacturing::{
+    ManufacturingExportOptions, ManufacturingPackage, build_manufacturing_package,
+};
 use pcb_ir::dialects::ipc::{
     ArtworkScope, BalancingRegionOptions, BoardArraySupportDocument, FeatureBucket, FeatureDomain,
     FeatureIntent, FeatureKind, FeatureOperation, FeatureRole, FeatureSpan, FiducialKind,
@@ -14,7 +17,26 @@ use pcb_ir::geom::copper_balance::{
     DenseCopperBalanceMode, DenseCopperBalanceProfile, SpatialCopperBalanceLayerRequest,
     SpatialCopperBalanceRequest, generate_spatial_dense_copper_balance,
 };
-use pcb_ir::geom::{BBox, ContourSet, Point, tol};
+use pcb_ir::geom::{BBox, ContourSet, Point};
+use pcb_ir::import::ipc2581::ImportedDesign;
+
+fn design(ipc: &Ipc2581) -> ImportedDesign {
+    pcb_ir::import::ipc2581::import_design(ipc).unwrap()
+}
+
+fn manufacturing_package(
+    ipc: &Ipc2581,
+    view: ArtworkScope,
+) -> anyhow::Result<ManufacturingPackage> {
+    build_manufacturing_package(
+        &design(ipc),
+        &ManufacturingExportOptions {
+            view,
+            relief_debug_dir: None,
+        },
+        Resolution::default(),
+    )
+}
 
 #[test]
 fn parses_board_margin_css_shorthand() {
@@ -138,11 +160,18 @@ fn creates_rounded_panel_step_from_board_bbox() {
             .iter()
             .all(|feature| feature.intent.domain == FeatureDomain::VCut)
     );
-    assert_eq!(geometry::board_array_vscore_lines(&ipc).unwrap().len(), 24);
+    assert_eq!(
+        geometry::board_array_vscore_lines(&design(&ipc))
+            .unwrap()
+            .len(),
+        24
+    );
 }
 
 #[test]
 fn generated_board_array_has_a_certified_safe_balancing_region() {
+    let resolution = Resolution::default();
+
     let input = board_fixture_with_mask_bbox_mm(12.0, 10.0);
     let source = Ipc2581::parse(&input).unwrap();
     let (options, validation_mode, panelization) = auto_board_array_options(&source, None).unwrap();
@@ -152,11 +181,14 @@ fn generated_board_array_has_a_certified_safe_balancing_region() {
     let xml = write_board_array_xml(&input, &spec).unwrap();
     let ipc = Ipc2581::parse(&xml).unwrap();
     let layout = geometry::extract_layout(&ipc).unwrap();
-    let score_lines = geometry::board_array_vscore_lines(&ipc).unwrap();
+    let score_lines = geometry::board_array_vscore_lines(&design(&ipc)).unwrap();
     let fabrication_profile =
-        geometry::board_array_fabrication_profile(&ipc, &layout, &score_lines).unwrap();
+        geometry::board_array_fabrication_profile(&design(&ipc), &layout, &score_lines, resolution)
+            .unwrap();
     let ecad = ipc.ecad().unwrap();
-    let support_layers = extract_array_support_layers(&ipc).unwrap();
+    let support_layers =
+        extract_array_support_layers(&pcb_ir::import::ipc2581::import_design(&ipc).unwrap())
+            .unwrap();
     let copper_layers = crate::layers::copper_layers(ecad);
 
     let collection = collect_board_array_balancing_input(
@@ -166,6 +198,7 @@ fn generated_board_array_has_a_certified_safe_balancing_region() {
         support_layers
             .iter()
             .map(|source| BoardArraySupportDocument::new(&source.document, source.policy)),
+        resolution,
     )
     .unwrap();
     let input = collection.input_for_layer(copper_layers[0].name);
@@ -197,6 +230,8 @@ fn two_layer_board_xml() -> String {
 
 #[test]
 fn board_array_balancing_solves_every_copper_layer() {
+    let resolution = Resolution::default();
+
     let input = two_layer_board_xml();
     let ipc = Ipc2581::parse(&input).unwrap();
     let sheet = Some(AutoSheetSize::A7);
@@ -204,7 +239,7 @@ fn board_array_balancing_solves_every_copper_layer() {
     let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization).unwrap();
     let provisional_xml = write_board_array_xml(&input, &spec).unwrap();
     let provisional = Ipc2581::parse(&provisional_xml).unwrap();
-    let balance = generate_automatic_board_array_copper_balance(&provisional).unwrap();
+    let balance = generate_automatic_board_array_copper_balance(&provisional, resolution).unwrap();
 
     assert!(balance.panel_area_mm2 > 0.0);
     assert_eq!(balance.layers.len(), 2);
@@ -249,8 +284,11 @@ fn board_array_balancing_solves_every_copper_layer() {
 /// generated geometry in the emitted document.
 #[test]
 fn board_array_creation_reports_and_emits_the_balance() {
+    let resolution = Resolution::default();
+
     let input = two_layer_board_xml();
-    let creation = create_auto_board_array(&input, Some(AutoSheetSize::A7), true).unwrap();
+    let creation =
+        create_auto_board_array(&input, Some(AutoSheetSize::A7), true, resolution).unwrap();
     let copper_balance = creation.copper_balance.as_ref().unwrap();
     assert_eq!(copper_balance.layers.len(), 2);
     for report in &copper_balance.layers {
@@ -278,6 +316,8 @@ fn board_array_creation_reports_and_emits_the_balance() {
 
 #[test]
 fn board_array_creation_accepts_no_source_copper_layers() {
+    let resolution = Resolution::default();
+
     let input = board_fixture_mm().replace(
         r#"<Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>"#,
         r#"<Layer name="TOP" layerFunction="SOLDERMASK" side="TOP" polarity="POSITIVE"/>"#,
@@ -291,6 +331,7 @@ fn board_array_creation_accepts_no_source_copper_layers() {
             edge_rail_mm: BoardMarginMm::all(20.0),
         },
         true,
+        resolution,
     )
     .unwrap();
 
@@ -299,17 +340,19 @@ fn board_array_creation_accepts_no_source_copper_layers() {
 
 #[test]
 fn board_array_creation_can_skip_copper_balancing() {
-    let creation = create_auto_board_array(board_fixture_with_top_line_mm(), None, false).unwrap();
+    let resolution = Resolution::default();
+
+    let creation =
+        create_auto_board_array(board_fixture_with_top_line_mm(), None, false, resolution).unwrap();
 
     assert!(creation.copper_balance.is_none());
     Ipc2581::parse(&creation.xml).unwrap();
 }
 
-/// Two-sided fiducials and their mask openings must reserve area on both
-/// surface copper layers alike. That is a property of the balancing regions,
-/// so it is read off them directly rather than through a full solve.
 #[test]
 fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_layers() {
+    let resolution = Resolution::default();
+
     let input = large_board_fixture_mm();
     let ipc = Ipc2581::parse(input).unwrap();
     // The smallest sheet the board fits: fiducial scoping does not depend on
@@ -320,10 +363,18 @@ fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_laye
     let provisional_xml = write_board_array_xml(input, &spec).unwrap();
     let provisional = Ipc2581::parse(&provisional_xml).unwrap();
     let layout = geometry::extract_layout(&provisional).unwrap();
-    let score_lines = geometry::board_array_vscore_lines(&provisional).unwrap();
-    let fabrication_profile =
-        geometry::board_array_fabrication_profile(&provisional, &layout, &score_lines).unwrap();
-    let support_layers = extract_array_support_layers(&provisional).unwrap();
+    let score_lines = geometry::board_array_vscore_lines(&design(&provisional)).unwrap();
+    let fabrication_profile = geometry::board_array_fabrication_profile(
+        &design(&provisional),
+        &layout,
+        &score_lines,
+        resolution,
+    )
+    .unwrap();
+    let support_layers = extract_array_support_layers(
+        &pcb_ir::import::ipc2581::import_design(&provisional).unwrap(),
+    )
+    .unwrap();
     let copper_layers = crate::layers::copper_layers(provisional.ecad().unwrap());
     let collection = collect_board_array_balancing_input(
         &layout,
@@ -332,26 +383,25 @@ fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_laye
         support_layers
             .iter()
             .map(|source| BoardArraySupportDocument::new(&source.document, source.policy)),
+        resolution,
     )
     .unwrap();
 
-    let safe_area = |name: &str| {
+    let support_area = |name: &str| {
         let layer = copper_layers
             .iter()
             .find(|layer| provisional.resolve(layer.name) == name)
             .unwrap();
         let input = collection.input_for_layer(layer.name);
-        board_array_balancing_region(&input, BalancingRegionOptions::default())
-            .unwrap()
-            .safe_region
-            .area()
+        input.support_features.area()
     };
 
-    let top = safe_area("TOP");
-    let bottom = safe_area("BOTTOM");
+    let top = support_area("TOP");
+    let bottom = support_area("BOTTOM");
+    assert!(top > 0.0);
     assert!(
-        (bottom - top).abs() <= 1e-6,
-        "two-sided fiducials and mask openings should reserve equal surface-copper area: top {top:.6} mm², bottom {bottom:.6} mm²",
+        (bottom - top).abs() <= resolution.accuracy.max_error_mm().powi(2),
+        "two-sided fiducials and mask openings should provide equal surface-copper obstacle area: top {top:.6} mm², bottom {bottom:.6} mm²",
     );
 }
 
@@ -593,6 +643,8 @@ fn creates_board_array_with_asymmetric_edge_rails() {
 
 #[test]
 fn created_board_array_vcuts_flow_to_svg_and_gerber() {
+    let resolution = Resolution::default();
+
     let xml = create_board_array_xml(
         board_fixture_mm(),
         &BoardArrayCreateOptions {
@@ -606,7 +658,7 @@ fn created_board_array_vcuts_flow_to_svg_and_gerber() {
     let ipc = Ipc2581::parse(&xml).unwrap();
     let accessor = IpcAccessor::new(&ipc);
 
-    let svg = crate::board_array::render_board_array_overview_svg(&accessor)
+    let svg = crate::board_array::render_board_array_overview_svg(&accessor, resolution)
         .unwrap()
         .unwrap();
     assert!(svg.matches("vcut-guide").count() > 24);
@@ -618,9 +670,14 @@ fn created_board_array_vcuts_flow_to_svg_and_gerber() {
     let viewbox = svg_viewbox(&svg);
     assert!(viewbox.0 + viewbox.2 > 100.0);
     assert!(viewbox.1 + viewbox.3 > 100.0);
-    assert_eq!(geometry::board_array_vscore_lines(&ipc).unwrap().len(), 24);
+    assert_eq!(
+        geometry::board_array_vscore_lines(&design(&ipc))
+            .unwrap()
+            .len(),
+        24
+    );
 
-    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+    let package = manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
     let vcut = package
         .files
@@ -633,7 +690,7 @@ fn created_board_array_vcuts_flow_to_svg_and_gerber() {
     assert!(!vcut.contents.contains("G36*"));
     assert!(vcut.contents.matches("D01*").count() > 24);
 
-    let board_package = build_manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
+    let board_package = manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
     assert!(
         board_package
             .files
@@ -644,6 +701,8 @@ fn created_board_array_vcuts_flow_to_svg_and_gerber() {
 
 #[test]
 fn created_board_array_profile_gerber_derives_vscore_reliefs() {
+    let resolution = Resolution::default();
+
     let xml = create_board_array_xml(
         rounded_corner_board_fixture_mm(),
         &BoardArrayCreateOptions {
@@ -660,9 +719,10 @@ fn created_board_array_profile_gerber_derives_vscore_reliefs() {
     let ipc = Ipc2581::parse(&xml).unwrap();
     let layout = geometry::extract_layout(&ipc).unwrap();
     let fabrication_profile = geometry::board_array_fabrication_profile(
-        &ipc,
+        &design(&ipc),
         &layout,
-        &geometry::board_array_vscore_lines(&ipc).unwrap(),
+        &geometry::board_array_vscore_lines(&design(&ipc)).unwrap(),
+        resolution,
     )
     .unwrap();
     assert_eq!(
@@ -671,7 +731,7 @@ fn created_board_array_profile_gerber_derives_vscore_reliefs() {
     );
     assert!(fabrication_profile.assembly_panel_outlines.is_empty());
 
-    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+    let package = manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
     let vcut = package
         .files
         .iter()
@@ -697,7 +757,9 @@ fn created_board_array_profile_gerber_derives_vscore_reliefs() {
     assert!(!profile.contents.contains("G36*"));
     assert!(
         profile.contents.matches("D01*").count()
-            > geometry::board_array_vscore_lines(&ipc).unwrap().len(),
+            > geometry::board_array_vscore_lines(&design(&ipc))
+                .unwrap()
+                .len(),
         "routed reliefs should emit closed contour strokes, not only the V-cut guide lines"
     );
     gerberx2::GerberX2::parse(&profile.contents).unwrap();
@@ -722,7 +784,7 @@ fn board_array_creation_drops_source_board_outline_layer_features() {
     assert!(!xml.contains(r#"<LayerFeature layerRef="Edge.Cuts">"#));
 
     let ipc = Ipc2581::parse(&xml).unwrap();
-    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+    let package = manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
     assert!(
         package
             .files
@@ -861,7 +923,7 @@ fn generated_array_geometry_writes_fiducials_and_nonplated_holes() {
     assert_eq!(drill.features[0].intent.operation, FeatureOperation::Drill);
     assert_eq!(drill.features[0].intent.plating, PlatingKind::NonPlated);
 
-    let package = build_manufacturing_package(&parsed, ArtworkScope::ArrayFlattened).unwrap();
+    let package = manufacturing_package(&parsed, ArtworkScope::ArrayFlattened).unwrap();
     let top = package
         .files
         .iter()
@@ -897,6 +959,8 @@ fn generated_array_geometry_writes_fiducials_and_nonplated_holes() {
 
 #[test]
 fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
+    let resolution = Resolution::default();
+
     let input = board_fixture_with_top_line_mm();
     let ipc = Ipc2581::parse(input).unwrap();
     let options = BoardArrayCreateOptions {
@@ -918,10 +982,10 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
     .unwrap();
     let safe_region = ContourSet::rectangle(
         BBox::new(Point::new(0.0, 10.0), Point::new(5.0, 90.0)),
-        tol::REGION_MM,
+        resolution,
     );
 
-    let existing = ContourSet::empty(tol::REGION_MM);
+    let existing = ContourSet::empty(Resolution::default());
     let layers = [SpatialCopperBalanceLayerRequest {
         safe_region: &safe_region,
         existing_copper: &existing,
@@ -994,7 +1058,7 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
             })
             .flat_map(|feature| feature.paths.slice(&top.arena.paths))
             .collect::<Vec<_>>();
-        ContourSet::from_painted_paths(&top.arena, paths, tol::REGION_MM)
+        ContourSet::from_painted_paths(&top.arena, paths, resolution).unwrap()
     };
     let round_trip = balance_paths(pcb_ir::dialects::ipc::CopperBalanceKind::Plane)
         .difference(&balance_paths(
@@ -1016,7 +1080,7 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
         balance.solution.generated_area_mm2
     );
 
-    let package = build_manufacturing_package(&parsed, ArtworkScope::ArrayFlattened).unwrap();
+    let package = manufacturing_package(&parsed, ArtworkScope::ArrayFlattened).unwrap();
     let top_gerber = package
         .files
         .iter()
@@ -1036,19 +1100,36 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
     assert!(top_gerber.contents.contains("%LPC*%"));
 
     // The composed Gerber image must match the composed IPC image.
-    let ipc_copper = crate::copper_balance::composed_copper_image(&parsed, "TOP").unwrap();
+    let ipc_copper = {
+        let imported = pcb_ir::import::ipc2581::import_design(&parsed).unwrap();
+        imported.composed_layer_image(
+            imported.layer_id("TOP").unwrap(),
+            pcb_ir::dialects::ipc::ArtworkScope::ArrayFlattened,
+            resolution,
+        )
+    }
+    .unwrap();
     let gerber = gerberx2::GerberX2::parse(&top_gerber.contents).unwrap();
-    let mask =
-        pcb_ir::dialects::artwork::compose_to_mask(&gerberx2::geometry::extract_document(&gerber));
+    let mask = pcb_ir::dialects::artwork::compose_to_mask(
+        &gerberx2::geometry::extract_document(&gerber, resolution.accuracy).unwrap(),
+        resolution,
+    )
+    .unwrap();
     let mut rings = Vec::new();
     for layer in &mask.layers {
         for shape in mask.shapes(layer) {
-            rings.extend(pcb_ir::geom::region::rings_from_contours(
-                &mask.arena.path_contours(shape),
-            ));
+            rings.extend(
+                pcb_ir::geom::ContourSet::from_contours(
+                    &mask.arena.path_contours(shape),
+                    pcb_ir::geom::FillRule::NonZero,
+                    resolution.strict(),
+                )
+                .unwrap()
+                .rings,
+            );
         }
     }
-    let gerber_copper = ContourSet::new(rings, pcb_ir::geom::FillRule::NonZero, tol::REGION_MM);
+    let gerber_copper = ContourSet::from_rings(rings, pcb_ir::geom::FillRule::NonZero, resolution);
     assert!(
         (gerber_copper.area() - ipc_copper.area()).abs() <= ipc_copper.area() * 1e-3,
         "Gerber area {}, IPC area {}",
@@ -1097,7 +1178,7 @@ fn board_array_creation_adds_default_tooling_at_single_column_min_width() {
         vec![(23.5, 67.5), (46.5, 67.5), (27.5, 2.5), (42.5, 2.5)],
     );
 
-    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+    let package = manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
     assert_fiducial_gerbers(&package, "Global");
 }
 
@@ -1339,7 +1420,7 @@ fn board_array_creation_adds_board_cell_fiducials_on_top_bottom_margins() {
         8
     );
 
-    let package = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+    let package = manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
     assert_fiducial_gerbers(&package, "Local");
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -270,6 +270,7 @@ fn board_array_balancing_solves_every_copper_layer() {
                 .result
                 .usable
                 .intersection(&layer.existing_copper)
+                .unwrap()
                 .is_empty()
         );
         assert_eq!(layer.result.solution.target_density, layer.target_density);
@@ -1064,12 +1065,15 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
         .difference(&balance_paths(
             pcb_ir::dialects::ipc::CopperBalanceKind::FullVoid,
         ))
+        .unwrap()
         .difference(&balance_paths(
             pcb_ir::dialects::ipc::CopperBalanceKind::EdgeVoid,
         ))
+        .unwrap()
         .union(&balance_paths(
             pcb_ir::dialects::ipc::CopperBalanceKind::BoundaryWeb,
-        ));
+        ))
+        .unwrap();
 
     assert!(!round_trip.is_empty());
     assert!(
@@ -1129,7 +1133,8 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
             );
         }
     }
-    let gerber_copper = ContourSet::from_rings(rings, pcb_ir::geom::FillRule::NonZero, resolution);
+    let gerber_copper =
+        ContourSet::from_rings(rings, pcb_ir::geom::FillRule::NonZero, resolution).unwrap();
     assert!(
         (gerber_copper.area() - ipc_copper.area()).abs() <= ipc_copper.area() * 1e-3,
         "Gerber area {}, IPC area {}",

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -201,7 +201,7 @@ fn generated_board_array_has_a_certified_safe_balancing_region() {
         resolution,
     )
     .unwrap();
-    let input = collection.input_for_layer(copper_layers[0].name);
+    let input = collection.input_for_layer(copper_layers[0].name).unwrap();
     let result = board_array_balancing_region(&input, BalancingRegionOptions::default()).unwrap();
 
     assert!(collection.board_instance_count > 0);
@@ -392,7 +392,7 @@ fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_laye
             .iter()
             .find(|layer| provisional.resolve(layer.name) == name)
             .unwrap();
-        let input = collection.input_for_layer(layer.name);
+        let input = collection.input_for_layer(layer.name).unwrap();
         input.support_features.area()
     };
 

--- a/crates/pcb-ipc2581-tools/src/commands/cpl.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/cpl.rs
@@ -15,9 +15,9 @@ use pcb_ir::dialects::placement::{
 };
 
 #[cfg(feature = "cli")]
-use crate::accessors::IpcAccessor;
-#[cfg(feature = "cli")]
 use crate::placement::extract_single_board_placements;
+#[cfg(feature = "cli")]
+use pcb_ir::import::ipc2581::import_design;
 
 #[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
@@ -39,8 +39,7 @@ pub struct CplOptions {
 #[cfg(feature = "cli")]
 pub fn execute(file: &Path, options: &CplOptions) -> Result<()> {
     let ipc = Ipc2581::parse_file(file)?;
-    let accessor = IpcAccessor::new(&ipc);
-    let placements = extract_single_board_placements(&accessor)?;
+    let placements = extract_single_board_placements(&import_design(&ipc)?)?;
     let cpl = emit_cpl_csv(&placements, options);
 
     if let Some(output) = &options.output {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -1,5 +1,6 @@
 //! PDK-driven manufacturability checks for IPC-2581 geometry.
 
+use pcb_ir::geom::Resolution;
 #[cfg(feature = "cli")]
 use std::{
     io::Write,
@@ -74,7 +75,11 @@ pub fn builtin_pdks() -> &'static [BuiltinPdk] {
 ///
 /// Manufacturing violations are successful results with a `fail` verdict;
 /// only invalid inputs or geometry that cannot be checked return an error.
-pub fn check(imported: &ImportedDesign, request: CheckRequest<'_>) -> Result<DfmReport> {
+pub fn check(
+    imported: &ImportedDesign,
+    request: CheckRequest<'_>,
+    resolution: Resolution,
+) -> Result<DfmReport> {
     let (pdk_path, pdk_source, selected_profile) = match request.pdk {
         PdkSource::Builtin(name) => {
             let pdk = builtin_pdks::find(name)
@@ -106,13 +111,18 @@ pub fn check(imported: &ImportedDesign, request: CheckRequest<'_>) -> Result<Dfm
         })
         .transpose()?;
 
-    let design = design::Design::extract(imported, request.layout_target.artwork_scope(), &rules)?;
+    let design = design::Design::extract(
+        imported,
+        request.layout_target.artwork_scope(),
+        &rules,
+        resolution,
+    )?;
     let checked = checks::run(
         &rules,
         &design,
         waivers.as_ref(),
         request.generated_at.date_naive(),
-    );
+    )?;
     let summary = summarize(&checked);
     let layout = design.report_layout();
     let scene = scene::export(&design, &layout, &checked.rules, &checked.findings)?;
@@ -226,9 +236,13 @@ pub fn validate_output(file: &Path, options: &CheckOptions) -> Result<()> {
 }
 
 #[cfg(feature = "cli")]
-pub fn execute_check(file: &Path, options: &CheckOptions) -> Result<CheckOutcome> {
+pub fn execute_check(
+    file: &Path,
+    options: &CheckOptions,
+    resolution: Resolution,
+) -> Result<CheckOutcome> {
     validate_output(file, options)?;
-    let report = match build_report(file, options) {
+    let report = match build_report(file, options, resolution) {
         Ok(checked) => checked,
         Err(error) => {
             write_error_report(file, options, &error)
@@ -283,7 +297,7 @@ pub fn write_error_report(
 }
 
 #[cfg(feature = "cli")]
-fn build_report(file: &Path, options: &CheckOptions) -> Result<DfmReport> {
+fn build_report(file: &Path, options: &CheckOptions, resolution: Resolution) -> Result<DfmReport> {
     let input_bytes = std::fs::read(file)
         .with_context(|| format!("failed to read IPC-2581 file {}", file.display()))?;
     let input = report::FileIdentity::new(file.display().to_string(), &input_bytes);
@@ -330,6 +344,7 @@ fn build_report(file: &Path, options: &CheckOptions) -> Result<DfmReport> {
             layout_target: options.layout_target,
             generated_at,
         },
+        resolution,
     )
 }
 
@@ -522,6 +537,8 @@ limit = { minimum = "300 mil" }
     }
 
     fn check_with_pdk(xml: &str, target: LayoutTarget, pdk_source: &str) -> DfmReport {
+        let resolution = Resolution::default();
+
         let ipc = Ipc2581::parse(xml).unwrap();
         let imported = import_design(&ipc).unwrap();
         super::check(
@@ -536,6 +553,7 @@ limit = { minimum = "300 mil" }
                 layout_target: target,
                 generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
             },
+            resolution,
         )
         .unwrap()
     }
@@ -796,6 +814,8 @@ limit = { minimum = "300 mil" }
 
     #[test]
     fn in_memory_report_keeps_source_identity_and_waiver_dates() {
+        let resolution = Resolution::default();
+
         let imported = import_design(&Ipc2581::parse(BOARD).unwrap()).unwrap();
         let pdk_source = PDK.replace("minimum = 2", "minimum = 3");
         let run = |waivers, day| {
@@ -815,6 +835,7 @@ limit = { minimum = "300 mil" }
                         .unwrap()
                         .and_utc(),
                 },
+                resolution,
             )
             .unwrap()
         };
@@ -869,6 +890,8 @@ reason = "old finding"
     #[cfg(feature = "cli")]
     #[test]
     fn cli_report_matches_in_memory_report_for_compressed_input() {
+        let resolution = Resolution::default();
+
         let directory = tempfile::tempdir().unwrap();
         let input = directory.path().join("board.xml.zst");
         let pdk = directory.path().join("custom.toml");
@@ -885,6 +908,7 @@ reason = "old finding"
                 output: Some(output.clone()),
                 layout_target: LayoutTarget::Board,
             },
+            resolution,
         )
         .unwrap();
         let CheckOutcome::Failed(error) = outcome else {
@@ -906,6 +930,8 @@ reason = "old finding"
 
     #[test]
     fn rejects_oversize_pdk_source() {
+        let resolution = Resolution::default();
+
         let imported = import_design(&Ipc2581::parse(BOARD).unwrap()).unwrap();
         let source = " ".repeat(MAX_PDK_BYTES + 1);
         let error = super::check(
@@ -920,6 +946,7 @@ reason = "old finding"
                 layout_target: LayoutTarget::Board,
                 generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
             },
+            resolution,
         )
         .unwrap_err();
 
@@ -1040,6 +1067,8 @@ reason = "old finding"
 
     #[test]
     fn profile_support_rejects_an_incomplete_physical_stackup() {
+        let resolution = Resolution::default();
+
         let ipc = Ipc2581::parse(&BOARD.replace(
             "layerOrGroupRef=\"BOTTOM\"",
             "layerOrGroupRef=\"DIELECTRIC\"",
@@ -1049,7 +1078,7 @@ reason = "old finding"
         let rules = rules::lower(&pdk, None).unwrap();
         let imported = import_design(&ipc).unwrap();
 
-        let error = design::Design::extract(&imported, ArtworkScope::Board, &rules)
+        let error = design::Design::extract(&imported, ArtworkScope::Board, &rules, resolution)
             .err()
             .unwrap();
 
@@ -1062,6 +1091,8 @@ reason = "old finding"
 
     #[test]
     fn one_evaluator_scales_through_board_array_and_fab_panel_lowering() {
+        let resolution = Resolution::default();
+
         let array = create_board_array(
             BOARD,
             &BoardArrayCreateOptions {
@@ -1071,6 +1102,7 @@ reason = "old finding"
                 edge_rail_mm: EdgeInsetsMm::all(5.0),
             },
             false,
+            resolution,
         )
         .unwrap()
         .xml;
@@ -1079,6 +1111,7 @@ reason = "old finding"
             &[0, 0],
             FabPanelSpec::default(),
             false,
+            resolution,
         )
         .unwrap()
         .xml;

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -33,7 +33,6 @@
 //! boundaries cannot violate.
 
 use pcb_ir::geom::dfm::{BBoxIndex, Distance, circular_region};
-use pcb_ir::geom::region::difference_rings;
 use pcb_ir::geom::{BBox, ContourSet, FillRule, Point};
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
@@ -59,7 +58,7 @@ pub(super) fn evaluate(
     class: HoleClass,
     conditions: &Conditions,
     design: &Design,
-) -> Evaluation {
+) -> anyhow::Result<Evaluation> {
     let holes = holes_of_class(design, class);
     let copper_layers = &design.copper_layers;
     let hole_lands = &design.hole_lands;
@@ -141,10 +140,10 @@ pub(super) fn evaluate(
                     measured(design, hole, subject, enclosure, radius + limit_mm)
                 });
             if let Some(worst) = &mut worst {
-                worst.sites = enclosures.iter().filter_map(|(subject, enclosure)| {
-                    let enclosure = (*enclosure).filter(|distance| violates(distance, limit_mm))?;
+                worst.sites = enclosures.iter().map(|(subject, enclosure)| {
+                    let Some(enclosure) = (*enclosure).filter(|distance| violates(distance, limit_mm)) else { return Ok(None); };
                     let mut detail = measured(design, hole, subject, enclosure, radius + limit_mm);
-                    let required = circular_region(hole.center, radius + limit_mm);
+                    let required = circular_region(hole.center, radius + limit_mm, design.resolution)?;
                     detail.evidence.push(Evidence {
                         display: Some(EvidenceDisplay::CircleMinusLayer {
                             center: hole.center.into(),
@@ -165,20 +164,19 @@ pub(super) fn evaluate(
                     } else if enclosure.mm < 0.0 {
                         site.note = Some("The drilled hole breaches the copper boundary; the annular enclosure is signed.".to_owned());
                     }
-                    Some(site)
-                }).collect();
+                    Ok::<_, anyhow::Error>(Some(site))
+                }).collect::<anyhow::Result<Vec<_>>>()?.into_iter().flatten().collect();
             }
-            (enclosures.len(), worst)
-        })
-        .collect::<Vec<_>>();
+            Ok::<_, anyhow::Error>((enclosures.len(), worst))
+        }).collect::<anyhow::Result<Vec<_>>>()?;
 
-    Evaluation {
+    Ok(Evaluation {
         checked: per_hole.iter().map(|(checked, _)| checked).sum(),
         measured: per_hole
             .into_iter()
             .filter_map(|(_, measured)| measured)
             .collect(),
-    }
+    })
 }
 
 /// A ring whose bounds miss the required disk cannot change material inside
@@ -191,11 +189,11 @@ fn missing_copper(required: &ContourSet, copper: &ContourSet, index: &BBoxIndex)
         .into_iter()
         .map(|id| copper.rings[id].clone())
         .collect();
-    ContourSet::new(
-        difference_rings(required.rings.clone(), rings),
+    required.difference(&ContourSet::from_rings(
+        rings,
         FillRule::NonZero,
-        required.tolerance,
-    )
+        required.resolution,
+    ))
 }
 
 fn measured(
@@ -258,6 +256,7 @@ fn measured(
 #[cfg(test)]
 mod tests {
     use pcb_ir::dialects::ipc::ArtworkScope;
+    use pcb_ir::geom::Resolution;
 
     use crate::commands::dfm::pdk::Pdk;
     use crate::commands::dfm::rules::{self, Rule};
@@ -355,14 +354,20 @@ limit = { minimum = "0.2 mm" }
     fn evaluate_pth(ipc: &Ipc2581) -> Evaluation {
         let rule = rule();
         let imported = pcb_ir::import::ipc2581::import_design(ipc).unwrap();
-        let design =
-            Design::extract(&imported, ArtworkScope::Board, std::slice::from_ref(&rule)).unwrap();
+        let design = Design::extract(
+            &imported,
+            ArtworkScope::Board,
+            std::slice::from_ref(&rule),
+            Resolution::default(),
+        )
+        .unwrap();
         evaluate(
             rule.limit.length().millimeters(),
             HoleClass::Pth,
             &rule.conditions,
             &design,
         )
+        .unwrap()
     }
 
     #[test]
@@ -419,7 +424,7 @@ limit = { minimum = "0.2 mm" }
         let middle = imported.layer_id("L1").unwrap();
         assert!(
             imported
-                .physical_lands(ArtworkScope::Board)
+                .physical_lands(ArtworkScope::Board, Resolution::default())
                 .unwrap()
                 .iter()
                 .all(|land| land.layer != middle),
@@ -537,21 +542,22 @@ limit = { minimum = "0.2 mm" }
 
     #[test]
     fn local_missing_copper_keeps_enclosing_planes_holes_and_repainted_islands() {
-        use pcb_ir::geom::tol;
+        let resolution = Resolution::default();
+
         let rectangle = |x0, y0, x1, y1| {
             ContourSet::rectangle(
                 BBox {
                     min: Point::new(x0, y0),
                     max: Point::new(x1, y1),
                 },
-                tol::REGION_MM,
+                resolution,
             )
         };
         let copper = rectangle(-100.0, -100.0, 100.0, 100.0)
             .difference(&rectangle(-0.4, -0.4, 0.4, 0.4))
             .union(&rectangle(-0.1, -0.1, 0.1, 0.1))
             .union(&rectangle(200.0, 200.0, 201.0, 201.0));
-        let required = circular_region(Point::ZERO, 0.6);
+        let required = circular_region(Point::ZERO, 0.6, resolution).unwrap();
         let bounds = copper
             .rings
             .iter()

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -152,7 +152,7 @@ pub(super) fn evaluate(
                         }),
                         ..Evidence::region("missing_copper", &missing_copper(
                             &required, &subject.copper.image, subject.ring_index,
-                        ))
+                        )?)
                     });
                     let mut site = MeasuredSite::new(
                         enclosure, detail.bbox, detail.layers, detail.evidence,
@@ -183,17 +183,21 @@ pub(super) fn evaluate(
 /// it. Retaining complete intersecting rings (including enclosing planes and
 /// their holes) preserves polarity while avoiding a full-panel boolean for
 /// each individual annular finding.
-fn missing_copper(required: &ContourSet, copper: &ContourSet, index: &BBoxIndex) -> ContourSet {
+fn missing_copper(
+    required: &ContourSet,
+    copper: &ContourSet,
+    index: &BBoxIndex,
+) -> anyhow::Result<ContourSet> {
     let rings = index
         .query(required.bbox)
         .into_iter()
         .map(|id| copper.rings[id].clone())
         .collect();
-    required.difference(&ContourSet::from_rings(
+    Ok(required.difference(&ContourSet::from_rings(
         rings,
         FillRule::NonZero,
         required.resolution,
-    ))
+    )?)?)
 }
 
 fn measured(
@@ -555,8 +559,11 @@ limit = { minimum = "0.2 mm" }
         };
         let copper = rectangle(-100.0, -100.0, 100.0, 100.0)
             .difference(&rectangle(-0.4, -0.4, 0.4, 0.4))
+            .unwrap()
             .union(&rectangle(-0.1, -0.1, 0.1, 0.1))
-            .union(&rectangle(200.0, 200.0, 201.0, 201.0));
+            .unwrap()
+            .union(&rectangle(200.0, 200.0, 201.0, 201.0))
+            .unwrap();
         let required = circular_region(Point::ZERO, 0.6, resolution).unwrap();
         let bounds = copper
             .rings
@@ -570,10 +577,10 @@ limit = { minimum = "0.2 mm" }
             .collect();
         let index = BBoxIndex::new(bounds);
         assert!(index.query(required.bbox).len() < copper.rings.len());
-        let local = missing_copper(&required, &copper, &index);
-        let complete = required.difference(&copper);
-        assert!(local.difference(&complete).is_empty());
-        assert!(complete.difference(&local).is_empty());
+        let local = missing_copper(&required, &copper, &index).unwrap();
+        let complete = required.difference(&copper).unwrap();
+        assert!(local.difference(&complete).unwrap().is_empty());
+        assert!(complete.difference(&local).unwrap().is_empty());
         assert!(
             !local.contains_point(Point::ZERO),
             "repainted island supplies copper"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
@@ -30,7 +30,7 @@ use crate::commands::dfm::report::{Evidence, SourceLocator, Subject};
 
 use super::{Evaluation, Measured, linework_clearance, violates};
 
-pub(super) fn evaluate(limit_mm: f64, design: &Design) -> Evaluation {
+pub(super) fn evaluate(limit_mm: f64, design: &Design) -> anyhow::Result<Evaluation> {
     let arrays = &design.board_arrays;
     let pairs = arrays.iter().enumerate().flat_map(|(index, first)| {
         arrays[index + 1..]
@@ -51,7 +51,7 @@ pub(super) fn evaluate(limit_mm: f64, design: &Design) -> Evaluation {
         .map(|(first, second)| {
             let distance = region_clearance(&first.region, &second.region)
                 .expect("board arrays are extracted with non-empty profiles");
-            Measured {
+            Ok::<_, anyhow::Error>(Measured {
                 distance,
                 bbox: first.region.bbox.union(second.region.bbox),
                 layers: Vec::new(),
@@ -66,18 +66,29 @@ pub(super) fn evaluate(limit_mm: f64, design: &Design) -> Evaluation {
                 sites: if violates(&distance, limit_mm) {
                     region_clearance_sites(&first.region, &second.region, limit_mm)
                         .into_iter()
-                        .map(|site| linework_clearance::report_site(site, Vec::new(), limit_mm))
+                        .map(|site| {
+                            linework_clearance::report_site(
+                                site,
+                                Vec::new(),
+                                limit_mm,
+                                design.resolution,
+                            )
+                        })
+                        .collect::<anyhow::Result<Vec<_>>>()?
+                        .into_iter()
                         .collect()
                 } else {
                     Vec::new()
                 },
-            }
+            })
         })
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
         .collect();
-    Evaluation {
+    Ok(Evaluation {
         checked: pairs.count(),
         measured,
-    }
+    })
 }
 
 fn board_array_subject(array: &BoardArray, role: &'static str) -> Subject {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/board_array_spacing.rs
@@ -64,7 +64,7 @@ pub(super) fn evaluate(limit_mm: f64, design: &Design) -> anyhow::Result<Evaluat
                     Evidence::bounds("second_board_array", second.region.bbox),
                 ],
                 sites: if violates(&distance, limit_mm) {
-                    region_clearance_sites(&first.region, &second.region, limit_mm)
+                    region_clearance_sites(&first.region, &second.region, limit_mm)?
                         .into_iter()
                         .map(|site| {
                             linework_clearance::report_site(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -121,7 +121,7 @@ pub(super) fn evaluate(
                         &right.region,
                         right_boundary,
                         limit_mm,
-                    )
+                    )?
                     .into_iter()
                     .map(|site| {
                         linework_clearance::report_site(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -21,7 +21,11 @@ struct Piece {
     region: pcb_ir::geom::ContourSet,
 }
 
-pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) -> Evaluation {
+pub(super) fn evaluate(
+    limit_mm: f64,
+    conditions: &Conditions,
+    design: &Design,
+) -> anyhow::Result<Evaluation> {
     let mut checked = 0;
     let mut measured = Vec::new();
 
@@ -120,8 +124,15 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
                     )
                     .into_iter()
                     .map(|site| {
-                        linework_clearance::report_site(site, vec![layer.layer.clone()], limit_mm)
+                        linework_clearance::report_site(
+                            site,
+                            vec![layer.layer.clone()],
+                            limit_mm,
+                            design.resolution,
+                        )
                     })
+                    .collect::<anyhow::Result<Vec<_>>>()?
+                    .into_iter()
                     .collect()
                 } else {
                     Vec::new()
@@ -130,7 +141,7 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
         }
     }
 
-    Evaluation { checked, measured }
+    Ok(Evaluation { checked, measured })
 }
 
 pub(super) fn conductor_subject(
@@ -198,6 +209,7 @@ pub(super) fn conductor_subject(
 
 #[cfg(test)]
 mod tests {
+    use pcb_ir::geom::Resolution;
     use std::collections::BTreeSet;
 
     use chrono::NaiveDate;
@@ -283,13 +295,20 @@ limit = { minimum = "0.15 mm" }
         let pdk = Pdk::parse(PDK).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
         let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-        let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+        let design = Design::extract(
+            &imported,
+            ArtworkScope::Board,
+            &rules,
+            Resolution::default(),
+        )
+        .unwrap();
         checks::run(
             &rules,
             &design,
             None,
             NaiveDate::from_ymd_opt(2026, 8, 25).unwrap(),
         )
+        .unwrap()
     }
 
     #[test]
@@ -334,13 +353,15 @@ limit = { minimum = "0.15 mm" }
 
     #[test]
     fn rejects_surviving_functional_copper_without_net_ownership() {
+        let resolution = Resolution::default();
+
         let xml = BOARD.replace("<Set net=\"N2\">", "<Set>");
         let ipc = Ipc2581::parse(&xml).unwrap();
         let pdk = Pdk::parse(PDK).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
         let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
 
-        let error = Design::extract(&imported, ArtworkScope::Board, &rules)
+        let error = Design::extract(&imported, ArtworkScope::Board, &rules, resolution)
             .err()
             .expect("unattributed copper must fail closed");
         assert!(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/drilled_board_edge_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/drilled_board_edge_clearance.rs
@@ -21,7 +21,11 @@ use super::{
     slot_subject,
 };
 
-pub(super) fn evaluate_holes(limit_mm: f64, class: HoleClass, design: &Design) -> Evaluation {
+pub(super) fn evaluate_holes(
+    limit_mm: f64,
+    class: HoleClass,
+    design: &Design,
+) -> anyhow::Result<Evaluation> {
     let holes = design
         .holes
         .iter()
@@ -29,25 +33,34 @@ pub(super) fn evaluate_holes(limit_mm: f64, class: HoleClass, design: &Design) -
         .collect::<Vec<_>>();
     let measured = holes
         .iter()
-        .filter_map(|&hole| {
+        .map(|&hole| {
             let outline = enclosing_outline(
                 &design.board_outlines,
                 hole.provenance.instance_index,
                 hole.center,
             );
-            let (distance, outside) = hole_clearance(hole, outline, limit_mm)?;
-            Some(measured_hole(
+            let Some((distance, outside)) = hole_clearance(hole, outline, limit_mm) else {
+                return Ok(None);
+            };
+            Ok::<_, anyhow::Error>(Some(measured_hole(
                 design, hole, outline, distance, outside, limit_mm,
-            ))
+            )?))
         })
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
         .collect();
-    Evaluation {
+    Ok(Evaluation {
         checked: holes.len(),
         measured,
-    }
+    })
 }
 
-pub(super) fn evaluate_slots(limit_mm: f64, plating: SlotPlating, design: &Design) -> Evaluation {
+pub(super) fn evaluate_slots(
+    limit_mm: f64,
+    plating: SlotPlating,
+    design: &Design,
+) -> anyhow::Result<Evaluation> {
     let slots = design
         .slots
         .iter()
@@ -55,22 +68,27 @@ pub(super) fn evaluate_slots(limit_mm: f64, plating: SlotPlating, design: &Desig
         .collect::<Vec<_>>();
     let measured = slots
         .iter()
-        .filter_map(|&slot| {
+        .map(|&slot| {
             let outline = enclosing_outline(
                 &design.board_outlines,
                 slot.provenance.instance_index,
                 slot.bbox.center(),
             );
-            let (distance, outside) = slot_clearance(slot, outline, limit_mm)?;
-            Some(measured_slot(
+            let Some((distance, outside)) = slot_clearance(slot, outline, limit_mm) else {
+                return Ok(None);
+            };
+            Ok::<_, anyhow::Error>(Some(measured_slot(
                 design, slot, outline, distance, outside, limit_mm,
-            ))
+            )?))
         })
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
         .collect();
-    Evaluation {
+    Ok(Evaluation {
         checked: slots.len(),
         measured,
-    }
+    })
 }
 
 /// Select only among profiles carrying the feature's occurrence identity.
@@ -120,7 +138,10 @@ fn hole_clearance(
             .circular_enclosure(hole.center, hole.diameter_mm / 2.0, limit_mm)?;
     if distance.mm <= 0.0 {
         Some((
-            Distance::flattened(0.0, distance.first, distance.second, 1),
+            Distance {
+                mm: 0.0,
+                ..distance
+            },
             true,
         ))
     } else {
@@ -138,11 +159,11 @@ fn zero_hole_clearance(hole: &Hole, outline: &BoardOutline, search_mm: f64) -> D
     } else {
         radial / radial.length()
     };
-    Distance::flattened(
+    Distance::with_uncertainty(
         0.0,
         hole.center + direction * (hole.diameter_mm / 2.0),
         nearest.second,
-        1,
+        nearest.uncertainty_mm,
     )
 }
 
@@ -172,10 +193,13 @@ fn slot_clearance(
                 .segment_nearest_within(start, end, search_mm)
         })
         .min_by(|left, right| left.mm.total_cmp(&right.mm))?
-        .also_flattened(1);
+        .also_uncertain(slot.outline.uncertainty_mm);
     if outside {
         Some((
-            Distance::flattened(0.0, distance.first, distance.second, 2),
+            Distance {
+                mm: 0.0,
+                ..distance
+            },
             true,
         ))
     } else {
@@ -195,7 +219,7 @@ fn measured_hole(
     distance: Distance,
     outside: bool,
     limit_mm: f64,
-) -> Measured {
+) -> anyhow::Result<Measured> {
     let feature = Evidence::circle("drilled_hole", hole.center, hole.diameter_mm);
     let mut evidence = vec![feature.clone()];
     let mut site_evidence = vec![
@@ -213,7 +237,8 @@ fn measured_hole(
         site_evidence.push(profile_evidence(outline));
         if outside {
             let outside_region =
-                circular_region(hole.center, hole.diameter_mm / 2.0).difference(&outline.region);
+                circular_region(hole.center, hole.diameter_mm / 2.0, design.resolution)?
+                    .difference(&outline.region);
             if !outside_region.is_empty() {
                 site_evidence.push(Evidence::region("outside_board_material", &outside_region));
             }
@@ -233,14 +258,14 @@ fn measured_hole(
     if outside {
         site.note = Some(outside_note(outline.is_some()));
     }
-    Measured {
+    Ok(Measured {
         distance,
         bbox: hole.bbox,
         layers: vec![hole.layer.clone()],
         subjects,
         evidence,
         sites: vec![site],
-    }
+    })
 }
 
 fn measured_slot(
@@ -250,11 +275,11 @@ fn measured_slot(
     distance: Distance,
     outside: bool,
     limit_mm: f64,
-) -> Measured {
+) -> anyhow::Result<Measured> {
     let feature = slot_evidence(slot);
     let mut evidence = vec![Evidence::bounds("routed_slot", slot.bbox)];
     let mut site_evidence = vec![feature];
-    let clearance_region = slot.outline.disk_dilate(limit_mm);
+    let clearance_region = slot.outline.disk_dilate(limit_mm)?;
     site_evidence.push(Evidence::region(
         "required_board_edge_clearance",
         &clearance_region,
@@ -285,14 +310,14 @@ fn measured_slot(
     if outside {
         site.note = Some(outside_note(outline.is_some()));
     }
-    Measured {
+    Ok(Measured {
         distance,
         bbox: slot.bbox,
         layers: vec![slot.layer.clone()],
         subjects,
         evidence,
         sites: vec![site],
-    }
+    })
 }
 
 pub(super) fn slot_evidence(slot: &Slot) -> Evidence {
@@ -342,6 +367,7 @@ mod tests {
     use crate::commands::dfm::report::{Measurement, RuleStatus, Verdict};
     use crate::commands::dfm::{CheckRequest, PdkSource, TextSource};
     use crate::ipc2581::Ipc2581;
+    use pcb_ir::geom::Resolution;
     use pcb_ir::import::ipc2581::import_design;
 
     fn pdk(rules: &str) -> String {
@@ -383,6 +409,8 @@ name = "Test"
     }
 
     fn check(xml: &str, pdk_source: &str, target: LayoutTarget) -> super::super::super::DfmReport {
+        let resolution = Resolution::default();
+
         let imported = import_design(&Ipc2581::parse(xml).unwrap()).unwrap();
         super::super::super::check(
             &imported,
@@ -399,6 +427,7 @@ name = "Test"
                 layout_target: target,
                 generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
             },
+            resolution,
         )
         .unwrap()
     }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/drilled_board_edge_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/drilled_board_edge_clearance.rs
@@ -74,7 +74,7 @@ pub(super) fn evaluate_slots(
                 slot.provenance.instance_index,
                 slot.bbox.center(),
             );
-            let Some((distance, outside)) = slot_clearance(slot, outline, limit_mm) else {
+            let Some((distance, outside)) = slot_clearance(slot, outline, limit_mm)? else {
                 return Ok(None);
             };
             Ok::<_, anyhow::Error>(Some(measured_slot(
@@ -171,12 +171,12 @@ fn slot_clearance(
     slot: &Slot,
     outline: Option<&BoardOutline>,
     limit_mm: f64,
-) -> Option<(Distance, bool)> {
+) -> anyhow::Result<Option<(Distance, bool)>> {
     let Some(outline) = outline else {
         let point = slot.bbox.center();
-        return Some((Distance::exact(0.0, point, point), true));
+        return Ok(Some((Distance::exact(0.0, point, point), true)));
     };
-    let outside = !slot.outline.difference(&outline.region).is_empty();
+    let outside = !slot.outline.difference(&outline.region)?.is_empty();
     let search_mm = if outside {
         broad_search(slot.bbox, outline.bbox)
     } else {
@@ -192,19 +192,22 @@ fn slot_clearance(
                 .boundary
                 .segment_nearest_within(start, end, search_mm)
         })
-        .min_by(|left, right| left.mm.total_cmp(&right.mm))?
-        .also_uncertain(slot.outline.uncertainty_mm);
-    if outside {
-        Some((
+        .min_by(|left, right| left.mm.total_cmp(&right.mm))
+        .map(|distance| distance.also_uncertain(slot.outline.uncertainty_mm));
+    let Some(distance) = distance else {
+        return Ok(None);
+    };
+    Ok(Some(if outside {
+        (
             Distance {
                 mm: 0.0,
                 ..distance
             },
             true,
-        ))
+        )
     } else {
-        Some((distance, false))
-    }
+        (distance, false)
+    }))
 }
 
 fn broad_search(feature: BBox, outline: BBox) -> f64 {
@@ -238,7 +241,7 @@ fn measured_hole(
         if outside {
             let outside_region =
                 circular_region(hole.center, hole.diameter_mm / 2.0, design.resolution)?
-                    .difference(&outline.region);
+                    .difference(&outline.region)?;
             if !outside_region.is_empty() {
                 site_evidence.push(Evidence::region("outside_board_material", &outside_region));
             }
@@ -290,7 +293,7 @@ fn measured_slot(
         evidence.push(Evidence::bounds("board_profile", outline.bbox));
         site_evidence.push(profile_evidence(outline));
         if outside {
-            let outside_region = slot.outline.difference(&outline.region);
+            let outside_region = slot.outline.difference(&outline.region)?;
             if !outside_region.is_empty() {
                 site_evidence.push(Evidence::region("outside_board_material", &outside_region));
             }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
@@ -117,6 +117,8 @@ fn incomplete(
 
 #[cfg(test)]
 mod tests {
+    use pcb_ir::geom::Resolution;
+
     use crate::LayoutTarget;
     use crate::commands::dfm::{
         CheckRequest, PdkSource, TextSource, check,
@@ -206,6 +208,8 @@ cases = [
 "#;
 
     fn run(xml: &str, pdk: &str) -> DfmReport {
+        let resolution = Resolution::default();
+
         let ipc = Ipc2581::parse(xml).unwrap();
         let imported = import_design(&ipc).unwrap();
         check(
@@ -220,6 +224,7 @@ cases = [
                 layout_target: LayoutTarget::Board,
                 generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
             },
+            resolution,
         )
         .unwrap()
     }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -27,7 +27,7 @@ pub(super) fn evaluate(
     class: HoleClass,
     conditions: &Conditions,
     design: &Design,
-) -> Evaluation {
+) -> anyhow::Result<Evaluation> {
     let mut checked = 0;
     let mut measured = Vec::new();
 
@@ -74,7 +74,7 @@ pub(super) fn evaluate(
                 Evidence::bounds("offending_copper", offender.image.bbox),
             ];
             let sites = if violates(&distance, limit_mm) {
-                let drill = circular_region(hole.center, radius_mm);
+                let drill = circular_region(hole.center, radius_mm, design.resolution)?;
                 let mut sites = region_clearance_sites(&drill, &offender.image, limit_mm)
                     .into_iter()
                     .map(|geometry| {
@@ -82,7 +82,8 @@ pub(super) fn evaluate(
                             geometry,
                             finding_layers.clone(),
                             limit_mm,
-                        );
+                            design.resolution,
+                        )?;
                         site.subjects = subjects.clone();
                         site.evidence.push(Evidence::circle(
                             "drilled_hole",
@@ -94,8 +95,10 @@ pub(super) fn evaluate(
                             hole.center,
                             hole.diameter_mm + 2.0 * limit_mm,
                         ));
-                        site
+                        Ok::<_, anyhow::Error>(site)
                     })
+                    .collect::<anyhow::Result<Vec<_>>>()?
+                    .into_iter()
                     .collect::<Vec<_>>();
                 if !sites.iter().any(|site| violates(&site.distance, limit_mm)) {
                     sites.push(fallback_site(
@@ -123,7 +126,7 @@ pub(super) fn evaluate(
         }
     }
 
-    Evaluation { checked, measured }
+    Ok(Evaluation { checked, measured })
 }
 
 fn disk_to_copper_clearance(
@@ -134,7 +137,12 @@ fn disk_to_copper_clearance(
     limit_mm: f64,
 ) -> Option<Distance> {
     if copper.contains_point(center) {
-        return Some(Distance::flattened(0.0, center, center, 1));
+        return Some(Distance::with_uncertainty(
+            0.0,
+            center,
+            center,
+            copper.uncertainty_mm,
+        ));
     }
     let nearest = boundary.nearest_within(center, radius_mm + limit_mm)?;
     let direction = nearest.second - center;
@@ -146,13 +154,18 @@ fn disk_to_copper_clearance(
     if nearest.mm <= radius_mm {
         // The copper boundary lies inside the drill disk, so this point is
         // shared by both closed regions even when neither center is contained.
-        return Some(Distance::flattened(0.0, nearest.second, nearest.second, 1));
+        return Some(Distance::with_uncertainty(
+            0.0,
+            nearest.second,
+            nearest.second,
+            nearest.uncertainty_mm,
+        ));
     }
-    Some(Distance::flattened(
+    Some(Distance::with_uncertainty(
         nearest.mm - radius_mm,
         center + direction * radius_mm,
         nearest.second,
-        1,
+        nearest.uncertainty_mm,
     ))
 }
 
@@ -230,6 +243,7 @@ fn fallback_site(
 mod tests {
     use chrono::NaiveDate;
     use pcb_ir::dialects::ipc::ArtworkScope;
+    use pcb_ir::geom::Resolution;
 
     use crate::commands::dfm::{checks, design::Design, pdk::Pdk, rules};
     use crate::ipc2581::Ipc2581;
@@ -350,13 +364,20 @@ limit = {{ minimum = "0.20 mm" }}
         let pdk = Pdk::parse(&pdk(hole)).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
         let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-        let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+        let design = Design::extract(
+            &imported,
+            ArtworkScope::Board,
+            &rules,
+            Resolution::default(),
+        )
+        .unwrap();
         checks::run(
             &rules,
             &design,
             None,
             NaiveDate::from_ymd_opt(2026, 9, 1).unwrap(),
         )
+        .unwrap()
     }
 
     #[test]
@@ -390,6 +411,8 @@ limit = {{ minimum = "0.20 mm" }}
 
     #[test]
     fn hole_clearance_report_includes_spatial_view_and_native_context() {
+        let resolution = Resolution::default();
+
         use crate::LayoutTarget;
         use crate::commands::dfm::{CheckRequest, PdkSource, TextSource, report};
 
@@ -409,6 +432,7 @@ limit = {{ minimum = "0.20 mm" }}
                 layout_target: LayoutTarget::Board,
                 generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
             },
+            resolution,
         )
         .unwrap();
 
@@ -528,12 +552,14 @@ limit = {{ minimum = "0.20 mm" }}
 
     #[test]
     fn rejects_a_hole_without_a_resolvable_drill_span() {
+        let resolution = Resolution::default();
+
         let xml = board("VIA", None, &[copper(0, Some("N2"), 0.8)]);
         let ipc = Ipc2581::parse(&xml).unwrap();
         let pdk = Pdk::parse(&pdk("via")).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
         let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-        let error = Design::extract(&imported, ArtworkScope::Board, &rules)
+        let error = Design::extract(&imported, ArtworkScope::Board, &rules, resolution)
             .err()
             .expect("an unknown span must fail closed");
         assert!(error.to_string().contains("no resolvable drill span"));
@@ -563,7 +589,13 @@ limit = {{ minimum = "0.20 mm" }}
                 let pdk = Pdk::parse(&pdk("via")).unwrap();
                 let rules = rules::lower(&pdk, None).unwrap();
                 let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-                let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+                let design = Design::extract(
+                    &imported,
+                    ArtworkScope::Board,
+                    &rules,
+                    Resolution::default(),
+                )
+                .unwrap();
                 let mut included = design
                     .copper_layers
                     .iter()
@@ -578,7 +610,8 @@ limit = {{ minimum = "0.20 mm" }}
                     &design,
                     None,
                     NaiveDate::from_ymd_opt(2026, 9, 1).unwrap(),
-                );
+                )
+                .unwrap();
                 assert_eq!(results.rules[0].checked, 2);
                 assert_eq!(
                     results.findings.len(),
@@ -591,6 +624,8 @@ limit = {{ minimum = "0.20 mm" }}
 
     #[test]
     fn does_not_require_a_span_for_a_nonapplicable_named_case() {
+        let resolution = Resolution::default();
+
         let xml = board("VIA", None, &[copper(0, Some("N2"), 0.55)]);
         let source = pdk("via").replace(
             "limit = { minimum = \"0.20 mm\" }",
@@ -600,13 +635,14 @@ limit = {{ minimum = "0.20 mm" }}
         let pdk = Pdk::parse(&source).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
         let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-        let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+        let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
         let results = checks::run(
             &rules,
             &design,
             None,
             NaiveDate::from_ymd_opt(2026, 9, 1).unwrap(),
-        );
+        )
+        .unwrap();
 
         assert!(matches!(
             results.rules[0].status,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -75,7 +75,7 @@ pub(super) fn evaluate(
             ];
             let sites = if violates(&distance, limit_mm) {
                 let drill = circular_region(hole.center, radius_mm, design.resolution)?;
-                let mut sites = region_clearance_sites(&drill, &offender.image, limit_mm)
+                let mut sites = region_clearance_sites(&drill, &offender.image, limit_mm)?
                     .into_iter()
                     .map(|geometry| {
                         let mut site = linework_clearance::report_site(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
@@ -87,7 +87,7 @@ pub(super) fn evaluate(
                                 second.center,
                                 second.diameter_mm / 2.0,
                                 design.resolution,
-                            )?);
+                            )?)?;
                             site_evidence.push(Evidence {
                                 display: Some(EvidenceDisplay::CircleIntersection {
                                     first: DisplayCircle {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
@@ -32,7 +32,7 @@ pub(super) fn evaluate(
     first_class: HoleClass,
     second_class: HoleClass,
     design: &Design,
-) -> Evaluation {
+) -> anyhow::Result<Evaluation> {
     let holes = design
         .holes
         .iter()
@@ -42,93 +42,110 @@ pub(super) fn evaluate(
     let measured = holes
         .iter()
         .enumerate()
-        .flat_map(|(index, first)| {
-            holes[index + 1..]
-                .iter()
-                .take_while(move |second| second.bbox.min.x - first.bbox.max.x < reach)
-                .filter(move |second| {
-                    let classes_match = (first.class == first_class
-                        && second.class == second_class)
-                        || (first.class == second_class && second.class == first_class);
-                    let y_gap = (second.bbox.min.y - first.bbox.max.y)
-                        .max(first.bbox.min.y - second.bbox.max.y)
-                        .max(0.0);
-                    classes_match && y_gap < reach && first.drill_span.overlaps(&second.drill_span)
-                })
-                .map(move |second| {
-                    let distance = disk_clearance(
-                        first.center,
-                        first.diameter_mm / 2.0,
-                        second.center,
-                        second.diameter_mm / 2.0,
-                    );
-                    let evidence = vec![
-                        Evidence::circle("first_hole", first.center, first.diameter_mm),
-                        Evidence::circle("second_hole", second.center, second.diameter_mm),
-                    ];
-                    let mut site_evidence = evidence.clone();
-                    site_evidence.push(Evidence::circle(
-                        "required_hole_separation",
-                        first.center,
-                        first.diameter_mm + 2.0 * limit_mm,
-                    ));
-                    let overlap = first.center.distance_to(second.center)
-                        < (first.diameter_mm + second.diameter_mm) / 2.0;
-                    if overlap {
-                        let overlap_region =
-                            circular_region(first.center, first.diameter_mm / 2.0).intersection(
-                                &circular_region(second.center, second.diameter_mm / 2.0),
+        .map(|(index, first)| {
+            Ok::<_, anyhow::Error>(
+                holes[index + 1..]
+                    .iter()
+                    .take_while(move |second| second.bbox.min.x - first.bbox.max.x < reach)
+                    .filter(move |second| {
+                        let classes_match = (first.class == first_class
+                            && second.class == second_class)
+                            || (first.class == second_class && second.class == first_class);
+                        let y_gap = (second.bbox.min.y - first.bbox.max.y)
+                            .max(first.bbox.min.y - second.bbox.max.y)
+                            .max(0.0);
+                        classes_match
+                            && y_gap < reach
+                            && first.drill_span.overlaps(&second.drill_span)
+                    })
+                    .map(move |second| {
+                        let distance = disk_clearance(
+                            first.center,
+                            first.diameter_mm / 2.0,
+                            second.center,
+                            second.diameter_mm / 2.0,
+                        );
+                        let evidence = vec![
+                            Evidence::circle("first_hole", first.center, first.diameter_mm),
+                            Evidence::circle("second_hole", second.center, second.diameter_mm),
+                        ];
+                        let mut site_evidence = evidence.clone();
+                        site_evidence.push(Evidence::circle(
+                            "required_hole_separation",
+                            first.center,
+                            first.diameter_mm + 2.0 * limit_mm,
+                        ));
+                        let overlap = first.center.distance_to(second.center)
+                            < (first.diameter_mm + second.diameter_mm) / 2.0;
+                        if overlap {
+                            let overlap_region = circular_region(
+                                first.center,
+                                first.diameter_mm / 2.0,
+                                design.resolution,
+                            )?
+                            .intersection(&circular_region(
+                                second.center,
+                                second.diameter_mm / 2.0,
+                                design.resolution,
+                            )?);
+                            site_evidence.push(Evidence {
+                                display: Some(EvidenceDisplay::CircleIntersection {
+                                    first: DisplayCircle {
+                                        center: first.center.into(),
+                                        diameter: first.diameter_mm,
+                                    },
+                                    second: DisplayCircle {
+                                        center: second.center.into(),
+                                        diameter: second.diameter_mm,
+                                    },
+                                }),
+                                ..Evidence::region("overlap_region", &overlap_region)
+                            });
+                        }
+                        let mut site = MeasuredSite::new(
+                            distance,
+                            first.bbox.expand(limit_mm).union(second.bbox),
+                            layers([&first.layer, &second.layer]),
+                            site_evidence,
+                            if distance.mm == 0.0 {
+                                MeasurementKind::Overlap
+                            } else {
+                                MeasurementKind::Clearance
+                            },
+                        );
+                        if overlap {
+                            site.note = Some(
+                                "Drilled regions overlap; the edge clearance is zero.".to_owned(),
                             );
-                        site_evidence.push(Evidence {
-                            display: Some(EvidenceDisplay::CircleIntersection {
-                                first: DisplayCircle {
-                                    center: first.center.into(),
-                                    diameter: first.diameter_mm,
-                                },
-                                second: DisplayCircle {
-                                    center: second.center.into(),
-                                    diameter: second.diameter_mm,
-                                },
-                            }),
-                            ..Evidence::region("overlap_region", &overlap_region)
-                        });
-                    }
-                    let mut site = MeasuredSite::new(
-                        distance,
-                        first.bbox.expand(limit_mm).union(second.bbox),
-                        layers([&first.layer, &second.layer]),
-                        site_evidence,
-                        if distance.mm == 0.0 {
-                            MeasurementKind::Overlap
-                        } else {
-                            MeasurementKind::Clearance
-                        },
-                    );
-                    if overlap {
-                        site.note =
-                            Some("Drilled regions overlap; the edge clearance is zero.".to_owned());
-                    } else if distance.mm == 0.0 {
-                        site.note =
-                            Some("Drilled regions touch; the edge clearance is zero.".to_owned());
-                    }
-                    Measured {
-                        distance,
-                        bbox: first.bbox.union(second.bbox),
-                        layers: layers([&first.layer, &second.layer]),
-                        subjects: vec![
-                            hole_subject(design, first, "first"),
-                            hole_subject(design, second, "second"),
-                        ],
-                        evidence,
-                        sites: vec![site],
-                    }
-                })
+                        } else if distance.mm == 0.0 {
+                            site.note = Some(
+                                "Drilled regions touch; the edge clearance is zero.".to_owned(),
+                            );
+                        }
+                        Ok::<_, anyhow::Error>(Measured {
+                            distance,
+                            bbox: first.bbox.union(second.bbox),
+                            layers: layers([&first.layer, &second.layer]),
+                            subjects: vec![
+                                hole_subject(design, first, "first"),
+                                hole_subject(design, second, "second"),
+                            ],
+                            evidence,
+                            sites: vec![site],
+                        })
+                    })
+                    .collect::<anyhow::Result<Vec<_>>>()?
+                    .into_iter(),
+            )
         })
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
         .collect();
-    Evaluation {
+    Ok(Evaluation {
         checked: holes.len(),
         measured,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -137,6 +154,7 @@ mod tests {
     use crate::commands::dfm::{pdk::Pdk, rules};
     use crate::ipc2581::Ipc2581;
     use pcb_ir::dialects::ipc::ArtworkScope;
+    use pcb_ir::geom::Resolution;
 
     #[test]
     fn physical_overlap_is_independent_of_copper_declaration_order() {
@@ -177,8 +195,14 @@ mod tests {
                 .unwrap();
                 let rules = rules::lower(&pdk, None).unwrap();
                 let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-                let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
-                let evaluation = evaluate(0.2, HoleClass::Pth, HoleClass::Pth, &design);
+                let design = Design::extract(
+                    &imported,
+                    ArtworkScope::Board,
+                    &rules,
+                    Resolution::default(),
+                )
+                .unwrap();
+                let evaluation = evaluate(0.2, HoleClass::Pth, HoleClass::Pth, &design).unwrap();
                 assert_eq!(evaluation.checked, 2);
                 assert_eq!(
                     evaluation.measured.len(),
@@ -191,6 +215,8 @@ mod tests {
 
     #[test]
     fn overlapping_drills_retain_exact_circle_intersection_parameters() {
+        let resolution = Resolution::default();
+
         let ipc = Ipc2581::parse(r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
           <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/><LayerRef name="DRILL"/></Content>
           <Ecad><CadHeader units="MILLIMETER"/><CadData>
@@ -219,8 +245,8 @@ mod tests {
         .unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
         let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-        let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
-        let evaluation = evaluate(0.2, HoleClass::Pth, HoleClass::Pth, &design);
+        let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
+        let evaluation = evaluate(0.2, HoleClass::Pth, HoleClass::Pth, &design).unwrap();
         assert_eq!(evaluation.measured.len(), 1);
         let site = &evaluation.measured[0].sites[0];
         let overlap = site

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/linework_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/linework_clearance.rs
@@ -22,6 +22,7 @@
 //! curves and count toward the measurement's uncertainty; a score line is
 //! exact.
 
+use pcb_ir::geom::Resolution;
 use std::ops::Range;
 
 use pcb_ir::geom::dfm::{ClearanceSite, Distance, linework_clearance_sites, linework_envelope};
@@ -40,7 +41,7 @@ use super::{Evaluation, Measured, MeasuredSite, layers, violates};
 /// of bare segments plus its report identity.
 struct LineworkItem {
     segments: Range<usize>,
-    flattened_boundaries: u32,
+    uncertainty_mm: f64,
     layer: Option<LayerRef>,
     subject: Subject,
     evidence: Evidence,
@@ -66,7 +67,7 @@ fn linework_items(linework: Linework, design: &Design) -> LineworkPool {
             .iter()
             .map(|score| LineworkItem {
                 segments: push(vec![(score.start, score.end)]),
-                flattened_boundaries: 0,
+                uncertainty_mm: 0.0,
                 layer: Some(score.layer.clone()),
                 subject: Subject {
                     role: "reference",
@@ -83,7 +84,7 @@ fn linework_items(linework: Linework, design: &Design) -> LineworkPool {
             .iter()
             .map(|outline| LineworkItem {
                 segments: push(outline.contours.iter().flat_map(ring_edges).collect()),
-                flattened_boundaries: 1,
+                uncertainty_mm: outline.region.uncertainty_mm,
                 layer: None,
                 subject: outline_subject(outline, "reference"),
                 evidence: Evidence::bounds("board_outline", outline.bbox),
@@ -98,7 +99,7 @@ pub(super) fn evaluate(
     linework: Linework,
     conditions: &Conditions,
     design: &Design,
-) -> Evaluation {
+) -> anyhow::Result<Evaluation> {
     let copper_layers = &design.copper_layers;
     let boundaries = &design.copper_boundaries;
     let pool = linework_items(linework, design);
@@ -108,66 +109,80 @@ pub(super) fn evaluate(
         .flat_map(|&(start, end)| [start, end])
         .collect::<Vec<_>>();
 
-    let measured = copper_layers
+    let mut measured = Vec::new();
+    for (copper_index, copper) in copper_layers
         .iter()
         .enumerate()
         .filter(|(_, copper)| conditions.applies_to_layer(copper))
-        .flat_map(|(copper_index, copper)| {
-            let inside = copper.image.contains_points_batch(&endpoints);
-            items.iter().filter_map(move |item| {
-                let nearest = item
-                    .segments
-                    .clone()
-                    .filter_map(|segment_index| {
-                        let (start, end) = segments[segment_index];
-                        let (start_inside, end_inside) =
-                            (inside[2 * segment_index], inside[2 * segment_index + 1]);
-                        // A segment touching copper measures zero at the
-                        // contained endpoint; otherwise both ends are outside
-                        // and the boundary distance is the set distance.
-                        match (start_inside, end_inside) {
-                            (true, _) => Some(Distance::flattened(0.0, start, start, 1)),
-                            (_, true) => Some(Distance::flattened(0.0, end, end, 1)),
-                            _ => boundaries[copper_index]
-                                .segment_nearest_within(start, end, limit_mm),
-                        }
-                    })
-                    .min_by(|left, right| left.mm.total_cmp(&right.mm))?;
-                let distance = nearest.also_flattened(item.flattened_boundaries);
-                let site_layers = layers(item.layer.iter().chain([&copper.layer]));
-                let sites = if violates(&distance, limit_mm) {
-                    linework_clearance_sites(
-                        &segments[item.segments.clone()],
-                        &copper.image,
-                        &boundaries[copper_index],
-                        limit_mm,
-                        item.flattened_boundaries,
-                    )
-                    .into_iter()
-                    .map(|site| report_site(site, site_layers.clone(), limit_mm))
-                    .collect()
-                } else {
-                    Vec::new()
-                };
-                Some(Measured {
-                    distance,
-                    bbox: BBox::from_point(distance.first).union(BBox::from_point(distance.second)),
-                    layers: site_layers,
-                    subjects: vec![item.subject.clone(), copper_subject(copper)],
-                    evidence: vec![item.evidence.clone()],
-                    sites,
+    {
+        let inside = copper.image.contains_points_batch(&endpoints);
+        for item in items {
+            let Some(nearest) = item
+                .segments
+                .clone()
+                .filter_map(|segment_index| {
+                    let (start, end) = segments[segment_index];
+                    let (start_inside, end_inside) =
+                        (inside[2 * segment_index], inside[2 * segment_index + 1]);
+                    // A segment touching copper measures zero at the
+                    // contained endpoint; otherwise both ends are outside
+                    // and the boundary distance is the set distance.
+                    match (start_inside, end_inside) {
+                        (true, _) => Some(Distance::with_uncertainty(
+                            0.0,
+                            start,
+                            start,
+                            copper.image.uncertainty_mm,
+                        )),
+                        (_, true) => Some(Distance::with_uncertainty(
+                            0.0,
+                            end,
+                            end,
+                            copper.image.uncertainty_mm,
+                        )),
+                        _ => boundaries[copper_index].segment_nearest_within(start, end, limit_mm),
+                    }
                 })
-            })
-        })
-        .collect();
-    Evaluation {
+                .min_by(|left, right| left.mm.total_cmp(&right.mm))
+            else {
+                continue;
+            };
+            let distance = nearest.also_uncertain(item.uncertainty_mm);
+            let site_layers = layers(item.layer.iter().chain([&copper.layer]));
+            let sites = if violates(&distance, limit_mm) {
+                linework_clearance_sites(
+                    &segments[item.segments.clone()],
+                    &copper.image,
+                    &boundaries[copper_index],
+                    limit_mm,
+                    item.uncertainty_mm,
+                )
+                .into_iter()
+                .map(|site| report_site(site, site_layers.clone(), limit_mm, design.resolution))
+                .collect::<anyhow::Result<Vec<_>>>()?
+                .into_iter()
+                .collect()
+            } else {
+                Vec::new()
+            };
+            measured.push(Measured {
+                distance,
+                bbox: BBox::from_point(distance.first).union(BBox::from_point(distance.second)),
+                layers: site_layers,
+                subjects: vec![item.subject.clone(), copper_subject(copper)],
+                evidence: vec![item.evidence.clone()],
+                sites,
+            });
+        }
+    }
+    Ok(Evaluation {
         checked: copper_layers
             .iter()
             .filter(|layer| conditions.applies_to_layer(layer))
             .count()
             * items.len(),
         measured,
-    }
+    })
 }
 
 /// All clearance families share the same local path/constraint construction;
@@ -176,7 +191,8 @@ pub(super) fn report_site(
     geometry: ClearanceSite,
     layers: Vec<LayerRef>,
     limit_mm: f64,
-) -> MeasuredSite {
+    resolution: Resolution,
+) -> anyhow::Result<MeasuredSite> {
     let mut evidence = [
         ("first_boundary", &geometry.first_paths),
         ("second_boundary", &geometry.second_paths),
@@ -190,7 +206,7 @@ pub(super) fn report_site(
         ..Evidence::default()
     })
     .collect::<Vec<_>>();
-    let band = linework_envelope(&geometry.first_paths, limit_mm);
+    let band = linework_envelope(&geometry.first_paths, limit_mm, resolution)?;
     if !band.is_empty() {
         evidence.push(Evidence {
             display: Some(EvidenceDisplay::RoundStroke {
@@ -227,7 +243,7 @@ pub(super) fn report_site(
     } else {
         site.note = Some("Highlighted boundary spans are below the limit after accounting for geometric uncertainty.".to_owned());
     }
-    site
+    Ok(site)
 }
 
 /// Consecutive open paths that share an exact endpoint describe the same
@@ -296,13 +312,18 @@ mod tests {
             vec![Point::new(8.0, 8.0), Point::new(9.0, 9.0)],
         ];
         let geometry = ClearanceSite {
-            distance: Distance::flattened(0.1, Point::new(3.0, 2.0), Point::new(3.1, 2.0), 1),
+            distance: Distance::with_uncertainty(
+                0.1,
+                Point::new(3.0, 2.0),
+                Point::new(3.1, 2.0),
+                0.005,
+            ),
             bbox: BBox::new(Point::new(1.0, 2.0), Point::new(9.0, 9.0)),
             first_paths,
             second_paths: vec![vec![Point::new(3.1, 2.0), Point::new(3.1, 4.0)]],
-            overlap: pcb_ir::geom::ContourSet::empty(pcb_ir::geom::tol::REGION_MM),
+            overlap: pcb_ir::geom::ContourSet::empty(pcb_ir::geom::Resolution::default()),
         };
-        let site = report_site(geometry, Vec::new(), 0.2);
+        let site = report_site(geometry, Vec::new(), 0.2, Resolution::default()).unwrap();
         let band = site
             .evidence
             .iter()
@@ -329,7 +350,7 @@ mod tests {
             "measured polygon evidence remains available"
         );
         assert_eq!(site.distance.mm, 0.1);
-        assert_eq!(site.distance.uncertainty_mm, pcb_ir::geom::tol::FLATTEN_MM);
+        assert_eq!(site.distance.uncertainty_mm, 0.005);
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -147,14 +147,14 @@ pub(super) fn run(
     design: &Design,
     waiver_file: Option<&WaiverFile>,
     today: NaiveDate,
-) -> Results {
+) -> anyhow::Result<Results> {
     let mut results = Results::default();
     for rule in rules {
         let mut result = RuleResult::new(rule);
         match skip_reason(rule, design) {
             Some(reason) => result.skip(reason),
             None => {
-                let evaluation = evaluate(rule, design);
+                let evaluation = evaluate(rule, design)?;
                 match evaluation {
                     RuleEvaluation::Distance(evaluation) => {
                         debug_assert_eq!(rule.comparison, Comparison::Minimum);
@@ -262,7 +262,7 @@ pub(super) fn run(
             result.finish(total, waived);
         }
     }
-    results
+    Ok(results)
 }
 
 /// The one verdict: a distance violates a minimum when it is certainly
@@ -354,48 +354,48 @@ fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
         .map(|what| format!("no {what} in the selected layout target"))
 }
 
-fn evaluate(rule: &Rule, design: &Design) -> RuleEvaluation {
+fn evaluate(rule: &Rule, design: &Design) -> anyhow::Result<RuleEvaluation> {
     let limit = || rule.limit.length().millimeters();
-    match rule.kind {
+    Ok(match rule.kind {
         RuleKind::CopperLayerCount => RuleEvaluation::Count(layer_count::evaluate(design)),
         RuleKind::HoleDiameter(class) => hole_diameter::evaluate(limit(), class, design).into(),
         RuleKind::HoleAspectRatio(class) => {
             RuleEvaluation::Ratio(hole_aspect_ratio::evaluate(class, &rule.conditions, design))
         }
-        RuleKind::SlotWidth(plating) => slot_width::evaluate(limit(), plating, design).into(),
+        RuleKind::SlotWidth(plating) => slot_width::evaluate(limit(), plating, design)?.into(),
         RuleKind::HolePairClearance(first, second) => {
-            hole_pair_clearance::evaluate(limit(), first, second, design).into()
+            hole_pair_clearance::evaluate(limit(), first, second, design)?.into()
         }
         RuleKind::HoleToBoardEdgeClearance(class) => {
-            drilled_board_edge_clearance::evaluate_holes(limit(), class, design).into()
+            drilled_board_edge_clearance::evaluate_holes(limit(), class, design)?.into()
         }
         RuleKind::SlotToBoardEdgeClearance(plating) => {
-            drilled_board_edge_clearance::evaluate_slots(limit(), plating, design).into()
+            drilled_board_edge_clearance::evaluate_slots(limit(), plating, design)?.into()
         }
         RuleKind::AnnularRing(class) => {
-            annular_ring::evaluate(limit(), class, &rule.conditions, design).into()
+            annular_ring::evaluate(limit(), class, &rule.conditions, design)?.into()
         }
         RuleKind::PlatedSlotEnclosure => {
-            plated_slot_enclosure::evaluate(limit(), &rule.conditions, design).into()
+            plated_slot_enclosure::evaluate(limit(), &rule.conditions, design)?.into()
         }
         RuleKind::HoleToCopperClearance(class) => {
-            hole_clearance::evaluate(limit(), class, &rule.conditions, design).into()
+            hole_clearance::evaluate(limit(), class, &rule.conditions, design)?.into()
         }
         RuleKind::SlotToCopperClearance(plating) => {
-            slot_clearance::evaluate(limit(), plating, &rule.conditions, design).into()
+            slot_clearance::evaluate(limit(), plating, &rule.conditions, design)?.into()
         }
         RuleKind::LineworkToCopperClearance(linework) => {
-            linework_clearance::evaluate(limit(), linework, &rule.conditions, design).into()
+            linework_clearance::evaluate(limit(), linework, &rule.conditions, design)?.into()
         }
-        RuleKind::BoardArrayPairClearance => board_array_spacing::evaluate(limit(), design).into(),
+        RuleKind::BoardArrayPairClearance => board_array_spacing::evaluate(limit(), design)?.into(),
         RuleKind::CopperFeatureWidth => {
-            thin_regions::copper_feature_width(limit(), &rule.conditions, design).into()
+            thin_regions::copper_feature_width(limit(), &rule.conditions, design)?.into()
         }
         RuleKind::CopperClearance => {
-            copper_clearance::evaluate(limit(), &rule.conditions, design).into()
+            copper_clearance::evaluate(limit(), &rule.conditions, design)?.into()
         }
-        RuleKind::SoldermaskWeb => thin_regions::soldermask_web(limit(), design).into(),
-    }
+        RuleKind::SoldermaskWeb => thin_regions::soldermask_web(limit(), design)?.into(),
+    })
 }
 
 pub(super) fn slot_matches(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/plated_slot_enclosure.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/plated_slot_enclosure.rs
@@ -16,7 +16,11 @@ use crate::commands::dfm::rules::Conditions;
 use super::drilled_board_edge_clearance::slot_evidence;
 use super::{Evaluation, Measured, MeasuredSite, layers, slot_matches, slot_subject, violates};
 
-pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) -> Evaluation {
+pub(super) fn evaluate(
+    limit_mm: f64,
+    conditions: &Conditions,
+    design: &Design,
+) -> anyhow::Result<Evaluation> {
     let mut checked = 0;
     let mut measured = Vec::new();
     for (slot_index, slot) in design
@@ -57,7 +61,7 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
             // within the existing flattening uncertainty, not a fab tolerance.
             let filled = copper
                 .image
-                .union(&slot.outline.disk_dilate(tol::REGION_MM));
+                .union(&slot.outline.disk_dilate(tol::REGION_MM)?);
             let boundary = filled.prepare_query();
             let distance = slot
                 .outline
@@ -67,7 +71,7 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
                 .filter_map(|(start, end)| boundary.segment_nearest_within(start, end, limit_mm))
                 .min_by(|a, b| a.mm.total_cmp(&b.mm))
                 .map(|distance| {
-                    let mut distance = distance.also_flattened(1);
+                    let mut distance = distance.also_uncertain(slot.outline.uncertainty_mm);
                     if distance.mm <= tol::REGION_MM {
                         distance.mm = 0.0;
                         distance.second = distance.first;
@@ -77,7 +81,7 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
             let Some(distance) = distance.filter(|distance| violates(distance, limit_mm)) else {
                 continue;
             };
-            let envelope = slot.outline.disk_dilate(limit_mm);
+            let envelope = slot.outline.disk_dilate(limit_mm)?;
             let mut site = MeasuredSite::new(
                 distance,
                 envelope.bbox,
@@ -116,7 +120,7 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
             });
         }
     }
-    Evaluation { checked, measured }
+    Ok(Evaluation { checked, measured })
 }
 
 #[cfg(test)]
@@ -126,6 +130,7 @@ mod tests {
     use crate::commands::dfm::report::{FileIdentity, RuleStatus, Verdict};
     use crate::commands::dfm::{self, CheckRequest, PdkSource, TextSource};
     use crate::ipc2581::Ipc2581;
+    use pcb_ir::geom::Resolution;
     use pcb_ir::import::ipc2581::import_design;
 
     const PDK: &str = r#"schema_version = 2
@@ -197,6 +202,7 @@ limit = { minimum = "0.2 mm", preferred = "0.3 mm" }
                 layout_target: LayoutTarget::Board,
                 generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
             },
+            Resolution::default(),
         )
         .unwrap()
     }
@@ -327,9 +333,14 @@ limit = { minimum = "0.2 mm", preferred = "0.3 mm" }
             if span == THROUGH {
                 imported.stackups.clear();
             }
-            let error = Design::extract(&imported, ArtworkScope::Board, &rules)
-                .err()
-                .unwrap();
+            let error = Design::extract(
+                &imported,
+                ArtworkScope::Board,
+                &rules,
+                Resolution::default(),
+            )
+            .err()
+            .unwrap();
             assert!(error.to_string().contains(if span == THROUGH {
                 "physical stackup"
             } else {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/plated_slot_enclosure.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/plated_slot_enclosure.rs
@@ -52,7 +52,7 @@ pub(super) fn evaluate(
                         .segment_nearest_within(start, end, tol::REGION_MM)
                         .is_some_and(|distance| distance.mm <= tol::REGION_MM)
                 });
-            if !required && !touching && slot.outline.intersection(&copper.image).is_empty() {
+            if !required && !touching && slot.outline.intersection(&copper.image)?.is_empty() {
                 continue;
             }
             checked += 1;
@@ -61,7 +61,7 @@ pub(super) fn evaluate(
             // within the existing flattening uncertainty, not a fab tolerance.
             let filled = copper
                 .image
-                .union(&slot.outline.disk_dilate(tol::REGION_MM)?);
+                .union(&slot.outline.disk_dilate(tol::REGION_MM)?)?;
             let boundary = filled.prepare_query();
             let distance = slot
                 .outline
@@ -90,9 +90,9 @@ pub(super) fn evaluate(
                     slot_evidence(slot),
                     Evidence::region(
                         "required_copper_envelope",
-                        &envelope.difference(&slot.outline),
+                        &envelope.difference(&slot.outline)?,
                     ),
-                    Evidence::region("missing_copper", &envelope.difference(&filled)),
+                    Evidence::region("missing_copper", &envelope.difference(&filled)?),
                 ],
                 if distance.mm <= f64::EPSILON {
                     MeasurementKind::MissingCopper

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
@@ -18,7 +18,7 @@ pub(super) fn evaluate(
     plating: SlotPlating,
     conditions: &Conditions,
     design: &Design,
-) -> Evaluation {
+) -> anyhow::Result<Evaluation> {
     let mut checked = 0;
     let mut measured = Vec::new();
     for (slot_index, slot) in design
@@ -97,13 +97,17 @@ pub(super) fn evaluate(
             )
             .into_iter()
             .map(|geometry| {
-                let mut site =
-                    linework_clearance::report_site(geometry, finding_layers.clone(), limit_mm);
+                let mut site = linework_clearance::report_site(
+                    geometry,
+                    finding_layers.clone(),
+                    limit_mm,
+                    design.resolution,
+                )?;
                 site.subjects = subjects.clone();
                 site.evidence.extend(evidence.clone());
-                site
+                Ok(site)
             })
-            .collect();
+            .collect::<anyhow::Result<Vec<_>>>()?;
             measured.push(Measured {
                 distance,
                 bbox: slot
@@ -116,7 +120,7 @@ pub(super) fn evaluate(
             });
         }
     }
-    Evaluation { checked, measured }
+    Ok(Evaluation { checked, measured })
 }
 
 #[cfg(test)]
@@ -124,6 +128,7 @@ mod tests {
     use crate::LayoutTarget;
     use crate::commands::dfm::{self, CheckRequest, PdkSource, TextSource, report};
     use crate::ipc2581::Ipc2581;
+    use pcb_ir::geom::Resolution;
 
     fn pdk(plating: &str) -> String {
         format!(
@@ -193,6 +198,7 @@ limit = {{ minimum = "0.20 mm" }}
                 layout_target: target,
                 generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
             },
+            Resolution::default(),
         )
     }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
@@ -94,7 +94,7 @@ pub(super) fn evaluate(
                 &offender.image,
                 copper_boundary,
                 limit_mm,
-            )
+            )?
             .into_iter()
             .map(|geometry| {
                 let mut site = linework_clearance::report_site(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
@@ -59,8 +59,13 @@ pub(super) fn evaluate(
                 site.note = Some("The slot primitive declares this width; its materialized outline was checked for agreement.".to_owned());
                 vec![site]
             } else {
-                thin_features(&slot.outline, limit_mm)?.iter()
-                    .flat_map(|piece| thin_regions::piece_sites(piece, limit_mm, &slot.layer)).collect()
+                thin_features(&slot.outline, limit_mm)?
+                    .iter()
+                    .map(|piece| thin_regions::piece_sites(piece, limit_mm, &slot.layer))
+                    .collect::<anyhow::Result<Vec<_>>>()?
+                    .into_iter()
+                    .flatten()
+                    .collect()
             };
             Ok::<_, anyhow::Error>(Measured {
             distance: slot.width,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
@@ -14,7 +14,11 @@ use pcb_ir::geom::dfm::thin_features;
 
 use super::{Evaluation, Measured, MeasuredSite, slot_subject, thin_regions, violates};
 
-pub(super) fn evaluate(limit_mm: f64, plating: SlotPlating, design: &Design) -> Evaluation {
+pub(super) fn evaluate(
+    limit_mm: f64,
+    plating: SlotPlating,
+    design: &Design,
+) -> anyhow::Result<Evaluation> {
     let slots = design
         .slots
         .iter()
@@ -55,22 +59,22 @@ pub(super) fn evaluate(limit_mm: f64, plating: SlotPlating, design: &Design) -> 
                 site.note = Some("The slot primitive declares this width; its materialized outline was checked for agreement.".to_owned());
                 vec![site]
             } else {
-                thin_features(&slot.outline, limit_mm).iter()
+                thin_features(&slot.outline, limit_mm)?.iter()
                     .flat_map(|piece| thin_regions::piece_sites(piece, limit_mm, &slot.layer)).collect()
             };
-            Measured {
+            Ok::<_, anyhow::Error>(Measured {
             distance: slot.width,
             bbox: slot.bbox,
             layers: vec![slot.layer.clone()],
             subjects: vec![subject],
             evidence: vec![Evidence::bounds("routed_slot", slot.bbox)],
             sites,
-        }})
+        })}).collect::<anyhow::Result<Vec<_>>>()?.into_iter()
         .collect();
-    Evaluation {
+    Ok(Evaluation {
         checked: slots.len(),
         measured,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -79,9 +83,12 @@ mod tests {
     use crate::commands::dfm::{pdk::Pdk, rules};
     use crate::ipc2581::Ipc2581;
     use pcb_ir::dialects::ipc::ArtworkScope;
+    use pcb_ir::geom::Resolution;
 
     #[test]
     fn nominal_slot_display_retains_native_curves_and_the_checked_outline() {
+        let resolution = Resolution::default();
+
         let ipc = Ipc2581::parse(r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
           <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/><LayerRef name="ROUT"/></Content>
           <Ecad><CadHeader units="MILLIMETER"/><CadData>
@@ -111,11 +118,13 @@ mod tests {
         .unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
         let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-        let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
-        let evaluation = evaluate(0.8, SlotPlating::Plated, &design);
+        let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
+        let evaluation = evaluate(0.8, SlotPlating::Plated, &design).unwrap();
         assert_eq!(evaluation.measured.len(), 1);
         assert_eq!(
-            evaluate(0.8, SlotPlating::Nonplated, &design).checked,
+            evaluate(0.8, SlotPlating::Nonplated, &design)
+                .unwrap()
+                .checked,
             0,
             "slot plating is part of rule selection"
         );

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
@@ -48,7 +48,7 @@ pub(super) fn copper_feature_width(
         thin_features(&layer.image, limit_mm)?
             .into_iter()
             .map(move |piece| {
-                let mut measured = measured_piece(&piece, limit_mm, &layer.layer, "copper_image");
+                let mut measured = measured_piece(&piece, limit_mm, &layer.layer, "copper_image")?;
                 // Prove ownership against final composed material. A bounding box
                 // is only a broad phase; overlapping owners remain ambiguous.
                 let mut construction = piece.candidate.clone();
@@ -57,9 +57,9 @@ pub(super) fn copper_feature_width(
                         site.disk.center,
                         site.disk.radius_mm,
                         design.resolution,
-                    )?);
+                    )?)?;
                 }
-                let owner = unique_copper_owner(&construction, &layer.conductors);
+                let owner = unique_copper_owner(&construction, &layer.conductors)?;
                 if let Some(owner) = owner {
                     measured.subjects[0].provenance =
                         copper_subject(design, owner, &layer.layer).provenance;
@@ -73,13 +73,13 @@ pub(super) fn copper_feature_width(
                             .intersection(&ContourSet::rectangle(
                                 geometry.bbox.expand(limit_mm / 2.0),
                                 piece.candidate.resolution,
-                            ))
+                            ))?
                             .union(&circular_region(
                                 geometry.disk.center,
                                 geometry.disk.radius_mm,
                                 design.resolution,
-                            )?);
-                        unique_copper_owner(&local, &layer.conductors)
+                            )?)?;
+                        unique_copper_owner(&local, &layer.conductors)?
                     };
                     if let Some(owner) = local_owner {
                         site.subjects = vec![copper_subject(design, owner, &layer.layer)];
@@ -117,38 +117,35 @@ pub(super) fn soldermask_web(limit_mm: f64, design: &Design) -> anyhow::Result<E
             .iter()
             .map(|owner| (owner.image.bbox, owner.image.prepare_query()))
             .collect::<Vec<_>>();
-        Ok::<_, anyhow::Error>(
-            thin_gaps(&layer.image, limit_mm)?
-                .into_iter()
-                .map(move |piece| {
-                    let mut measured =
-                        measured_piece(&piece, limit_mm, &layer.layer, "soldermask_image");
-                    let mut aggregate_owner = None;
-                    let mut one_owner = true;
-                    for (geometry, site) in piece.sites.iter().zip(&mut measured.sites) {
-                        let Some(owners) = wall_owners(&geometry.walls, &boundaries) else {
-                            one_owner = false;
-                            continue;
-                        };
-                        if owners.len() != 1
-                            || aggregate_owner.is_some_and(|owner| owners[0] != owner)
-                        {
-                            one_owner = false;
-                        }
-                        aggregate_owner = aggregate_owner.or_else(|| owners.first().copied());
-                        site.subjects = owners
-                            .into_iter()
-                            .map(|index| mask_subject(design, &layer.owners[index], &layer.layer))
-                            .collect();
+        thin_gaps(&layer.image, limit_mm)?
+            .into_iter()
+            .map(move |piece| {
+                let mut measured =
+                    measured_piece(&piece, limit_mm, &layer.layer, "soldermask_image")?;
+                let mut aggregate_owner = None;
+                let mut one_owner = true;
+                for (geometry, site) in piece.sites.iter().zip(&mut measured.sites) {
+                    let Some(owners) = wall_owners(&geometry.walls, &boundaries) else {
+                        one_owner = false;
+                        continue;
+                    };
+                    if owners.len() != 1 || aggregate_owner.is_some_and(|owner| owners[0] != owner)
+                    {
+                        one_owner = false;
                     }
-                    if one_owner && let Some(index) = aggregate_owner {
-                        measured.subjects[0].provenance =
-                            mask_subject(design, &layer.owners[index], &layer.layer).provenance;
-                    }
-                    measured
-                })
-                .collect::<Vec<_>>(),
-        )
+                    aggregate_owner = aggregate_owner.or_else(|| owners.first().copied());
+                    site.subjects = owners
+                        .into_iter()
+                        .map(|index| mask_subject(design, &layer.owners[index], &layer.layer))
+                        .collect();
+                }
+                if one_owner && let Some(index) = aggregate_owner {
+                    measured.subjects[0].provenance =
+                        mask_subject(design, &layer.owners[index], &layer.layer).provenance;
+                }
+                Ok::<_, anyhow::Error>(measured)
+            })
+            .collect::<anyhow::Result<Vec<_>>>()
     };
     #[cfg(not(target_family = "wasm"))]
     let layers = design.mask_layers.par_iter();
@@ -171,8 +168,8 @@ fn measured_piece(
     limit_mm: f64,
     layer: &LayerRef,
     offender_kind: &'static str,
-) -> Measured {
-    Measured {
+) -> anyhow::Result<Measured> {
+    Ok(Measured {
         distance: piece.width,
         bbox: piece.bbox,
         layers: vec![layer.clone()],
@@ -183,22 +180,32 @@ fn measured_piece(
             ..Subject::default()
         }],
         evidence: vec![Evidence::bounds("thin_piece", piece.bbox)],
-        sites: piece_sites(piece, limit_mm, layer),
-    }
+        sites: piece_sites(piece, limit_mm, layer)?,
+    })
 }
 
 fn unique_copper_owner<'a>(
     region: &ContourSet,
     owners: &'a [CopperConductor],
-) -> Option<&'a CopperConductor> {
+) -> anyhow::Result<Option<&'a CopperConductor>> {
     if region.is_empty() {
-        return None;
+        return Ok(None);
     }
-    let mut intersections = owners.iter().filter(|owner| {
-        region.bbox.intersects(owner.image.bbox) && !region.intersection(&owner.image).is_empty()
-    });
-    let owner = intersections.next()?;
-    (intersections.next().is_none() && region.difference(&owner.image).is_empty()).then_some(owner)
+    let mut intersecting = Vec::new();
+    for owner in owners {
+        if region.bbox.intersects(owner.image.bbox)
+            && !region.intersection(&owner.image)?.is_empty()
+        {
+            intersecting.push(owner);
+        }
+    }
+    let [owner] = intersecting.as_slice() else {
+        return Ok(None);
+    };
+    Ok(region
+        .difference(&owner.image)?
+        .is_empty()
+        .then_some(*owner))
 }
 
 fn copper_subject(design: &Design, owner: &CopperConductor, layer: &LayerRef) -> Subject {
@@ -298,11 +305,15 @@ fn wall_owners(
 /// Shared width construction for composed copper, mask webs and routed slots.
 /// The conservative residue is explicitly context. Only the independently
 /// verified medial-axis paths and their real inscribed disks are offenders.
-pub(super) fn piece_sites(piece: &ThinPiece, limit_mm: f64, layer: &LayerRef) -> Vec<MeasuredSite> {
+pub(super) fn piece_sites(
+    piece: &ThinPiece,
+    limit_mm: f64,
+    layer: &LayerRef,
+) -> anyhow::Result<Vec<MeasuredSite>> {
     piece.sites.iter().map(|geometry| {
         let disk = geometry.disk;
         let bbox = geometry.bbox.union(BBox::from_point(disk.center).expand(limit_mm / 2.0));
-        let local_candidate = piece.candidate.intersection(&ContourSet::rectangle(bbox, piece.candidate.resolution));
+        let local_candidate = piece.candidate.intersection(&ContourSet::rectangle(bbox, piece.candidate.resolution))?;
         let mut evidence = vec![
             Evidence::region("candidate_region", &local_candidate),
             Evidence::circle("inscribed_width_disk", disk.center, disk.radius_mm * 2.0),
@@ -326,7 +337,7 @@ pub(super) fn piece_sites(piece: &ThinPiece, limit_mm: f64, layer: &LayerRef) ->
         }
         let mut site = MeasuredSite::new(disk.width, bbox, vec![layer.clone()], evidence, MeasurementKind::InscribedWidth);
         site.note = Some("Width is the inscribed disk diameter. Candidate contours are context; highlighted axis portions are verified below the limit, including geometric uncertainty.".to_owned());
-        site
+        Ok(site)
     }).collect()
 }
 
@@ -367,10 +378,13 @@ mod tests {
     #[test]
     fn copper_ownership_requires_unique_complete_material_coverage() {
         let candidate = rectangle(0.0, 0.0, 0.08, 2.0);
-        let decoy = rectangle(-1.0, -1.0, 1.0, 3.0).difference(&rectangle(-0.1, -0.1, 0.2, 2.1));
+        let decoy = rectangle(-1.0, -1.0, 1.0, 3.0)
+            .difference(&rectangle(-0.1, -0.1, 0.2, 2.1))
+            .unwrap();
         let owners = [conductor(decoy, 8), conductor(candidate.clone(), 3)];
         assert_eq!(
             unique_copper_owner(&candidate, &owners)
+                .unwrap()
                 .unwrap()
                 .id
                 .instance(),
@@ -382,11 +396,13 @@ mod tests {
             conductor(rectangle(0.04, 0.0, 0.08, 2.0), 4),
         ];
         assert!(
-            unique_copper_owner(&candidate, &split).is_none(),
+            unique_copper_owner(&candidate, &split).unwrap().is_none(),
             "a connected image can span occurrences"
         );
         assert!(
-            unique_copper_owner(&candidate, &split[..1]).is_none(),
+            unique_copper_owner(&candidate, &split[..1])
+                .unwrap()
+                .is_none(),
             "one intersecting owner does not prove complete coverage"
         );
         let overlapping = [
@@ -394,7 +410,9 @@ mod tests {
             conductor(candidate.clone(), 4),
         ];
         assert!(
-            unique_copper_owner(&candidate, &overlapping).is_none(),
+            unique_copper_owner(&candidate, &overlapping)
+                .unwrap()
+                .is_none(),
             "coincident material remains ambiguous"
         );
     }
@@ -408,7 +426,7 @@ mod tests {
             (Point::new(1.1, 0.2), Point::new(1.1, 0.8)),
         ];
         assert_eq!(
-            wall_owners(&walls, &boundaries(&[left.union(&right)])),
+            wall_owners(&walls, &boundaries(&[left.union(&right).unwrap()])),
             Some(vec![0])
         );
         assert_eq!(
@@ -424,7 +442,9 @@ mod tests {
 
     #[test]
     fn wall_endpoints_do_not_prove_the_interior_span() {
-        let incomplete = rectangle(0.0, 0.0, 1.0, 0.4).union(&rectangle(0.0, 0.6, 1.0, 1.0));
+        let incomplete = rectangle(0.0, 0.0, 1.0, 0.4)
+            .union(&rectangle(0.0, 0.6, 1.0, 1.0))
+            .unwrap();
         let walls = [(Point::new(1.0, 0.1), Point::new(1.0, 0.9))];
         assert!(wall_owners(&walls, &boundaries(&[incomplete])).is_none());
         let contiguous = [rectangle(0.0, 0.0, 1.0, 0.5), rectangle(0.0, 0.5, 1.0, 1.0)];

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/thin_regions.rs
@@ -30,7 +30,7 @@
 //! reinterpret a same-net notch as spacing between conductors.
 
 use pcb_ir::geom::dfm::{ThinPiece, circular_region, thin_features, thin_gaps};
-use pcb_ir::geom::{BBox, ContourSet, Point, PreparedRegion, tol};
+use pcb_ir::geom::{BBox, ContourSet, Point, PreparedRegion};
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 
@@ -43,121 +43,127 @@ pub(super) fn copper_feature_width(
     limit_mm: f64,
     conditions: &Conditions,
     design: &Design,
-) -> Evaluation {
+) -> anyhow::Result<Evaluation> {
     let measure = |layer: &CopperLayer| {
-        thin_features(&layer.image, limit_mm)
+        thin_features(&layer.image, limit_mm)?
             .into_iter()
             .map(move |piece| {
                 let mut measured = measured_piece(&piece, limit_mm, &layer.layer, "copper_image");
                 // Prove ownership against final composed material. A bounding box
                 // is only a broad phase; overlapping owners remain ambiguous.
-                let construction =
-                    piece
-                        .sites
-                        .iter()
-                        .fold(piece.candidate.clone(), |region, site| {
-                            region.union(&circular_region(site.disk.center, site.disk.radius_mm))
-                        });
+                let mut construction = piece.candidate.clone();
+                for site in &piece.sites {
+                    construction.union_assign(&circular_region(
+                        site.disk.center,
+                        site.disk.radius_mm,
+                        design.resolution,
+                    )?);
+                }
                 let owner = unique_copper_owner(&construction, &layer.conductors);
                 if let Some(owner) = owner {
                     measured.subjects[0].provenance =
                         copper_subject(design, owner, &layer.layer).provenance;
                 }
                 for (geometry, site) in piece.sites.iter().zip(&mut measured.sites) {
-                    let local_owner = owner.or_else(|| {
+                    let local_owner = if owner.is_some() {
+                        owner
+                    } else {
                         let local = piece
                             .candidate
                             .intersection(&ContourSet::rectangle(
                                 geometry.bbox.expand(limit_mm / 2.0),
-                                tol::REGION_MM,
+                                piece.candidate.resolution,
                             ))
                             .union(&circular_region(
                                 geometry.disk.center,
                                 geometry.disk.radius_mm,
-                            ));
+                                design.resolution,
+                            )?);
                         unique_copper_owner(&local, &layer.conductors)
-                    });
+                    };
                     if let Some(owner) = local_owner {
                         site.subjects = vec![copper_subject(design, owner, &layer.layer)];
                     }
                 }
-                measured
+                Ok::<_, anyhow::Error>(measured)
             })
-            .collect::<Vec<_>>()
+            .collect::<anyhow::Result<Vec<_>>>()
     };
     #[cfg(not(target_family = "wasm"))]
-    let measured = design
-        .copper_layers
-        .par_iter()
-        .filter(|layer| conditions.applies_to_layer(layer))
-        .flat_map_iter(measure)
-        .collect();
+    let layers = design.copper_layers.par_iter();
     #[cfg(target_family = "wasm")]
-    let measured = design
-        .copper_layers
-        .iter()
+    let layers = design.copper_layers.iter();
+    let measured = layers
         .filter(|layer| conditions.applies_to_layer(layer))
-        .flat_map(measure)
+        .map(measure)
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
         .collect();
-    Evaluation {
+    Ok(Evaluation {
         checked: design
             .copper_layers
             .iter()
             .filter(|layer| conditions.applies_to_layer(layer))
             .count(),
         measured,
-    }
+    })
 }
 
-pub(super) fn soldermask_web(limit_mm: f64, design: &Design) -> Evaluation {
+pub(super) fn soldermask_web(limit_mm: f64, design: &Design) -> anyhow::Result<Evaluation> {
     let measure = |layer: &MaskLayer| {
         let boundaries = layer
             .owners
             .iter()
             .map(|owner| (owner.image.bbox, owner.image.prepare_query()))
             .collect::<Vec<_>>();
-        thin_gaps(&layer.image, limit_mm)
-            .into_iter()
-            .map(move |piece| {
-                let mut measured =
-                    measured_piece(&piece, limit_mm, &layer.layer, "soldermask_image");
-                let mut aggregate_owner = None;
-                let mut one_owner = true;
-                for (geometry, site) in piece.sites.iter().zip(&mut measured.sites) {
-                    let Some(owners) = wall_owners(&geometry.walls, &boundaries) else {
-                        one_owner = false;
-                        continue;
-                    };
-                    if owners.len() != 1 || aggregate_owner.is_some_and(|owner| owners[0] != owner)
-                    {
-                        one_owner = false;
+        Ok::<_, anyhow::Error>(
+            thin_gaps(&layer.image, limit_mm)?
+                .into_iter()
+                .map(move |piece| {
+                    let mut measured =
+                        measured_piece(&piece, limit_mm, &layer.layer, "soldermask_image");
+                    let mut aggregate_owner = None;
+                    let mut one_owner = true;
+                    for (geometry, site) in piece.sites.iter().zip(&mut measured.sites) {
+                        let Some(owners) = wall_owners(&geometry.walls, &boundaries) else {
+                            one_owner = false;
+                            continue;
+                        };
+                        if owners.len() != 1
+                            || aggregate_owner.is_some_and(|owner| owners[0] != owner)
+                        {
+                            one_owner = false;
+                        }
+                        aggregate_owner = aggregate_owner.or_else(|| owners.first().copied());
+                        site.subjects = owners
+                            .into_iter()
+                            .map(|index| mask_subject(design, &layer.owners[index], &layer.layer))
+                            .collect();
                     }
-                    aggregate_owner = aggregate_owner.or_else(|| owners.first().copied());
-                    site.subjects = owners
-                        .into_iter()
-                        .map(|index| mask_subject(design, &layer.owners[index], &layer.layer))
-                        .collect();
-                }
-                if one_owner && let Some(index) = aggregate_owner {
-                    measured.subjects[0].provenance =
-                        mask_subject(design, &layer.owners[index], &layer.layer).provenance;
-                }
-                measured
-            })
-            .collect::<Vec<_>>()
+                    if one_owner && let Some(index) = aggregate_owner {
+                        measured.subjects[0].provenance =
+                            mask_subject(design, &layer.owners[index], &layer.layer).provenance;
+                    }
+                    measured
+                })
+                .collect::<Vec<_>>(),
+        )
     };
     #[cfg(not(target_family = "wasm"))]
-    let measured = design
-        .mask_layers
-        .par_iter()
-        .flat_map_iter(measure)
-        .collect();
+    let layers = design.mask_layers.par_iter();
     #[cfg(target_family = "wasm")]
-    let measured = design.mask_layers.iter().flat_map(measure).collect();
-    Evaluation {
+    let layers = design.mask_layers.iter();
+    let measured = layers
+        .map(measure)
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect();
+    Ok(Evaluation {
         checked: design.mask_layers.len(),
         measured,
-    }
+    })
 }
 
 fn measured_piece(
@@ -296,7 +302,7 @@ pub(super) fn piece_sites(piece: &ThinPiece, limit_mm: f64, layer: &LayerRef) ->
     piece.sites.iter().map(|geometry| {
         let disk = geometry.disk;
         let bbox = geometry.bbox.union(BBox::from_point(disk.center).expand(limit_mm / 2.0));
-        let local_candidate = piece.candidate.intersection(&ContourSet::rectangle(bbox, tol::REGION_MM));
+        let local_candidate = piece.candidate.intersection(&ContourSet::rectangle(bbox, piece.candidate.resolution));
         let mut evidence = vec![
             Evidence::region("candidate_region", &local_candidate),
             Evidence::circle("inscribed_width_disk", disk.center, disk.radius_mm * 2.0),
@@ -328,6 +334,7 @@ pub(super) fn piece_sites(piece: &ThinPiece, limit_mm: f64, layer: &LayerRef) ->
 mod tests {
     use super::*;
     use crate::commands::dfm::design::ConductorId;
+    use pcb_ir::geom::Resolution;
 
     fn rectangle(x0: f64, y0: f64, x1: f64, y1: f64) -> ContourSet {
         ContourSet::rectangle(
@@ -335,7 +342,7 @@ mod tests {
                 min: Point::new(x0, y0),
                 max: Point::new(x1, y1),
             },
-            tol::REGION_MM,
+            Resolution::default(),
         )
     }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -1125,7 +1125,7 @@ fn compose_attributed_copper(
     for (_, image) in &owners {
         composer.push(pcb_ir::geom::Polarity::Dark, image.clone());
     }
-    let image = composer.finish();
+    let image = composer.finish()?;
     let conductors = owners
         .into_iter()
         .map(|(id, rings)| CopperConductor { id, image: rings })

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -1552,7 +1552,7 @@ fn collect_board_outlines(
                 ContourSet::from_filled_contours(&native_outline[..outer_count], resolution)?;
             let cutouts =
                 ContourSet::from_filled_contours(&native_outline[outer_count..], resolution)?;
-            let region = outer.difference(&cutouts);
+            let region = outer.difference(&cutouts).unwrap();
             if region.is_empty() {
                 return Ok(None);
             }
@@ -1800,8 +1800,19 @@ mod tests {
             slots[0].bbox
         );
         let reconstructed = ContourSet::from_filled_contours(native, resolution).unwrap();
-        assert!(reconstructed.difference(&slots[0].outline).is_empty());
-        assert!(slots[0].outline.difference(&reconstructed).is_empty());
+        assert!(
+            reconstructed
+                .difference(&slots[0].outline)
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            slots[0]
+                .outline
+                .difference(&reconstructed)
+                .unwrap()
+                .is_empty()
+        );
 
         let outline = slot_fixture(
             r#"<Outline>

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -9,6 +9,7 @@
 //! drilled feature whose plating, diameter, or outline the file does not
 //! state is an error, never a quietly dropped subject.
 
+use pcb_ir::geom::Resolution;
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{Context, Result, bail};
@@ -22,8 +23,8 @@ use pcb_ir::dialects::ipc::{
 use pcb_ir::dialects::{LayerRole, Side, artwork};
 use pcb_ir::geom::dfm::{Distance, WidthDisk, min_width_disk};
 use pcb_ir::geom::path::ContourBuf;
-use pcb_ir::geom::region::{Ring, union_rings};
-use pcb_ir::geom::{BBox, ContourSet, FillRule, Point, Polarity, PreparedRegion, Span, tol};
+use pcb_ir::geom::region::Ring;
+use pcb_ir::geom::{BBox, ContourSet, Point, Polarity, PreparedRegion, Span};
 #[cfg(not(target_family = "wasm"))]
 use rayon::prelude::*;
 
@@ -42,6 +43,9 @@ use super::rules::{self, Rule};
 pub(super) struct Design<'a> {
     pub imported: &'a ImportedDesign,
     pub scope: ArtworkScope,
+    /// The resolution every pool was prepared at; checks derive their own
+    /// constructions from it.
+    pub resolution: Resolution,
     pub stackup: Option<PhysicalStackup>,
     pub holes: Vec<Hole>,
     pub slots: Vec<Slot>,
@@ -71,6 +75,7 @@ impl<'a> Design<'a> {
         imported: &'a ImportedDesign,
         scope: ArtworkScope,
         rules: &[Rule],
+        resolution: Resolution,
     ) -> Result<Self> {
         let pools = rules::pools(rules);
         // Circular drill checks must use the declared physical order even
@@ -89,14 +94,20 @@ impl<'a> Design<'a> {
             || collect_physical_stackup(imported).map(Some),
         )?;
         let (holes, slots) = when(pools.drilled, || {
-            collect_drilled(imported, scope, stackup.as_ref())
+            collect_drilled(imported, scope, stackup.as_ref(), resolution)
         })?;
         let copper_layers = when(pools.copper, || {
-            collect_copper_layers(imported, scope, pools.conductor_ownership, stackup.as_ref())
+            collect_copper_layers(
+                imported,
+                scope,
+                pools.conductor_ownership,
+                stackup.as_ref(),
+                resolution,
+            )
         })?;
         let (physical_holes, land_indices) = when(pools.hole_lands || pools.slot_lands, || {
             let physical_holes = imported
-                .physical_holes(scope)?
+                .physical_holes(scope, resolution)?
                 .into_iter()
                 .map(|hole| (hole.id.0, hole))
                 .collect();
@@ -127,6 +138,7 @@ impl<'a> Design<'a> {
         let design = Self {
             imported,
             scope,
+            resolution,
             stackup,
             copper_boundaries: when(pools.copper_boundaries, || {
                 #[cfg(not(target_family = "wasm"))]
@@ -164,17 +176,21 @@ impl<'a> Design<'a> {
                     &physical_holes,
                 )
             })?,
-            mask_layers: when(pools.masks, || collect_mask_layers(imported, scope))?,
+            mask_layers: when(pools.masks, || {
+                collect_mask_layers(imported, scope, resolution)
+            })?,
             scores: when(pools.scores, || collect_scores(imported, scope))?,
             board_outlines: layout
                 .as_ref()
                 .filter(|_| pools.board_outlines)
-                .map(|layout| collect_board_outlines(imported, layout, scope))
+                .map(|layout| collect_board_outlines(imported, layout, scope, resolution))
+                .transpose()?
                 .unwrap_or_default(),
             board_arrays: layout
                 .as_ref()
                 .filter(|_| pools.board_arrays)
-                .map(|layout| collect_board_arrays(imported, layout))
+                .map(|layout| collect_board_arrays(imported, layout, resolution))
+                .transpose()?
                 .unwrap_or_default(),
             holes,
             slots,
@@ -775,6 +791,7 @@ fn collect_drilled(
     imported: &ImportedDesign,
     scope: ArtworkScope,
     stackup: Option<&PhysicalStackup>,
+    resolution: Resolution,
 ) -> Result<(Vec<Hole>, Vec<Slot>)> {
     let copper_count = imported
         .layer_definitions
@@ -854,8 +871,8 @@ fn collect_drilled(
                         bail!("{at} has unknown plating; DFM rules cannot certify it");
                     }
                     let contours = document.placed_feature_contours(feature);
-                    let outline = ContourSet::from_filled_contours(&contours, tol::REGION_MM);
-                    let Some(width_disk) = min_width_disk(&outline) else {
+                    let outline = ContourSet::from_filled_contours(&contours, resolution)?;
+                    let Some(width_disk) = min_width_disk(&outline)? else {
                         bail!("{at} has no measurable outline");
                     };
                     slots.push(Slot {
@@ -920,9 +937,7 @@ fn slot_width(stated_mm: f64, measured: Distance) -> Result<Distance> {
     if !(stated_mm > 0.0 && stated_mm.is_finite()) {
         return Ok(measured);
     }
-    // The outline's width is short by up to its uncertainty, plus the
-    // flattening slack the medial-axis pruning allows.
-    if (measured.mm - stated_mm).abs() > measured.uncertainty_mm + tol::FLATTEN_MM {
+    if (measured.mm - stated_mm).abs() > measured.uncertainty_mm {
         bail!(
             "states width {stated_mm:.6} mm but its outline measures {:.6} mm",
             measured.mm
@@ -1098,25 +1113,22 @@ impl ArtworkLowering<Symbol, Option<ConductorId>> for CopperAttributionLowering 
 
 fn compose_attributed_copper(
     document: &mut GeometryDocument,
+    resolution: Resolution,
 ) -> Result<(ContourSet, Vec<CopperConductor>)> {
-    let owners =
-        compose_attributed_owners(document, LayerRole::Copper, &mut CopperAttributionLowering)?;
-    let image = ContourSet::from_regularized(
-        union_rings(
-            owners
-                .iter()
-                .flat_map(|(_, rings)| rings.iter().cloned())
-                .collect(),
-            FillRule::NonZero,
-        ),
-        tol::REGION_MM,
-    );
+    let owners = compose_attributed_owners(
+        document,
+        LayerRole::Copper,
+        &mut CopperAttributionLowering,
+        resolution,
+    )?;
+    let mut composer = pcb_ir::geom::region::PaintComposer::new(resolution);
+    for (_, image) in &owners {
+        composer.push(pcb_ir::geom::Polarity::Dark, image.clone());
+    }
+    let image = composer.finish();
     let conductors = owners
         .into_iter()
-        .map(|(id, rings)| CopperConductor {
-            id,
-            image: ContourSet::from_regularized(rings, tol::REGION_MM),
-        })
+        .map(|(id, rings)| CopperConductor { id, image: rings })
         .collect();
     Ok((image, conductors))
 }
@@ -1128,8 +1140,9 @@ fn compose_attributed_owners<Owner: Clone + Eq + std::hash::Hash>(
     document: &mut GeometryDocument,
     role: LayerRole,
     lowering: &mut impl ArtworkLowering<Symbol, Option<Owner>>,
+    resolution: Resolution,
 ) -> Result<artwork::OwnerImages<Owner>> {
-    pcb_ir::dialects::ipc::process::normalize_for_artwork(document);
+    pcb_ir::dialects::ipc::process::normalize_for_artwork(document, resolution)?;
     pcb_ir::dialects::ipc::validate_artwork_ready(document)
         .map_err(|error| anyhow::anyhow!("layer is not artwork-ready: {error}"))?;
     let layer = document
@@ -1145,8 +1158,11 @@ fn compose_attributed_owners<Owner: Clone + Eq + std::hash::Hash>(
         meta: layer.layer_function,
     };
     let attributed_artwork = lower_layer_to_artwork_with(document, 0, header, lowering);
-    let (mut layers, _) =
-        artwork::compose_selected_owners(&attributed_artwork, |owner| Some(owner.clone()));
+    let (mut layers, _) = artwork::compose_owner_regions(
+        &attributed_artwork,
+        |owner| Some(owner.clone()),
+        resolution,
+    )?;
     let owners = layers
         .pop()
         .context("attributed artwork composition produced no layer")?;
@@ -1243,6 +1259,7 @@ fn collect_copper_layers(
     scope: ArtworkScope,
     require_conductor_ownership: bool,
     stackup: Option<&PhysicalStackup>,
+    resolution: Resolution,
 ) -> Result<Vec<CopperLayer>> {
     let mut copper_layers = imported
         .layer_definitions
@@ -1269,8 +1286,7 @@ fn collect_copper_layers(
         .map(|(ordinal, (layer_index, layer))| {
             let name = imported.resolve(layer.name);
             let mut document = imported
-                .materialize_layer(LayerId(layer_index as u32), scope)
-                .with_context(|| format!("failed to extract IPC-2581 copper layer '{name}'"))?;
+                .materialize_layer(LayerId(layer_index as u32), scope).with_context(|| format!("failed to extract IPC-2581 copper layer '{name}'"))?;
             pcb_ir::dialects::ipc::process::expand_feature_placement_groups(&mut document);
             let mut lands = Vec::new();
             for feature in document.features.iter().filter(|feature| {
@@ -1299,7 +1315,7 @@ fn collect_copper_layers(
                     provenance: feature_provenance(imported, name, feature),
                 });
             }
-            let (image, mut conductors) = compose_attributed_copper(&mut document)?;
+            let (image, mut conductors) = compose_attributed_copper(&mut document, resolution)?;
             conductors.sort_by_key(|conductor| conductor_order(imported, conductor.id));
             if require_conductor_ownership
                 && let Some(conductor) = conductors
@@ -1385,7 +1401,11 @@ impl ArtworkLowering<Symbol, Option<(Option<Symbol>, Option<u32>)>> for MaskAttr
     }
 }
 
-fn collect_mask_layers(imported: &ImportedDesign, scope: ArtworkScope) -> Result<Vec<MaskLayer>> {
+fn collect_mask_layers(
+    imported: &ImportedDesign,
+    scope: ArtworkScope,
+    resolution: Resolution,
+) -> Result<Vec<MaskLayer>> {
     let layers = imported
         .layer_definitions
         .iter()
@@ -1402,17 +1422,18 @@ fn collect_mask_layers(imported: &ImportedDesign, scope: ArtworkScope) -> Result
             let mut document = imported
                 .materialize_layer(LayerId(layer_index as u32), scope)
                 .with_context(|| format!("failed to extract soldermask layer '{name}'"))?;
-            // Keep the historical all-material fold bit-for-bit for measurements
-            // and waiver IDs. Grouping boolean operations by source occurrence
-            // can shift snapped vertices by nanometers. The separate attributed
-            // fold supplies source labels only; it never replaces this image.
-            let image =
-                crate::copper_balance::composed_copper_image_from_document(document.clone());
+            let image = document.clone().into_layer_image(
+                0,
+                LayerRole::Soldermask,
+                pcb_ir::dialects::Side::None,
+                resolution,
+            )?;
             pcb_ir::dialects::ipc::process::expand_feature_placement_groups(&mut document);
             let owners = compose_attributed_owners(
                 &mut document,
                 LayerRole::Soldermask,
                 &mut MaskAttributionLowering,
+                resolution,
             )?;
             Ok(MaskLayer {
                 layer: layer_ref(
@@ -1426,7 +1447,7 @@ fn collect_mask_layers(imported: &ImportedDesign, scope: ArtworkScope) -> Result
                     .map(|((step, instance_index), rings)| MaskOwner {
                         step,
                         instance_index,
-                        image: ContourSet::from_regularized(rings, tol::REGION_MM),
+                        image: rings,
                     })
                     .collect(),
             })
@@ -1507,8 +1528,9 @@ fn collect_board_outlines(
     imported: &ImportedDesign,
     layout: &GeometryDocument,
     scope: ArtworkScope,
-) -> Vec<BoardOutline> {
-    profile_occurrences_for(layout, scope.profile_set())
+    resolution: Resolution,
+) -> anyhow::Result<Vec<BoardOutline>> {
+    Ok(profile_occurrences_for(layout, scope.profile_set())
         .into_iter()
         .filter(|occurrence| {
             matches!(
@@ -1518,7 +1540,7 @@ fn collect_board_outlines(
                     | ProfileOccurrenceRole::BoardInstance
             )
         })
-        .filter_map(|occurrence| {
+        .map(|occurrence| {
             let mut native_outline = layout
                 .transformed_path_contours(occurrence.profile.outer_path, occurrence.transform);
             let outer_count = native_outline.len();
@@ -1527,12 +1549,12 @@ fn collect_board_outlines(
                     .extend(layout.transformed_path_contours(cutout.path, occurrence.transform));
             }
             let outer =
-                ContourSet::from_filled_contours(&native_outline[..outer_count], tol::REGION_MM);
+                ContourSet::from_filled_contours(&native_outline[..outer_count], resolution)?;
             let cutouts =
-                ContourSet::from_filled_contours(&native_outline[outer_count..], tol::REGION_MM);
+                ContourSet::from_filled_contours(&native_outline[outer_count..], resolution)?;
             let region = outer.difference(&cutouts);
             if region.is_empty() {
-                return None;
+                return Ok(None);
             }
             let bbox = region.bbox;
             let name = occurrence
@@ -1541,7 +1563,7 @@ fn collect_board_outlines(
                 .map(|step| imported.resolve(step.source_step_ref).to_owned())
                 .unwrap_or_else(|| "board".to_owned());
             let boundary = region.prepare_query();
-            Some(BoardOutline {
+            Ok::<_, anyhow::Error>(Some(BoardOutline {
                 name,
                 instance_index: occurrence.instance,
                 contours: region.rings.clone(),
@@ -1549,14 +1571,21 @@ fn collect_board_outlines(
                 boundary,
                 native_outline,
                 bbox,
-            })
+            }))
         })
-        .collect()
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect())
 }
 
-fn collect_board_arrays(imported: &ImportedDesign, layout: &GeometryDocument) -> Vec<BoardArray> {
+fn collect_board_arrays(
+    imported: &ImportedDesign,
+    layout: &GeometryDocument,
+    resolution: Resolution,
+) -> anyhow::Result<Vec<BoardArray>> {
     let Some(root_step) = layout.layout.root_step else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
     // A panel-kind child that wraps exactly one board is per-board packaging
     // (a cell in a larger grid), not a sibling array to keep spacing from; a
@@ -1574,7 +1603,7 @@ fn collect_board_arrays(imported: &ImportedDesign, layout: &GeometryDocument) ->
             _ => false,
         }
     };
-    layout
+    Ok(layout
         .layout
         .instances
         .iter()
@@ -1585,24 +1614,32 @@ fn collect_board_arrays(imported: &ImportedDesign, layout: &GeometryDocument) ->
                 && layout.layout.steps[instance.child_step as usize].kind == LayoutStepKind::Panel
                 && !wraps_single_board(*instance_index)
         })
-        .filter_map(|(instance_index, instance)| {
+        .map(|(instance_index, instance)| {
             let step = &layout.layout.steps[instance.child_step as usize];
             let contours = step
                 .profiles
                 .slice(&layout.profiles)
                 .iter()
-                .flat_map(|profile| {
-                    layout.transformed_path_contours(profile.outer_path, instance.transform)
+                .map(|profile| {
+                    Ok::<_, anyhow::Error>(
+                        layout.transformed_path_contours(profile.outer_path, instance.transform),
+                    )
                 })
+                .collect::<anyhow::Result<Vec<_>>>()?
+                .into_iter()
+                .flatten()
                 .collect::<Vec<_>>();
-            let region = ContourSet::from_filled_contours(&contours, tol::REGION_MM);
-            (!region.is_empty()).then(|| BoardArray {
+            let region = ContourSet::from_filled_contours(&contours, resolution)?;
+            Ok::<_, anyhow::Error>((!region.is_empty()).then(|| BoardArray {
                 name: imported.resolve(step.source_step_ref).to_owned(),
                 instance_index: instance_index as u32,
                 region,
-            })
+            }))
         })
-        .collect()
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
+        .flatten()
+        .collect())
 }
 
 fn layer_ref(name: &str, function: LayerFunction, side: Option<&'static str>) -> LayerRef {
@@ -1620,6 +1657,8 @@ mod tests {
 
     #[test]
     fn mask_owners_preserve_composed_openings_and_repeat_identity() {
+        let resolution = Resolution::default();
+
         let rectangle = |polarity, min, max| {
             format!(
                 r#"<Set polarity="{polarity}"><Features><UserSpecial><Contour><Polygon>
@@ -1659,8 +1698,15 @@ mod tests {
                 ArtworkScope::ArrayFlattened,
             )
             .unwrap();
-        let previous = crate::copper_balance::composed_copper_image_from_document(document);
-        let layer = collect_mask_layers(&imported, ArtworkScope::ArrayFlattened)
+        let previous = document
+            .into_layer_image(
+                0,
+                LayerRole::Soldermask,
+                pcb_ir::dialects::Side::None,
+                resolution,
+            )
+            .unwrap();
+        let layer = collect_mask_layers(&imported, ArtworkScope::ArrayFlattened, resolution)
             .unwrap()
             .remove(0);
         assert_eq!(
@@ -1719,12 +1765,14 @@ mod tests {
 
     #[test]
     fn slot_width_is_stated_when_given_and_measured_otherwise() {
+        let resolution = Resolution::default();
+
         let oval = slot_fixture(
             r#"<Location x="10" y="20"/>
               <Oval width="1.8" height="0.6"/>"#,
         );
         let oval = import_design(&oval).unwrap();
-        let (_, slots) = collect_drilled(&oval, ArtworkScope::Board, None).unwrap();
+        let (_, slots) = collect_drilled(&oval, ArtworkScope::Board, None, resolution).unwrap();
         assert_eq!(slots.len(), 1);
         assert!((slots[0].width.mm - 0.6).abs() < 1e-9);
         assert_eq!(
@@ -1751,7 +1799,7 @@ mod tests {
                 .fold(BBox::empty(), BBox::union),
             slots[0].bbox
         );
-        let reconstructed = ContourSet::from_filled_contours(native, tol::REGION_MM);
+        let reconstructed = ContourSet::from_filled_contours(native, resolution).unwrap();
         assert!(reconstructed.difference(&slots[0].outline).is_empty());
         assert!(slots[0].outline.difference(&reconstructed).is_empty());
 
@@ -1768,7 +1816,7 @@ mod tests {
               </Outline>"#,
         );
         let outline = import_design(&outline).unwrap();
-        let (_, slots) = collect_drilled(&outline, ArtworkScope::Board, None).unwrap();
+        let (_, slots) = collect_drilled(&outline, ArtworkScope::Board, None, resolution).unwrap();
         assert_eq!(slots.len(), 1);
         let width = slots[0].width;
         assert!(
@@ -1797,12 +1845,14 @@ mod tests {
 
     #[test]
     fn stated_width_must_match_the_outline() {
+        let resolution = Resolution::default();
+
         let ipc = slot_fixture(
             r#"<Location x="10" y="20"/>
               <Oval width="1.8" height="0.6"/>"#,
         );
         let imported = import_design(&ipc).unwrap();
-        let oval = collect_drilled(&imported, ArtworkScope::Board, None)
+        let oval = collect_drilled(&imported, ArtworkScope::Board, None, resolution)
             .unwrap()
             .1
             .remove(0);

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/scene.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/scene.rs
@@ -10,7 +10,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Context, Result, ensure};
 use pcb_ir::dialects::ipc::{ArtworkScope, ProfileSet, profile_occurrences_for};
 use pcb_ir::dialects::{LayerRole, Side, mask};
-use pcb_ir::geom::path::{ContourBuf, PathCmd, transform_cmds};
+use pcb_ir::geom::path::{ContourBuf, PathCmd};
 use pcb_ir::geom::{Affine2, BBox, FillRule, Point, shapes};
 use pcb_ir::render::RenderOptions;
 
@@ -85,13 +85,15 @@ impl GeometryPass {
     }
 
     fn svg(&self, design: &Design<'_>, bounds: BBox) -> Result<String> {
-        let options = RenderOptions::default().with_viewport(bounds);
+        let options = RenderOptions::default()
+            .with_viewport(bounds)
+            .with_accuracy(design.resolution.accuracy);
         match &self.source {
             GeometrySource::Layer => {
                 let layer = self.layer.as_deref().context("artwork pass has no layer")?;
                 let artwork = native_artwork(design, layer)
                     .with_context(|| format!("failed to prepare DFM scene layer {layer}"))?;
-                Ok(pcb_ir::render::artwork_svg(&artwork, &options))
+                Ok(pcb_ir::render::artwork_svg(&artwork, &options)?)
             }
             GeometrySource::Shapes { shapes, fill_rule } => {
                 let mut doc = mask::Document::<()>::new();
@@ -113,12 +115,9 @@ fn native_artwork(
 ) -> Result<
     pcb_ir::dialects::artwork::Document<ipc2581::types::LayerFunction, Option<ipc2581::Symbol>>,
 > {
-    let geometry = geometry::render::prepare_layer(design.imported, layer, design.scope)?;
-    Ok(geometry::render::layer_artwork(
-        &geometry,
-        false,
-        design.scope.profile_set(),
-    ))
+    let geometry =
+        geometry::render::prepare_layer(design.imported, layer, design.scope, design.resolution)?;
+    geometry::render::layer_artwork(&geometry, false, design.scope.profile_set())
 }
 
 pub(super) fn export(
@@ -127,7 +126,7 @@ pub(super) fn export(
     rules: &[RuleResult],
     findings: &[Finding],
 ) -> Result<Scene> {
-    let sources = scene_passes(rules, design);
+    let sources = scene_passes(rules, design)?;
     let mut bounds = scene_bounds(layout.bounding_box, &sources);
     for finding in findings {
         let rule = rules
@@ -206,7 +205,7 @@ fn scene_bounds(layout: Option<ReportBBox>, sources: &[GeometryPass]) -> BBox {
     )
 }
 
-fn scene_passes(rules: &[RuleResult], design: &Design<'_>) -> Vec<GeometryPass> {
+fn scene_passes(rules: &[RuleResult], design: &Design<'_>) -> anyhow::Result<Vec<GeometryPass>> {
     let layout = &design.imported.geometry;
     let wanted = rules
         .iter()
@@ -244,10 +243,7 @@ fn scene_passes(rules: &[RuleResult], design: &Design<'_>) -> Vec<GeometryPass> 
                 layers
                     .entry(hole.layer.name.clone())
                     .or_default()
-                    .push(vec![transform_cmds(
-                        circle.cmds,
-                        Affine2::translation(hole.center),
-                    )]);
+                    .push(vec![circle.transformed(Affine2::translation(hole.center))]);
             }
         }
         for slot in &design.slots {
@@ -314,8 +310,10 @@ fn scene_passes(rules: &[RuleResult], design: &Design<'_>) -> Vec<GeometryPass> 
                 contours
                     .extend(layout.transformed_path_contours(cutout.path, occurrence.transform));
             }
-            contours
+            Ok::<_, anyhow::Error>(contours)
         })
+        .collect::<anyhow::Result<Vec<_>>>()?
+        .into_iter()
         .collect::<Vec<_>>();
     passes.push(GeometryPass::shapes(
         "Physical outlines".into(),
@@ -332,20 +330,25 @@ fn scene_passes(rules: &[RuleResult], design: &Design<'_>) -> Vec<GeometryPass> 
             .iter()
             .map(|array| array.instance_index)
             .collect::<BTreeSet<_>>();
-        let outlines = profile_occurrences_for(layout, ProfileSet::LayoutBoundaries)
-            .into_iter()
-            .filter(|occurrence| {
-                occurrence
-                    .instance
-                    .is_none_or(|index| arrays.contains(&index))
-            })
-            .map(|occurrence| {
-                // Retain native profile arcs instead of reconstructing the
-                // check's tessellated array region for display.
-                layout
-                    .transformed_path_contours(occurrence.profile.outer_path, occurrence.transform)
-            })
-            .collect();
+        let outlines =
+            profile_occurrences_for(layout, ProfileSet::LayoutBoundaries)
+                .into_iter()
+                .filter(|occurrence| {
+                    occurrence
+                        .instance
+                        .is_none_or(|index| arrays.contains(&index))
+                })
+                .map(|occurrence| {
+                    // Retain native profile arcs instead of reconstructing the
+                    // check's tessellated array region for display.
+                    Ok::<_, anyhow::Error>(layout.transformed_path_contours(
+                        occurrence.profile.outer_path,
+                        occurrence.transform,
+                    ))
+                })
+                .collect::<anyhow::Result<Vec<_>>>()?
+                .into_iter()
+                .collect();
         passes.push(GeometryPass::shapes(
             "Array / panel outlines".into(),
             "array_outlines",
@@ -356,7 +359,7 @@ fn scene_passes(rules: &[RuleResult], design: &Design<'_>) -> Vec<GeometryPass> 
             outlines,
         ));
     }
-    passes
+    Ok(passes)
 }
 
 #[cfg(test)]
@@ -364,7 +367,7 @@ mod tests {
     use super::super::{pdk, rules};
     use super::*;
     use crate::ipc2581::Ipc2581;
-    use pcb_ir::geom::{ContourSet, tol};
+    use pcb_ir::geom::{ContourSet, Resolution};
 
     const MASK_BOARD: &str = r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
       <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/><LayerRef name="F.Mask"/></Content>
@@ -395,18 +398,20 @@ mod tests {
 
     #[test]
     fn native_mask_scene_preserves_openings_voids_and_world_coordinates() {
+        let resolution = Resolution::default();
+
         let ipc = Ipc2581::parse(MASK_BOARD).unwrap();
         let rules = rules::lower(&pdk::Pdk::parse(MASK_PDK).unwrap(), None).unwrap();
         let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-        let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+        let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
         let artwork = native_artwork(&design, "F.Mask").unwrap();
-        let rendered = pcb_ir::dialects::artwork::compose_to_mask(&artwork);
+        let rendered = pcb_ir::dialects::artwork::compose_to_mask(&artwork, resolution).unwrap();
         let contours = rendered
             .shapes(&rendered.layers[0])
             .iter()
             .flat_map(|shape| rendered.arena.path_contours(shape))
             .collect::<Vec<_>>();
-        let image = ContourSet::from_contours(&contours, FillRule::NonZero, tol::REGION_MM);
+        let image = ContourSet::from_contours(&contours, FillRule::NonZero, resolution).unwrap();
         let samples = [Point::ZERO, Point::new(8.0, 0.0), Point::new(15.0, 0.0)];
         assert_eq!(image.contains_points_batch(&samples), [false, true, false]);
         assert_eq!(
@@ -434,13 +439,15 @@ mod tests {
 
     #[test]
     fn outlines_and_drills_remain_full_native_paths_outside_any_site() {
+        let resolution = Resolution::default();
+
         let ipc = Ipc2581::parse(MASK_BOARD).unwrap();
         let rules = rules::lower(&pdk::Pdk::parse(MASK_PDK).unwrap(), None).unwrap();
         let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
-        let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+        let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
         let outline = ContourSet::rectangle(
             BBox::new(Point::new(-50.0, -50.0), Point::new(50.0, 50.0)),
-            tol::REGION_MM,
+            resolution,
         );
         let pass = GeometryPass::shapes(
             "Physical outlines".into(),
@@ -460,10 +467,9 @@ mod tests {
         assert!(svg.contains("50"));
         assert!(svg.contains("fill='none'"));
 
-        let circle = transform_cmds(
-            shapes::circle(1.0).unwrap().cmds,
-            Affine2::translation(Point::new(40.0, -30.0)),
-        );
+        let circle = shapes::circle(1.0)
+            .unwrap()
+            .transformed(Affine2::translation(Point::new(40.0, -30.0)));
         let drill = GeometryPass::shapes(
             "Drills".into(),
             "drills",

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
@@ -62,7 +62,7 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
                 ArtworkScope::ArrayFlattened,
                 resolution,
             )
-            .map(|image| (layer_name.clone(), image.intersection(&usable_region)))
+            .and_then(|image| Ok((layer_name.clone(), image.intersection(&usable_region)?)))
     };
     let copper_images = map_layers(&layer_names, extract)
         .into_iter()
@@ -75,9 +75,9 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
     let stray_copper = copper_images
         .iter()
         .map(|(_, image)| image.difference(&footprints))
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
     for stray in &stray_copper {
-        input.support_features = input.support_features.union(stray);
+        input.support_features = input.support_features.union(stray)?;
     }
 
     let balancing_region = board_array_balancing_region(&input, BalancingRegionOptions::default())
@@ -94,7 +94,7 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
     // target. Everything else inside the usable region — clearance around each
     // placed panel, material removal, gaps too narrow for a void — can never
     // hold generated copper and so stays out of the density denominator.
-    let panel_domain = footprints.union(&safe_region);
+    let panel_domain = footprints.union(&safe_region)?;
 
     let stack_weights = physical_copper_stack_weights(ipc);
     let stack_weights_available = stack_weights.is_some();
@@ -102,23 +102,23 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
         .into_iter()
         .zip(stray_copper)
         .map(|((layer_name, existing_copper), stray)| {
-            let target_density = (existing_copper.intersection(&footprints).area()
+            let target_density = (existing_copper.intersection(&footprints)?.area()
                 / footprint_area_mm2)
                 .clamp(0.0, 1.0);
             let stack_weight_mm2 = stack_weights
                 .as_ref()
                 .and_then(|weights| weights.get(&layer_name).copied())
                 .unwrap_or(0.0);
-            PreparedCopperLayer {
+            Ok(PreparedCopperLayer {
                 layer_name,
                 target_density,
                 stack_weight_mm2,
                 existing_copper,
                 safe_region: safe_region.clone(),
-                density_domain: panel_domain.union(&stray),
-            }
+                density_domain: panel_domain.union(&stray)?,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>>>()?;
 
     solve_copper_balance(
         &usable_region,

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
@@ -11,7 +11,7 @@ use pcb_ir::dialects::ipc::{
     BalancingRegionOptions, board_array_balancing_region, collect_fab_panel_balancing_input,
 };
 use pcb_ir::geom::Resolution;
-use pcb_ir::geom::copper_balance::map_layers;
+use pcb_ir::geom::copper_balance::{DenseCopperBalanceProfile, map_layers};
 use pcb_ir::geom::{BBox, ContourSet};
 use pcb_ir::import::ipc2581::import_design;
 
@@ -30,11 +30,14 @@ use crate::ipc2581::Ipc2581;
 /// between them. `ipc` must describe the completed, not-yet-balanced
 /// fabrication panel, and `usable` the stock region between the reserved
 /// process margins; the margins never enter the density domain and stay bare.
+/// Balance geometry is prepared to the profile's own accuracy; `tolerance_mm`
+/// only sets which features are significant.
 pub(super) fn generate_automatic_fab_panel_copper_balance(
     ipc: &Ipc2581,
     usable: BBox,
-    resolution: Resolution,
+    tolerance_mm: f64,
 ) -> Result<CopperBalancePlan> {
+    let resolution = Resolution::new(tolerance_mm, DenseCopperBalanceProfile::V1.accuracy);
     let imported = import_design(ipc)?;
     let layout = &imported.geometry;
     // V-scores and profile cutouts all lie inside the placed assembly panels,

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
@@ -6,13 +6,17 @@
 //! own, so one certified safe region serves the whole copper stack.
 
 use anyhow::{Context, Result, bail};
+use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::dialects::ipc::{
     BalancingRegionOptions, board_array_balancing_region, collect_fab_panel_balancing_input,
 };
-use pcb_ir::geom::{BBox, ContourSet, tol};
+use pcb_ir::geom::Resolution;
+use pcb_ir::geom::copper_balance::map_layers;
+use pcb_ir::geom::{BBox, ContourSet};
+use pcb_ir::import::ipc2581::import_design;
 
 use crate::copper_balance::{
-    CERTIFICATE_AREA_TOLERANCE_MM2, CopperBalancePlan, PreparedCopperLayer, composed_copper_image,
+    CERTIFICATE_AREA_TOLERANCE_MM2, CopperBalancePlan, PreparedCopperLayer,
     physical_copper_stack_weights, solve_copper_balance,
 };
 use crate::geometry;
@@ -29,14 +33,16 @@ use crate::ipc2581::Ipc2581;
 pub(super) fn generate_automatic_fab_panel_copper_balance(
     ipc: &Ipc2581,
     usable: BBox,
+    resolution: Resolution,
 ) -> Result<CopperBalancePlan> {
-    let layout = geometry::extract_layout(ipc)
-        .context("failed to extract fabrication-panel layout for copper balancing")?;
+    let imported = import_design(ipc)?;
+    let layout = &imported.geometry;
     // V-scores and profile cutouts all lie inside the placed assembly panels,
     // so the fabrication profile needs no relief geometry here.
-    let fabrication_profile = geometry::board_array_fabrication_profile(ipc, &layout, &[])
-        .context("failed to derive fabrication-panel profile for copper balancing")?;
-    let usable_region = ContourSet::rectangle(usable, tol::REGION_MM);
+    let fabrication_profile =
+        geometry::board_array_fabrication_profile(&imported, layout, &[], resolution)
+            .context("failed to derive fabrication-panel profile for copper balancing")?;
+    let usable_region = ContourSet::rectangle(usable, resolution);
     let mut input = collect_fab_panel_balancing_input(usable_region.clone(), &fabrication_profile)
         .context("failed to collect fabrication-panel balancing obstacles")?;
     let footprints = input.board_footprints.clone();
@@ -48,24 +54,18 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
         .map(|layer| ipc.resolve(layer.name).to_string())
         .collect::<Vec<_>>();
     let extract = |layer_name: &String| {
-        composed_copper_image(ipc, layer_name)
+        imported
+            .composed_layer_image(
+                imported
+                    .layer_id(layer_name)
+                    .context("missing copper layer")?,
+                ArtworkScope::ArrayFlattened,
+                resolution,
+            )
             .map(|image| (layer_name.clone(), image.intersection(&usable_region)))
     };
-    #[cfg(not(target_family = "wasm"))]
-    let copper_images = std::thread::scope(|scope| {
-        let extractions = layer_names
-            .iter()
-            .map(|layer_name| scope.spawn(|| extract(layer_name)))
-            .collect::<Vec<_>>();
-        extractions
-            .into_iter()
-            .map(|extraction| extraction.join().expect("copper-image extraction panicked"))
-            .collect::<Result<Vec<_>>>()
-    })?;
-    #[cfg(target_family = "wasm")]
-    let copper_images = layer_names
-        .iter()
-        .map(extract)
+    let copper_images = map_layers(&layer_names, extract)
+        .into_iter()
         .collect::<Result<Vec<_>>>()?;
     // Copper found outside the placed panels joins the shared obstacle set,
     // so unexpected overhang shrinks the certified safe region for every

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -1,3 +1,4 @@
+use pcb_ir::geom::Resolution;
 #[cfg(feature = "cli")]
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -223,6 +224,8 @@ pub fn execute(
     spec: FabPanelSpec,
     balance_copper: bool,
 ) -> Result<()> {
+    let resolution = Resolution::default();
+
     if inputs.is_empty() {
         bail!("at least one assembly panel IPC-2581 file is required");
     }
@@ -250,7 +253,7 @@ pub fn execute(
         occurrences.push(source_index);
     }
 
-    let creation = create_fab_panel(&source_xml, &occurrences, spec, balance_copper)?;
+    let creation = create_fab_panel(&source_xml, &occurrences, spec, balance_copper, resolution)?;
     if let Some(report) = &creation.copper_balance {
         for line in report.summary_lines() {
             eprintln!("  {line}");
@@ -271,8 +274,16 @@ pub fn execute(
 
 #[cfg(test)]
 fn create_fab_panel_xml(source_xml: &[String], occurrences: &[usize]) -> Result<String> {
-    create_fab_panel(source_xml, occurrences, FabPanelSpec::default(), false)
-        .map(|creation| creation.xml)
+    let resolution = Resolution::default();
+
+    create_fab_panel(
+        source_xml,
+        occurrences,
+        FabPanelSpec::default(),
+        false,
+        resolution,
+    )
+    .map(|creation| creation.xml)
 }
 
 pub fn create_fab_panel(
@@ -280,6 +291,7 @@ pub fn create_fab_panel(
     occurrences: &[usize],
     spec: FabPanelSpec,
     balance_copper: bool,
+    resolution: Resolution,
 ) -> Result<FabPanelCreation> {
     if occurrences.is_empty() {
         bail!("at least one assembly panel is required");
@@ -380,6 +392,7 @@ pub fn create_fab_panel(
         let balance = balance::generate_automatic_fab_panel_copper_balance(
             &parsed,
             spec.output_usable_bbox()?,
+            resolution,
         )?;
         let report = balance.report();
         let features = balance

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -392,7 +392,7 @@ pub fn create_fab_panel(
         let balance = balance::generate_automatic_fab_panel_copper_balance(
             &parsed,
             spec.output_usable_bbox()?,
-            resolution,
+            resolution.tolerance_mm,
         )?;
         let report = balance.report();
         let features = balance

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -1,10 +1,33 @@
 use ipc2581::edit::Doc;
 use pcb_ir::dialects::ipc::{ArtworkScope, root_step};
-use pcb_ir::geom::{BBox, ContourSet, Point, tol};
+use pcb_ir::geom::Resolution;
+use pcb_ir::geom::{BBox, ContourSet, Point};
 
-use crate::copper_balance::{CopperBalanceMode, composed_copper_image};
+use crate::copper_balance::CopperBalanceMode;
+use crate::manufacturing::{
+    ManufacturingExportOptions, ManufacturingPackage, build_manufacturing_package,
+};
+use pcb_ir::import::ipc2581::ImportedDesign;
 
 use super::*;
+
+fn design(ipc: &Ipc2581) -> ImportedDesign {
+    pcb_ir::import::ipc2581::import_design(ipc).unwrap()
+}
+
+fn manufacturing_package(
+    ipc: &Ipc2581,
+    view: ArtworkScope,
+) -> anyhow::Result<ManufacturingPackage> {
+    build_manufacturing_package(
+        &design(ipc),
+        &ManufacturingExportOptions {
+            view,
+            relief_debug_dir: None,
+        },
+        Resolution::default(),
+    )
+}
 
 const FAB_PANEL_WIDTH_MM: f64 = FabPanelSpec::INCHES_18_X_24.width_mm();
 const FAB_PANEL_HEIGHT_MM: f64 = FabPanelSpec::INCHES_18_X_24.height_mm();
@@ -222,6 +245,8 @@ fn assembly_panel_with_non_manufacturing_data() -> String {
 
 #[test]
 fn exports_separate_nominal_panel_outlines_and_board_cutouts() {
+    let resolution = Resolution::default();
+
     let sources = vec![
         assembly_panel_with_profile_cutouts_xml(100.0, 80.0),
         assembly_panel_xml_at(-15.0, 7.0, 120.0, 90.0),
@@ -231,7 +256,9 @@ fn exports_separate_nominal_panel_outlines_and_board_cutouts() {
     Ipc2581::validate(&generated).unwrap();
     let parsed = Ipc2581::parse(&generated).unwrap();
     let layout = geometry::extract_layout(&parsed).unwrap();
-    let profile = geometry::board_array_fabrication_profile(&parsed, &layout, &[]).unwrap();
+    let profile =
+        geometry::board_array_fabrication_profile(&design(&parsed), &layout, &[], resolution)
+            .unwrap();
     let placed_panels = layout
         .layout
         .instances
@@ -283,9 +310,7 @@ fn exports_separate_nominal_panel_outlines_and_board_cutouts() {
         .expand(profile_stroke_radius);
     let expected_cutout_bbox =
         contour_bbox(profile.material_removal.iter()).expand(profile_stroke_radius);
-    let package =
-        crate::manufacturing::build_manufacturing_package(&parsed, ArtworkScope::ArrayFlattened)
-            .unwrap();
+    let package = manufacturing_package(&parsed, ArtworkScope::ArrayFlattened).unwrap();
     for (filename, expected_bbox) in [
         ("Fab_Panel_Outline.gm1", expected_fab_bbox),
         ("Assembly_Panel_Outlines.gm1", expected_assembly_bbox),
@@ -302,7 +327,8 @@ fn exports_separate_nominal_panel_outlines_and_board_cutouts() {
         assert!(file.contents.contains("%ADD10C,0.05*%"));
         assert!(!file.contents.contains("C,1*%"));
         let parsed_gerber = gerberx2::GerberX2::parse(&file.contents).unwrap();
-        let artwork = gerberx2::geometry::extract_document(&parsed_gerber);
+        let artwork =
+            gerberx2::geometry::extract_document(&parsed_gerber, resolution.accuracy).unwrap();
         assert_bbox_close(artwork.layers[0].bbox, expected_bbox);
         let crate::manufacturing::ManufacturingFileKind::GerberX2(layer) = &file.kind else {
             panic!("{filename} is not a Gerber layer");
@@ -452,6 +478,8 @@ fn repeating_an_input_reuses_its_definitions_and_adds_placements() {
 
 #[test]
 fn creates_supported_standard_fabrication_panel_sizes() {
+    let resolution = Resolution::default();
+
     let sources = vec![assembly_panel_xml(100.0, 80.0)];
 
     for (spec, usable_width, usable_height) in [
@@ -460,7 +488,9 @@ fn creates_supported_standard_fabrication_panel_sizes() {
         (FabPanelSpec::INCHES_18_X_24, 406.4, 508.0),
         (FabPanelSpec::INCHES_21_X_24, 482.6, 508.0),
     ] {
-        let generated = create_fab_panel(&sources, &[0], spec, false).unwrap().xml;
+        let generated = create_fab_panel(&sources, &[0], spec, false, resolution)
+            .unwrap()
+            .xml;
         Ipc2581::validate(&generated).unwrap();
         let parsed = Ipc2581::parse(&generated).unwrap();
         let layout = geometry::extract_layout(&parsed).unwrap();
@@ -496,6 +526,8 @@ fn writes_default_process_margin_and_usable_area_metadata() {
 
 #[test]
 fn emits_usable_area_profile_rebased_to_origin() {
+    let resolution = Resolution::default();
+
     let stock_spec = FabPanelSpec {
         edge_margin_mm: EdgeInsetsMm::all(25.4),
         ..FabPanelSpec::INCHES_18_X_24
@@ -505,10 +537,10 @@ fn emits_usable_area_profile_rebased_to_origin() {
         ..stock_spec
     };
     let sources = [assembly_panel_xml(100.0, 80.0)];
-    let stock_xml = create_fab_panel(&sources, &[0], stock_spec, false)
+    let stock_xml = create_fab_panel(&sources, &[0], stock_spec, false, resolution)
         .unwrap()
         .xml;
-    let emitted_xml = create_fab_panel(&sources, &[0], emitted_spec, false)
+    let emitted_xml = create_fab_panel(&sources, &[0], emitted_spec, false, resolution)
         .unwrap()
         .xml;
 
@@ -548,16 +580,15 @@ fn emits_usable_area_profile_rebased_to_origin() {
         r#"<NonstandardAttribute name="diode.fab_panel.output_region" type="STRING" value="usable"/>"#
     ));
 
-    let package =
-        crate::manufacturing::build_manufacturing_package(&emitted, ArtworkScope::ArrayFlattened)
-            .unwrap();
+    let package = manufacturing_package(&emitted, ArtworkScope::ArrayFlattened).unwrap();
     let outline = package
         .files
         .iter()
         .find(|file| file.filename == "Fab_Panel_Outline.gm1")
         .unwrap();
     let parsed_gerber = gerberx2::GerberX2::parse(&outline.contents).unwrap();
-    let artwork = gerberx2::geometry::extract_document(&parsed_gerber);
+    let artwork =
+        gerberx2::geometry::extract_document(&parsed_gerber, resolution.accuracy).unwrap();
     assert_bbox_close(
         artwork.layers[0].bbox,
         BBox::new(Point::new(0.0, 0.0), Point::new(406.4, 558.8)).expand(0.025),
@@ -566,14 +597,22 @@ fn emits_usable_area_profile_rebased_to_origin() {
 
 #[test]
 fn applies_asymmetric_process_margin_and_gap_overrides() {
+    let resolution = Resolution::default();
+
     let spec = FabPanelSpec {
         edge_margin_mm: EdgeInsetsMm::new(30.0, 20.0, 10.0, 40.0),
         panel_gap_mm: 7.0,
         ..FabPanelSpec::INCHES_12_X_18
     };
-    let generated = create_fab_panel(&[assembly_panel_xml(100.0, 80.0)], &[0], spec, false)
-        .unwrap()
-        .xml;
+    let generated = create_fab_panel(
+        &[assembly_panel_xml(100.0, 80.0)],
+        &[0],
+        spec,
+        false,
+        resolution,
+    )
+    .unwrap()
+    .xml;
     let parsed = Ipc2581::parse(&generated).unwrap();
     let layout = geometry::extract_layout(&parsed).unwrap();
     let instance = layout
@@ -600,6 +639,8 @@ fn applies_asymmetric_process_margin_and_gap_overrides() {
 
 #[test]
 fn accepts_subtool_spacing_and_rejects_invalid_fabrication_panel_domains() {
+    let resolution = Resolution::default();
+
     let sources = [assembly_panel_xml(100.0, 80.0)];
 
     let subtool_spacing = FabPanelSpec {
@@ -607,13 +648,13 @@ fn accepts_subtool_spacing_and_rejects_invalid_fabrication_panel_domains() {
         panel_gap_mm: 0.5,
         ..FabPanelSpec::INCHES_18_X_24
     };
-    create_fab_panel(&sources, &[0], subtool_spacing, false).unwrap();
+    create_fab_panel(&sources, &[0], subtool_spacing, false, resolution).unwrap();
 
     let negative_margin = FabPanelSpec {
         edge_margin_mm: EdgeInsetsMm::new(50.8, 25.4, 50.8, -0.5),
         ..FabPanelSpec::INCHES_18_X_24
     };
-    let error = create_fab_panel(&sources, &[0], negative_margin, false).unwrap_err();
+    let error = create_fab_panel(&sources, &[0], negative_margin, false, resolution).unwrap_err();
     assert!(
         error
             .to_string()
@@ -624,7 +665,7 @@ fn accepts_subtool_spacing_and_rejects_invalid_fabrication_panel_domains() {
         panel_gap_mm: -0.5,
         ..FabPanelSpec::INCHES_18_X_24
     };
-    let error = create_fab_panel(&sources, &[0], negative_gap, false).unwrap_err();
+    let error = create_fab_panel(&sources, &[0], negative_gap, false, resolution).unwrap_err();
     assert!(
         error
             .to_string()
@@ -635,7 +676,7 @@ fn accepts_subtool_spacing_and_rejects_invalid_fabrication_panel_domains() {
         edge_margin_mm: EdgeInsetsMm::new(50.8, 250.0, 50.8, 250.0),
         ..FabPanelSpec::INCHES_18_X_24
     };
-    let error = create_fab_panel(&sources, &[0], no_usable_width, false).unwrap_err();
+    let error = create_fab_panel(&sources, &[0], no_usable_width, false, resolution).unwrap_err();
     assert!(
         error
             .to_string()
@@ -673,9 +714,8 @@ fn strips_non_manufacturing_data_and_preserves_manufacturing_exports() {
 
     Ipc2581::validate(&generated).expect("fabrication panel should validate against IPC-2581C");
     let parsed = Ipc2581::parse(&generated).expect("fabrication panel should parse");
-    let package =
-        crate::manufacturing::build_manufacturing_package(&parsed, ArtworkScope::ArrayFlattened)
-            .expect("fabrication panel should export manufacturing files");
+    let package = manufacturing_package(&parsed, ArtworkScope::ArrayFlattened)
+        .expect("fabrication panel should export manufacturing files");
     assert!(package.files.iter().any(|file| file.filename == "F_Cu.gtl"));
     assert!(package.files.iter().any(|file| file.filename == "PTH.drl"));
     assert!(
@@ -797,11 +837,13 @@ fn dense_assembly_panel_xml(width_mm: f64, height_mm: f64) -> String {
 
 #[test]
 fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
+    let resolution = Resolution::default();
+
     let sources = vec![
         dense_assembly_panel_xml(90.0, 40.0),
         dense_assembly_panel_xml(25.0, 20.0),
     ];
-    let creation = create_fab_panel(&sources, &[0, 1], BALANCE_SPEC, true).unwrap();
+    let creation = create_fab_panel(&sources, &[0, 1], BALANCE_SPEC, true, resolution).unwrap();
 
     let report = creation.copper_balance.as_ref().unwrap();
     assert!(report.stack_weights_available);
@@ -846,16 +888,26 @@ fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
                 && (instance.bbox.height() - 90.0).abs() < 1e-6)
     );
 
-    let profile = geometry::board_array_fabrication_profile(&parsed, &layout, &[]).unwrap();
+    let profile =
+        geometry::board_array_fabrication_profile(&design(&parsed), &layout, &[], resolution)
+            .unwrap();
     let panel_contours = profile
         .assembly_panel_outlines
         .iter()
         .flatten()
         .cloned()
         .collect::<Vec<_>>();
-    let footprints = ContourSet::from_filled_contours(&panel_contours, tol::REGION_MM);
-    let usable = ContourSet::rectangle(BALANCE_SPEC.usable_bbox().unwrap(), tol::REGION_MM);
-    let copper = composed_copper_image(&parsed, "TOP").unwrap();
+    let footprints = ContourSet::from_filled_contours(&panel_contours, resolution).unwrap();
+    let usable = ContourSet::rectangle(BALANCE_SPEC.usable_bbox().unwrap(), resolution);
+    let copper = {
+        let imported = pcb_ir::import::ipc2581::import_design(&parsed).unwrap();
+        imported.composed_layer_image(
+            imported.layer_id("TOP").unwrap(),
+            pcb_ir::dialects::ipc::ArtworkScope::ArrayFlattened,
+            resolution,
+        )
+    }
+    .unwrap();
     let gutter_copper = copper.difference(&footprints);
 
     assert!(
@@ -869,21 +921,26 @@ fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
     );
     assert!(
         gutter_copper
-            .intersection(&footprints.disk_dilate(0.4))
+            .intersection(&footprints.disk_dilate(0.4).unwrap())
             .area()
             <= 1e-6,
         "generated copper must keep clearance from the placed panels"
     );
     assert!(
-        gutter_copper.difference(&usable.disk_erode(0.4)).area() <= 1e-6,
+        gutter_copper
+            .difference(&usable.disk_erode(0.4).unwrap())
+            .area()
+            <= 1e-6,
         "generated copper must keep clearance from the usable-area boundary"
     );
 }
 
 #[test]
 fn fab_panel_creation_skips_copper_balancing_unless_enabled() {
+    let resolution = Resolution::default();
+
     let sources = vec![dense_assembly_panel_xml(30.0, 25.0)];
-    let creation = create_fab_panel(&sources, &[0], BALANCE_SPEC, false).unwrap();
+    let creation = create_fab_panel(&sources, &[0], BALANCE_SPEC, false, resolution).unwrap();
 
     assert!(creation.copper_balance.is_none());
     assert_eq!(
@@ -899,8 +956,10 @@ fn fab_panel_creation_skips_copper_balancing_unless_enabled() {
 
 #[test]
 fn single_panel_filling_the_usable_area_generates_no_fill() {
+    let resolution = Resolution::default();
+
     let sources = vec![dense_assembly_panel_xml(66.0, 116.0)];
-    let creation = create_fab_panel(&sources, &[0], BALANCE_SPEC, true).unwrap();
+    let creation = create_fab_panel(&sources, &[0], BALANCE_SPEC, true, resolution).unwrap();
 
     let layer = &creation.copper_balance.unwrap().layers[0];
     assert_eq!(layer.mode, CopperBalanceMode::None);

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -908,10 +908,10 @@ fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
         )
     }
     .unwrap();
-    let gutter_copper = copper.difference(&footprints);
+    let gutter_copper = copper.difference(&footprints).unwrap();
 
     assert!(
-        copper.difference(&usable).area() <= 1e-6,
+        copper.difference(&usable).unwrap().area() <= 1e-6,
         "process margins must stay bare"
     );
     assert!(
@@ -922,6 +922,7 @@ fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
     assert!(
         gutter_copper
             .intersection(&footprints.disk_dilate(0.4).unwrap())
+            .unwrap()
             .area()
             <= 1e-6,
         "generated copper must keep clearance from the placed panels"
@@ -929,6 +930,7 @@ fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
     assert!(
         gutter_copper
             .difference(&usable.disk_erode(0.4).unwrap())
+            .unwrap()
             .area()
             <= 1e-6,
         "generated copper must keep clearance from the usable-area boundary"

--- a/crates/pcb-ipc2581-tools/src/commands/html_export.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/html_export.rs
@@ -1,3 +1,4 @@
+use pcb_ir::geom::Resolution;
 use std::collections::{HashMap, HashSet};
 #[cfg(feature = "cli")]
 use std::path::Path;
@@ -23,13 +24,15 @@ pub fn execute(
     output_file: Option<&Path>,
     unit_format: UnitFormat,
 ) -> Result<()> {
+    let resolution = Resolution::default();
+
     // Load and parse IPC-2581 file
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
     let accessor = IpcAccessor::new(&ipc);
 
     // Generate HTML
-    let html = generate_html(&accessor, unit_format)?;
+    let html = generate_html(&accessor, unit_format, resolution)?;
 
     // Determine output path
     let output_path = match output_file {
@@ -50,7 +53,11 @@ pub fn execute(
     Ok(())
 }
 
-pub fn generate_html(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<String> {
+pub fn generate_html(
+    accessor: &IpcAccessor,
+    unit_format: UnitFormat,
+    resolution: Resolution,
+) -> Result<String> {
     let mut env = Environment::new();
     env.add_template("html", HTML_TEMPLATE)
         .context("Failed to add HTML template")?;
@@ -58,9 +65,9 @@ pub fn generate_html(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<
     let template = env.get_template("html")?;
 
     // Extract data
-    let board_summary = extract_board_summary(accessor, unit_format)?;
+    let board_summary = extract_board_summary(accessor, unit_format, resolution)?;
     let stackup = extract_stackup_data(accessor, unit_format);
-    let rendered_layers = extract_rendered_layers(accessor)?;
+    let rendered_layers = extract_rendered_layers(accessor, resolution)?;
     let version = env!("CARGO_PKG_VERSION");
 
     // Extract file metadata
@@ -189,10 +196,15 @@ struct Color {
     hex: String,
 }
 
-fn extract_board_summary(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<BoardSummary> {
+fn extract_board_summary(
+    accessor: &IpcAccessor,
+    unit_format: UnitFormat,
+    resolution: Resolution,
+) -> Result<BoardSummary> {
     let layout = accessor.board_layout_info();
     let design_name = layout.as_ref().and_then(|layout| layout.board_name.clone());
-    let array_overview_svg = crate::board_array::render_board_array_overview_svg(accessor)?;
+    let array_overview_svg =
+        crate::board_array::render_board_array_overview_svg(accessor, resolution)?;
 
     let (width, height) = if let Some(dims) = layout
         .as_ref()
@@ -212,7 +224,7 @@ fn extract_board_summary(accessor: &IpcAccessor, unit_format: UnitFormat) -> Res
                 .as_ref()
                 .map(|dims| formatted_dimensions(dims.width_mm(), dims.height_mm(), unit_format))
                 .unwrap_or((None, None));
-            BoardArraySummary {
+            Ok::<_, anyhow::Error>(BoardArraySummary {
                 width,
                 height,
                 grid: board_array.grid.as_ref().map(|grid| BoardArrayGridSummary {
@@ -227,11 +239,12 @@ fn extract_board_summary(accessor: &IpcAccessor, unit_format: UnitFormat) -> Res
                     ),
                 }),
                 drill_holes: accessor
-                    .board_array_drill_stats()
+                    .board_array_drill_stats()?
                     .and_then(format_drill_count),
                 overview_svg: array_overview_svg,
-            }
-        });
+            })
+        })
+        .transpose()?;
 
     let thickness = if let Some(stackup) = accessor.stackup_details() {
         stackup.overall_thickness_mm.map(|t| match unit_format {
@@ -252,7 +265,7 @@ fn extract_board_summary(accessor: &IpcAccessor, unit_format: UnitFormat) -> Res
 
     let components = accessor.component_stats().map(|stats| stats.total);
     let nets = accessor.net_stats().map(|stats| stats.count);
-    let drill_holes = accessor.board_drill_stats().and_then(format_drill_count);
+    let drill_holes = accessor.board_drill_stats()?.and_then(format_drill_count);
 
     Ok(BoardSummary {
         design_name,
@@ -305,7 +318,10 @@ fn formatted_dimensions(
     }
 }
 
-fn extract_rendered_layers(accessor: &IpcAccessor) -> Result<RenderedLayers> {
+fn extract_rendered_layers(
+    accessor: &IpcAccessor,
+    resolution: Resolution,
+) -> Result<RenderedLayers> {
     let ipc = accessor.ipc();
     let Some(ecad) = ipc.ecad() else {
         return Ok(RenderedLayers::default());
@@ -334,7 +350,8 @@ fn extract_rendered_layers(accessor: &IpcAccessor) -> Result<RenderedLayers> {
                 ipc,
                 layer,
                 stackup_layer.layer_number.map(|number| number.to_string()),
-            );
+                resolution,
+            )?;
             if layer.layer_function.is_coating() && !rendered.has_native_content {
                 continue;
             }
@@ -349,7 +366,7 @@ fn extract_rendered_layers(accessor: &IpcAccessor) -> Result<RenderedLayers> {
                 continue;
             }
             stackup_layer_refs.insert(layer.name);
-            stackup_layers.push(rendered_source_layer(ipc, layer, None));
+            stackup_layers.push(rendered_source_layer(ipc, layer, None, resolution)?);
         }
     }
 
@@ -360,7 +377,7 @@ fn extract_rendered_layers(accessor: &IpcAccessor) -> Result<RenderedLayers> {
             continue;
         }
 
-        let rendered = rendered_source_layer(ipc, layer, None);
+        let rendered = rendered_source_layer(ipc, layer, None, resolution)?;
         if rendered.has_native_content {
             non_stackup_layers.push(rendered);
         }
@@ -376,7 +393,8 @@ fn rendered_source_layer(
     ipc: &ipc2581::Ipc2581,
     layer: &Layer,
     sequence: Option<String>,
-) -> RenderedLayer {
+    resolution: Resolution,
+) -> anyhow::Result<RenderedLayer> {
     let name = ipc.resolve(layer.name).to_string();
     let mut rendered = RenderedLayer {
         name: name.clone(),
@@ -393,32 +411,39 @@ fn rendered_source_layer(
     };
 
     match geometry::extract_layer_for_view(ipc, &name, ArtworkScope::Board) {
-        Ok(geometry) => {
-            render_extracted_layer(&mut rendered, geometry, ArtworkScope::Board.profile_set())
-        }
+        Ok(geometry) => render_extracted_layer(
+            &mut rendered,
+            geometry,
+            ArtworkScope::Board.profile_set(),
+            resolution,
+        )?,
         Err(error) => {
             rendered.warning = Some(format!("Render unavailable: {error}"));
         }
     }
 
-    rendered
+    Ok(rendered)
 }
 
 fn render_extracted_layer(
     rendered: &mut RenderedLayer,
     mut geometry: GeometryDocument,
     profile_set: ProfileSet,
-) {
-    rendered.has_native_content = geometry::render::layer_has_native_content(&geometry);
-    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut geometry);
+    resolution: Resolution,
+) -> anyhow::Result<()> {
+    rendered.has_native_content =
+        geometry::render::layer_has_native_content(&geometry, resolution)?;
+    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut geometry, resolution)?;
     rendered.svg = Some(geometry::render::render_layer_svg(
         &geometry,
         true,
         profile_set,
-    ));
+        resolution.accuracy,
+    )?);
     if !geometry.diagnostics.is_empty() {
         rendered.warning = Some(format!("{} warning(s)", geometry.diagnostics.len()));
-    }
+    };
+    Ok(())
 }
 
 /// Format a decimal number with engineering precision:
@@ -546,10 +571,12 @@ mod tests {
 
     #[test]
     fn html_keeps_board_summary_separate_from_board_array_summary() {
+        let resolution = Resolution::default();
+
         let ipc = ipc2581::Ipc2581::parse(board_array_design_name_fixture()).unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let html = generate_html(&accessor, UnitFormat::Mm).unwrap();
+        let html = generate_html(&accessor, UnitFormat::Mm, resolution).unwrap();
         let design_start = html.find("Design Name:").unwrap();
         let dimensions_start = html.find("Board Dimensions:").unwrap();
         let design_row = &html[design_start..dimensions_start];
@@ -571,10 +598,12 @@ mod tests {
 
     #[test]
     fn html_renders_stackup_layers_then_separate_drills_and_outline() {
+        let resolution = Resolution::default();
+
         let ipc = ipc2581::Ipc2581::parse(layer_render_fixture()).unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let html = generate_html(&accessor, UnitFormat::Mm).unwrap();
+        let html = generate_html(&accessor, UnitFormat::Mm, resolution).unwrap();
 
         assert!(html.contains("<h2>Layers</h2>"));
         assert!(html.contains("<h3>Stackup Layers</h3>"));
@@ -601,10 +630,12 @@ mod tests {
 
     #[test]
     fn html_renders_array_support_layers_in_board_array_summary_only() {
+        let resolution = Resolution::default();
+
         let ipc = ipc2581::Ipc2581::parse(array_layer_render_fixture()).unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let html = generate_html(&accessor, UnitFormat::Mm).unwrap();
+        let html = generate_html(&accessor, UnitFormat::Mm, resolution).unwrap();
 
         let array_summary = html.find("<h2>Board Array Summary</h2>").unwrap();
         let file_info = html.find(r#"<div class="file-info">"#).unwrap();

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -7,6 +7,7 @@
 //! position when the export carries per-pad nets and the component
 //! origin otherwise.
 
+use pcb_ir::geom::Resolution;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 #[cfg(feature = "cli")]
@@ -24,7 +25,7 @@ use pcb_ir::import::physical::Association;
 
 use crate::accessors::IpcAccessor;
 use crate::commands::cpl::CplSideFilter;
-use crate::placement::extract_single_board_placements_from_design;
+use crate::placement::extract_single_board_placements;
 
 #[derive(Debug, Clone)]
 pub struct IctOptions {
@@ -47,8 +48,10 @@ pub struct IctContact {
 
 #[cfg(feature = "cli")]
 pub fn execute(file: &Path, options: &IctOptions) -> Result<()> {
+    let resolution = Resolution::default();
+
     let ipc = Ipc2581::parse_file(file)?;
-    let contacts = extract_contacts(&ipc)?;
+    let contacts = extract_contacts(&ipc, &import_design(&ipc)?, resolution)?;
     let csv = emit_ict_csv(&contacts, options.side);
 
     if let Some(output) = &options.output {
@@ -60,15 +63,10 @@ pub fn execute(file: &Path, options: &IctOptions) -> Result<()> {
     Ok(())
 }
 
-pub fn extract_contacts(ipc: &Ipc2581) -> Result<Vec<IctContact>> {
-    let imported = import_design(ipc)?;
-    extract_contacts_from_design(ipc, &imported)
-}
-
-/// Extract contacts while reusing a previously imported design.
-pub fn extract_contacts_from_design(
+pub fn extract_contacts(
     ipc: &Ipc2581,
     imported: &ImportedDesign,
+    resolution: Resolution,
 ) -> Result<Vec<IctContact>> {
     let accessor = IpcAccessor::new(ipc);
 
@@ -159,7 +157,7 @@ pub fn extract_contacts_from_design(
             }
         }
     }
-    let lands = imported.physical_lands(ArtworkScope::Board)?;
+    let lands = imported.physical_lands(ArtworkScope::Board, resolution)?;
     for land in &lands {
         let component = match &land.component {
             Association::Resolved(component) => *component,
@@ -193,7 +191,7 @@ pub fn extract_contacts_from_design(
         info.at = Some((land.at.x, land.at.y));
     }
 
-    let placements = extract_single_board_placements_from_design(imported)?;
+    let placements = extract_single_board_placements(imported)?;
     let mut contacts = Vec::new();
     for component in &placements.components {
         let Some((ict, path)) = roles.get(&component.designator) else {
@@ -415,8 +413,11 @@ mod tests {
 
     #[test]
     fn lists_ict_contacts_with_nets() {
+        let resolution = Resolution::default();
+
         let ipc = Ipc2581::parse(FIXTURE).expect("fixture parses");
-        let contacts = extract_contacts(&ipc).expect("extracts");
+        let contacts =
+            extract_contacts(&ipc, &import_design(&ipc).unwrap(), resolution).expect("extracts");
 
         assert_eq!(contacts.len(), 1);
         let contact = &contacts[0];

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -20,7 +20,9 @@ use anyhow::{Result, bail};
 use ipc2581::Ipc2581;
 use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::dialects::placement::PlacementSide;
-use pcb_ir::import::ipc2581::{ImportedDesign, import_design};
+use pcb_ir::import::ipc2581::ImportedDesign;
+#[cfg(feature = "cli")]
+use pcb_ir::import::ipc2581::import_design;
 use pcb_ir::import::physical::Association;
 
 use crate::accessors::IpcAccessor;

--- a/crates/pcb-ipc2581-tools/src/commands/info.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/info.rs
@@ -206,7 +206,7 @@ fn output_text(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<()> {
     }
 
     // Drill statistics (summary)
-    if let Some(drills) = accessor.board_drill_stats()
+    if let Some(drills) = accessor.board_drill_stats()?
         && drills.total_holes > 0
     {
         summary_table.add_row(vec![
@@ -480,17 +480,17 @@ fn output_text(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<()> {
     }
 
     // Drill distribution
-    if let Some(drills) = accessor.board_drill_stats()
+    if let Some(drills) = accessor.board_drill_stats()?
         && !drills.distribution.is_empty()
     {
         print_drill_distribution("Drill Distribution", &drills);
     }
 
     if let Some(board_array) = layout.and_then(|layout| layout.board_array) {
-        print_board_array_summary(&board_array, accessor, unit_format);
+        print_board_array_summary(&board_array, accessor, unit_format)?;
     }
 
-    if let Some(drills) = accessor.board_array_drill_stats()
+    if let Some(drills) = accessor.board_array_drill_stats()?
         && !drills.distribution.is_empty()
     {
         print_drill_distribution("Array Drill Distribution", &drills);
@@ -536,7 +536,7 @@ fn print_board_array_summary(
     board_array: &BoardArrayInfo,
     accessor: &IpcAccessor,
     unit_format: UnitFormat,
-) {
+) -> anyhow::Result<()> {
     println!("{}", "Board Array Summary".bold());
 
     let mut table = Table::new();
@@ -574,7 +574,7 @@ fn print_board_array_summary(
         ]);
     }
 
-    if let Some(drills) = accessor.board_array_drill_stats()
+    if let Some(drills) = accessor.board_array_drill_stats()?
         && drills.total_holes > 0
     {
         table.add_row(vec![
@@ -588,6 +588,8 @@ fn print_board_array_summary(
 
     println!("{table}");
     println!();
+
+    Ok(())
 }
 
 #[cfg(feature = "cli")]
@@ -661,12 +663,12 @@ fn drill_stats_json(drills: &DrillStats) -> serde_json::Value {
 
 #[cfg(feature = "cli")]
 fn output_json(accessor: &IpcAccessor) -> Result<()> {
-    println!("{}", serde_json::to_string_pretty(&info_json(accessor))?);
+    println!("{}", serde_json::to_string_pretty(&info_json(accessor)?)?);
     Ok(())
 }
 
 /// Extract the same board, assembly, and fabrication summary emitted by `ipc info --format json`.
-pub fn info_json(accessor: &IpcAccessor) -> serde_json::Value {
+pub fn info_json(accessor: &IpcAccessor) -> anyhow::Result<serde_json::Value> {
     let ipc = accessor.ipc();
     let content = ipc.content();
     let layer_side_map: BTreeMap<_, _> = ipc
@@ -758,7 +760,7 @@ pub fn info_json(accessor: &IpcAccessor) -> serde_json::Value {
                 "height_inch": dimensions.height_inch(),
             });
         }
-        if let Some(drills) = accessor.board_array_drill_stats()
+        if let Some(drills) = accessor.board_array_drill_stats()?
             && drills.total_holes > 0
         {
             info["board_array"]["drills"] = drill_stats_json(&drills);
@@ -776,7 +778,7 @@ pub fn info_json(accessor: &IpcAccessor) -> serde_json::Value {
     }
 
     // Drill statistics with distribution
-    if let Some(drills) = accessor.board_drill_stats()
+    if let Some(drills) = accessor.board_drill_stats()?
         && drills.total_holes > 0
     {
         info["drills"] = drill_stats_json(&drills);
@@ -952,5 +954,5 @@ pub fn info_json(accessor: &IpcAccessor) -> serde_json::Value {
 
     info["component_placements"] = json!(component_placements);
 
-    info
+    Ok(info)
 }

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -54,7 +54,7 @@ pub fn export_dxf(
         bail!("IPC-2581 primary step and repeated child steps have no board Profile outline");
     }
 
-    Ok(geometry::dxf::render_profile_set_dxf(&layout, profile_set))
+    geometry::dxf::render_profile_set_dxf(&layout, profile_set)
 }
 
 #[cfg(test)]

--- a/crates/pcb-ipc2581-tools/src/commands/render.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/render.rs
@@ -1,3 +1,4 @@
+use pcb_ir::geom::Resolution;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -20,19 +21,26 @@ pub struct RenderOptions {
 /// The layer runs through the same normalization Gerber export uses, so a
 /// render and a fabrication file describe the same image.
 pub fn execute(input_file: &Path, options: &RenderOptions) -> Result<()> {
+    let resolution = Resolution::default();
+
     let target = resolve_target(options)?;
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
     let view = options.layout_target.artwork_scope();
     let imported = pcb_ir::import::ipc2581::import_design(&ipc)?;
-    let geometry = geometry::render::prepare_layer(&imported, &options.layer, view)?;
+    let geometry = geometry::render::prepare_layer(&imported, &options.layer, view, resolution)?;
 
     match target {
-        RenderTarget::Svg => render_svg(&geometry, options, view)?,
-        RenderTarget::Png => render_png(&geometry, options, view)?,
+        RenderTarget::Svg => render_svg(&geometry, options, view, resolution)?,
+        RenderTarget::Png => render_png(&geometry, options, view, resolution)?,
         RenderTarget::Terminal => {
-            geometry::render::render_layer_terminal(&geometry, true, view.profile_set())
-                .map_err(anyhow::Error::msg)?;
+            geometry::render::render_layer_terminal(
+                &geometry,
+                true,
+                view.profile_set(),
+                resolution.accuracy,
+            )
+            .map_err(anyhow::Error::msg)?;
         }
     }
 
@@ -87,8 +95,14 @@ fn render_svg(
     geometry: &pcb_ir::dialects::ipc::Document<ipc2581::Symbol, ipc2581::types::LayerFunction>,
     options: &RenderOptions,
     view: pcb_ir::dialects::ipc::ArtworkScope,
+    resolution: Resolution,
 ) -> Result<()> {
-    let svg = geometry::render::render_layer_svg(geometry, true, view.profile_set());
+    let svg = geometry::render::render_layer_svg(
+        geometry,
+        true,
+        view.profile_set(),
+        resolution.accuracy,
+    )?;
 
     if let Some(output) = &options.output {
         std::fs::write(output, svg)
@@ -109,9 +123,11 @@ fn render_png(
     geometry: &pcb_ir::dialects::ipc::Document<ipc2581::Symbol, ipc2581::types::LayerFunction>,
     options: &RenderOptions,
     view: pcb_ir::dialects::ipc::ArtworkScope,
+    resolution: Resolution,
 ) -> Result<()> {
-    let png = geometry::render::render_layer_png(geometry, true, view.profile_set())
-        .map_err(anyhow::Error::msg)?;
+    let png =
+        geometry::render::render_layer_png(geometry, true, view.profile_set(), resolution.accuracy)
+            .map_err(anyhow::Error::msg)?;
 
     if let Some(output) = &options.output {
         std::fs::write(output, png)

--- a/crates/pcb-ipc2581-tools/src/commands/warp.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/warp.rs
@@ -1,6 +1,8 @@
 //! Report estimated panel bow and twist.
 
 #[cfg(feature = "cli")]
+use pcb_ir::geom::Resolution;
+#[cfg(feature = "cli")]
 use std::path::Path;
 
 #[cfg(feature = "cli")]
@@ -17,10 +19,12 @@ const SURFACE_MOUNT_LIMIT_PERCENT: f64 = 0.75;
 
 #[cfg(feature = "cli")]
 pub fn execute(file: &Path, report: Option<&Path>) -> Result<()> {
+    let resolution = Resolution::default();
+
     let xml = std::fs::read_to_string(file)
         .with_context(|| format!("failed to read {}", file.display()))?;
     let ipc = Ipc2581::parse(&xml).context("failed to parse IPC-2581 file")?;
-    let analysis = warp::analyze(&ipc)?;
+    let analysis = warp::analyze(&ipc, resolution)?;
 
     for line in summary_lines(&analysis) {
         println!("{line}");

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -453,7 +453,7 @@ pub fn balance_features(result: &DenseCopperBalanceResult) -> Result<BalanceFeat
             Ok(BalanceFeatureSets {
                 plane: ipc_region_features(&result.usable)?,
                 // The plane covers the web exactly, so its decimation is free.
-                boundary_web: ipc_region_features(&result.boundary_web().decimate_inward()?)?,
+                boundary_web: ipc_region_features(&result.boundary_web()?.decimate_inward()?)?,
                 templates,
                 void_sets,
                 edge_voids: ipc_region_features(&emission.clipped)?,
@@ -699,7 +699,14 @@ mod tests {
             result.full_voids.len() + emission.instanced.len()
         );
         assert_eq!(features.edge_voids.is_empty(), emission.clipped.is_empty());
-        assert!(emission.clipped.difference(&result.voidable).area() < 1e-6);
+        assert!(
+            emission
+                .clipped
+                .difference(&result.voidable)
+                .unwrap()
+                .area()
+                < 1e-6
+        );
         assert!(features.void_sets.iter().all(|set| {
             features
                 .templates

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -453,10 +453,7 @@ pub fn balance_features(result: &DenseCopperBalanceResult) -> Result<BalanceFeat
             Ok(BalanceFeatureSets {
                 plane: ipc_region_features(&result.usable)?,
                 // The plane covers the web exactly, so its decimation is free.
-                boundary_web: ipc_region_features(&{
-                    let web = result.boundary_web();
-                    web.decimate_inward(web.budget().max_error_mm())?
-                })?,
+                boundary_web: ipc_region_features(&result.boundary_web().decimate_inward()?)?,
                 templates,
                 void_sets,
                 edge_voids: ipc_region_features(&emission.clipped)?,

--- a/crates/pcb-ipc2581-tools/src/copper_balance.rs
+++ b/crates/pcb-ipc2581-tools/src/copper_balance.rs
@@ -14,7 +14,6 @@ use ipc2581::types::{
         Polygon, UserPrimitive, UserShape, UserShapeType, UserSpecial,
     },
 };
-use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::geom::copper_balance::{
     DenseCopperBalanceMode, DenseCopperBalanceProfile, DenseCopperBalanceResult,
     DenseCopperLattice, DenseCopperLatticeSite, DenseCopperVoid,
@@ -24,10 +23,9 @@ use pcb_ir::geom::copper_balance::{
 };
 use pcb_ir::geom::path::ContourBuf;
 use pcb_ir::geom::region::{rings_to_contours, simplify_shapes};
-use pcb_ir::geom::{ContourSet, FillRule, PathOp, tol};
+use pcb_ir::geom::{ContourSet, FillRule, PathOp};
 use serde::Serialize;
 
-use crate::geometry;
 use crate::ipc2581::Ipc2581;
 use pcb_ir::dialects::ipc::CopperBalanceKind;
 
@@ -455,9 +453,10 @@ pub fn balance_features(result: &DenseCopperBalanceResult) -> Result<BalanceFeat
             Ok(BalanceFeatureSets {
                 plane: ipc_region_features(&result.usable)?,
                 // The plane covers the web exactly, so its decimation is free.
-                boundary_web: ipc_region_features(
-                    &result.boundary_web().decimate_inward(tol::FLATTEN_MM),
-                )?,
+                boundary_web: ipc_region_features(&{
+                    let web = result.boundary_web();
+                    web.decimate_inward(web.budget().max_error_mm())?
+                })?,
                 templates,
                 void_sets,
                 edge_voids: ipc_region_features(&emission.clipped)?,
@@ -505,42 +504,6 @@ fn void_sets(
         })
         .collect::<Result<Vec<_>>>()
         .map(|pairs| pairs.into_iter().unzip())
-}
-
-/// Extract one layer's flattened, composed copper image.
-///
-/// Composition goes through the artwork mask fold so clear-polarity
-/// features subtract in paint order instead of being unioned as copper.
-pub fn composed_copper_image(ipc: &Ipc2581, layer_name: &str) -> Result<ContourSet> {
-    let document = geometry::extract_layer_for_view(ipc, layer_name, ArtworkScope::ArrayFlattened)
-        .with_context(|| format!("failed to extract IPC-2581 copper layer '{layer_name}'"))?;
-    Ok(composed_copper_image_from_document(document))
-}
-
-/// Compose an already extracted copper document into its final painted image.
-///
-/// Callers that also need source-feature identity can inspect or clone the
-/// structure-preserving document before handing it to this destructive fold.
-pub(crate) fn composed_copper_image_from_document(
-    mut document: geometry::GeometryDocument,
-) -> ContourSet {
-    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut document);
-    let artwork = pcb_ir::dialects::ipc::lower_layer_to_artwork(
-        &document,
-        0,
-        pcb_ir::dialects::LayerRole::Copper,
-        pcb_ir::dialects::Side::None,
-    );
-    let mask = pcb_ir::dialects::artwork::compose_to_mask(&artwork);
-    let mut rings = Vec::new();
-    for layer in &mask.layers {
-        for shape in mask.shapes(layer) {
-            rings.extend(pcb_ir::geom::region::rings_from_contours(
-                &mask.arena.path_contours(shape),
-            ));
-        }
-    }
-    ContourSet::new(rings, FillRule::NonZero, tol::REGION_MM)
 }
 
 /// Signed first-moment weight `t * z` per copper layer, arms measured from
@@ -656,15 +619,18 @@ fn ipc_polygon_from_contour(contour: &ContourBuf) -> Result<Polygon> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pcb_ir::geom::{BBox, ContourSet, Point, tol};
+    use pcb_ir::geom::Resolution;
+    use pcb_ir::geom::{BBox, ContourSet, Point};
 
     #[test]
     fn converts_perforated_region_to_positive_ipc_contours() {
+        let resolution = Resolution::default();
+
         let safe_region = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 10.0)),
-            tol::REGION_MM,
+            resolution,
         );
-        let existing = ContourSet::empty(tol::REGION_MM);
+        let existing = ContourSet::empty(Resolution::default());
         let layers = [SpatialCopperBalanceLayerRequest {
             safe_region: &safe_region,
             existing_copper: &existing,

--- a/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
@@ -1,13 +1,12 @@
 use std::fmt::Write;
 
 use pcb_ir::dialects::ipc::{Document, ProfileSet, profile_occurrences_for};
-use pcb_ir::geom::{ContourBuf, Point, Segment};
+use pcb_ir::geom::{ContourBuf, GeometryAccuracy, Point, Segment};
 
 use crate::utils::format::fmt_num;
 
 const OUTLINE_LAYER: &str = "BOARD_OUTLINE";
 const EPSILON: f64 = 1e-9;
-const CURVE_FLATTEN_STEPS: usize = 16;
 
 #[derive(Debug, Clone, Copy)]
 struct DxfVertex {
@@ -68,6 +67,7 @@ fn write_path<Symbol, LayerFunction>(
     transform: pcb_ir::geom::Affine2,
 ) -> anyhow::Result<()> {
     for contour in doc.transformed_path_contours(path_index, transform) {
+        let contour = contour.flattened_curves(GeometryAccuracy::default())?;
         write_polyline(dxf, &contour_vertices(&contour));
     }
     Ok(())
@@ -91,8 +91,8 @@ fn write_polyline(dxf: &mut String, vertices: &[DxfVertex]) {
     }
 }
 
-/// Flatten a contour to polyline vertices: circular arcs keep their bulge,
-/// cubic and elliptical curves are sampled.
+/// Polyline vertices of a contour whose curves were flattened to lines and
+/// circular arcs; arcs keep their bulge.
 fn contour_vertices(contour: &ContourBuf) -> Vec<DxfVertex> {
     let Some(first) = contour.cmds.first().map(|cmd| cmd.p0) else {
         return Vec::new();
@@ -125,12 +125,7 @@ fn contour_vertices(contour: &ContourBuf) -> Vec<DxfVertex> {
                 }
             }
             Segment::Cubic { .. } | Segment::Ellipse(_) => {
-                let mut points = Vec::with_capacity(CURVE_FLATTEN_STEPS);
-                segment.sample_points(CURVE_FLATTEN_STEPS, &mut points);
-                for end in points {
-                    vertices.last_mut().unwrap().bulge = 0.0;
-                    push_endpoint(&mut vertices, end, first);
-                }
+                unreachable!("curves are flattened before polyline conversion")
             }
         }
     }

--- a/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
@@ -1,13 +1,13 @@
 use std::fmt::Write;
 
 use pcb_ir::dialects::ipc::{Document, ProfileSet, profile_occurrences_for};
-use pcb_ir::geom::Point;
+use pcb_ir::geom::{ContourBuf, Point, Segment};
 
 use crate::utils::format::fmt_num;
-use pcb_ir::geom::path::{PathCmd, PathOp};
 
 const OUTLINE_LAYER: &str = "BOARD_OUTLINE";
 const EPSILON: f64 = 1e-9;
+const CURVE_FLATTEN_STEPS: usize = 16;
 
 #[derive(Debug, Clone, Copy)]
 struct DxfVertex {
@@ -19,7 +19,7 @@ struct DxfVertex {
 pub fn render_profile_set_dxf<Symbol, LayerFunction>(
     doc: &Document<Symbol, LayerFunction>,
     profile_set: ProfileSet,
-) -> String {
+) -> anyhow::Result<String> {
     let mut dxf = String::new();
     write_header(&mut dxf);
     write_tables(&mut dxf);
@@ -30,13 +30,13 @@ pub fn render_profile_set_dxf<Symbol, LayerFunction>(
             doc,
             occurrence.profile.outer_path,
             occurrence.transform,
-        );
+        )?;
         for cutout in occurrence.profile.cutouts.slice(&doc.profile_cutouts) {
-            write_path(&mut dxf, doc, cutout.path, occurrence.transform);
+            write_path(&mut dxf, doc, cutout.path, occurrence.transform)?;
         }
     }
     write_footer(&mut dxf);
-    dxf
+    Ok(dxf)
 }
 
 fn write_header(dxf: &mut String) {
@@ -66,10 +66,11 @@ fn write_path<Symbol, LayerFunction>(
     doc: &Document<Symbol, LayerFunction>,
     path_index: u32,
     transform: pcb_ir::geom::Affine2,
-) {
+) -> anyhow::Result<()> {
     for contour in doc.transformed_path_contours(path_index, transform) {
-        write_polyline(dxf, &contour_vertices(&contour.cmds));
+        write_polyline(dxf, &contour_vertices(&contour));
     }
+    Ok(())
 }
 
 fn write_polyline(dxf: &mut String, vertices: &[DxfVertex]) {
@@ -90,62 +91,47 @@ fn write_polyline(dxf: &mut String, vertices: &[DxfVertex]) {
     }
 }
 
-fn contour_vertices(cmds: &[PathCmd]) -> Vec<DxfVertex> {
-    let mut first = None;
-    let mut current = Point::default();
-    let mut vertices = Vec::new();
-
-    for cmd in cmds {
-        match cmd.op {
-            PathOp::MoveTo => {
-                first = Some(cmd.p0);
-                current = cmd.p0;
-                vertices.push(DxfVertex {
-                    x: cmd.p0.x,
-                    y: cmd.p0.y,
-                    bulge: 0.0,
-                });
+/// Flatten a contour to polyline vertices: circular arcs keep their bulge,
+/// cubic and elliptical curves are sampled.
+fn contour_vertices(contour: &ContourBuf) -> Vec<DxfVertex> {
+    let Some(first) = contour.cmds.first().map(|cmd| cmd.p0) else {
+        return Vec::new();
+    };
+    let mut vertices = vec![DxfVertex {
+        x: first.x,
+        y: first.y,
+        bulge: 0.0,
+    }];
+    for segment in contour.segments() {
+        match segment {
+            Segment::Line { end, .. } => {
+                vertices.last_mut().unwrap().bulge = 0.0;
+                push_endpoint(&mut vertices, end, first);
             }
-            PathOp::LineTo => {
-                current = cmd.p0;
-                if let Some(first) = first {
+            Segment::Arc(arc) => {
+                if same_point(arc.start, arc.end) && arc.start.distance_to(arc.center) > EPSILON {
+                    let opposite = opposite_arc_point(arc.start, arc.center, arc.clockwise);
+                    vertices.last_mut().unwrap().bulge = half_circle_bulge(arc.clockwise);
+                    vertices.push(DxfVertex {
+                        x: opposite.x,
+                        y: opposite.y,
+                        bulge: half_circle_bulge(arc.clockwise),
+                    });
+                    push_endpoint(&mut vertices, arc.end, first);
+                } else {
+                    vertices.last_mut().unwrap().bulge =
+                        arc_bulge(arc.start, arc.end, arc.center, arc.clockwise);
+                    push_endpoint(&mut vertices, arc.end, first);
+                }
+            }
+            Segment::Cubic { .. } | Segment::Ellipse(_) => {
+                let mut points = Vec::with_capacity(CURVE_FLATTEN_STEPS);
+                segment.sample_points(CURVE_FLATTEN_STEPS, &mut points);
+                for end in points {
                     vertices.last_mut().unwrap().bulge = 0.0;
-                    push_endpoint(&mut vertices, current, first);
+                    push_endpoint(&mut vertices, end, first);
                 }
             }
-            PathOp::ArcTo => {
-                let end = cmd.p0;
-                let center = cmd.p1;
-                if let Some(first) = first {
-                    if same_point(current, end) && current.distance_to(center) > EPSILON {
-                        let opposite = opposite_arc_point(current, center, cmd.clockwise);
-                        vertices.last_mut().unwrap().bulge = half_circle_bulge(cmd.clockwise);
-                        vertices.push(DxfVertex {
-                            x: opposite.x,
-                            y: opposite.y,
-                            bulge: half_circle_bulge(cmd.clockwise),
-                        });
-                        push_endpoint(&mut vertices, end, first);
-                    } else {
-                        vertices.last_mut().unwrap().bulge =
-                            arc_bulge(current, end, center, cmd.clockwise);
-                        push_endpoint(&mut vertices, end, first);
-                    }
-                }
-                current = end;
-            }
-            PathOp::CubicTo => {
-                let start = current;
-                for step in 1..=16 {
-                    let end = cubic_point(start, cmd.p0, cmd.p1, cmd.p2, step as f64 / 16.0);
-                    if let Some(first) = first {
-                        vertices.last_mut().unwrap().bulge = 0.0;
-                        push_endpoint(&mut vertices, end, first);
-                    }
-                    current = end;
-                }
-            }
-            PathOp::Close => {}
         }
     }
 
@@ -194,20 +180,6 @@ fn half_circle_bulge(clockwise: bool) -> f64 {
     if clockwise { -1.0 } else { 1.0 }
 }
 
-fn cubic_point(start: Point, c1: Point, c2: Point, end: Point, t: f64) -> Point {
-    let mt = 1.0 - t;
-    Point::new(
-        mt.powi(3) * start.x
-            + 3.0 * mt.powi(2) * t * c1.x
-            + 3.0 * mt * t.powi(2) * c2.x
-            + t.powi(3) * end.x,
-        mt.powi(3) * start.y
-            + 3.0 * mt.powi(2) * t * c1.y
-            + 3.0 * mt * t.powi(2) * c2.y
-            + t.powi(3) * end.y,
-    )
-}
-
 fn same_point(a: Point, b: Point) -> bool {
     (a.x - b.x).abs() <= EPSILON && (a.y - b.y).abs() <= EPSILON
 }
@@ -217,13 +189,14 @@ mod tests {
     use super::*;
     use pcb_ir::dialects::ipc::{StepProfile, StepProfileCutout};
     use pcb_ir::geom::BBox;
+    use pcb_ir::geom::path::PathCmd;
     use pcb_ir::geom::{ContourBuf, Paint, Span};
 
     #[test]
     fn renders_profile_ir_as_mm_dxf_with_closed_outline_layer() {
         let doc = rect_profile_doc();
 
-        let dxf = render_profile_set_dxf(&doc, ProfileSet::FabricationOutlines);
+        let dxf = render_profile_set_dxf(&doc, ProfileSet::FabricationOutlines).unwrap();
 
         assert!(dxf.contains("9\n$INSUNITS\n70\n4\n"));
         assert!(dxf.contains("2\nBOARD_OUTLINE\n"));
@@ -250,7 +223,7 @@ mod tests {
             bbox: BBox::empty(),
         });
 
-        let dxf = render_profile_set_dxf(&doc, ProfileSet::FabricationOutlines);
+        let dxf = render_profile_set_dxf(&doc, ProfileSet::FabricationOutlines).unwrap();
 
         assert!(dxf.contains("42\n1\n"));
     }

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -12,7 +12,7 @@ use pcb_ir::dialects::ipc::{
     },
 };
 use pcb_ir::geom::Resolution;
-use pcb_ir::geom::{BBox, ContourSet, Point, Polarity};
+use pcb_ir::geom::{BBox, ContourBuf, ContourSet, Point, Polarity};
 use pcb_ir::import::ipc2581::{ImportedDesign, LayerId};
 
 pub use pcb_ir::import::ipc2581::{extract_layer, extract_layer_for_view, extract_layout};
@@ -102,24 +102,49 @@ fn board_array_relief_features(
     }
 
     let resolution = resolution.with_tolerance(DEFAULT_RELIEF_TOLERANCE_MM);
-    let (cutouts, envelopes) = collect_relief_feature_candidates(imported, resolution)?;
-    let mut score_blockers = ContourSet::empty(resolution);
-    for cutout in cutouts {
-        if !score_lines.iter().any(|line| {
-            !cutout
-                .region
-                .intersection(&score_line_strip(*line, resolution))
-                .is_empty()
-        }) {
-            continue;
+    let (cutouts, envelopes) = collect_relief_feature_candidates(imported)?;
+    let strips = score_lines
+        .iter()
+        .map(|line| score_line_strip(*line, resolution))
+        .collect::<Vec<_>>();
+    // Regions are prepared only for candidates near a score line: on a dense
+    // panel almost every hole is nowhere near one.
+    let near_score_line = |candidate: &ReliefFeatureCandidate| {
+        strips
+            .iter()
+            .any(|strip| candidate.bbox.intersects(strip.bbox))
+    };
+    let mut crossing = Vec::new();
+    for cutout in cutouts.into_iter().filter(near_score_line) {
+        let region = cutout.region(resolution)?;
+        if strips
+            .iter()
+            .any(|strip| !region.intersection(strip).is_empty())
+        {
+            crossing.push((cutout, region));
         }
+    }
+    let envelopes = envelopes
+        .into_iter()
+        .filter(|envelope| {
+            crossing
+                .iter()
+                .any(|(cutout, _)| envelope.bbox.intersects(cutout.bbox))
+        })
+        .map(|envelope| Ok((envelope.region(resolution)?, envelope)))
+        .collect::<Result<Vec<_>>>()?;
+    // Every blocker joins one batched union: unioning them one at a time is
+    // quadratic in the number of cutouts on dense panels.
+    let mut blockers = Vec::new();
+    for (cutout, region) in crossing {
         if plated_like(cutout.plating) {
-            let mut matches = Vec::new();
-            for envelope in &envelopes {
-                if envelope_matches_cutout(envelope, &cutout) {
-                    matches.push(envelope);
-                }
-            }
+            let matches = envelopes
+                .iter()
+                .filter(|(envelope_region, envelope)| {
+                    envelope_matches_cutout(envelope, envelope_region, &cutout, &region)
+                })
+                .map(|(envelope_region, _)| envelope_region.clone())
+                .collect::<Vec<_>>();
             if matches.is_empty() {
                 bail!(
                     "plated edge cutout at [{:.3}, {:.3}]..[{:.3}, {:.3}] has no matching pad envelope for V-score relief generation",
@@ -129,13 +154,12 @@ fn board_array_relief_features(
                     cutout.bbox.max.y
                 );
             }
-            for envelope in matches {
-                score_blockers = score_blockers.union(&envelope.region);
-            }
+            blockers.extend(matches);
         } else {
-            score_blockers = score_blockers.union(&cutout.region);
+            blockers.push(region);
         }
     }
+    let score_blockers = ContourSet::union_all(resolution, blockers)?;
 
     Ok(BoardArrayReliefFeatures {
         score_blockers: score_blockers.to_contours(),
@@ -144,7 +168,6 @@ fn board_array_relief_features(
 
 fn collect_relief_feature_candidates(
     imported: &ImportedDesign,
-    resolution: Resolution,
 ) -> Result<(Vec<ReliefFeatureCandidate>, Vec<ReliefFeatureCandidate>)> {
     let mut cutouts = Vec::new();
     let mut envelopes = Vec::new();
@@ -161,9 +184,9 @@ fn collect_relief_feature_candidates(
             .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
         for feature in &doc.features {
             if is_through_cutout(feature) {
-                cutouts.push(ReliefFeatureCandidate::new(&doc, feature, resolution)?);
+                cutouts.push(ReliefFeatureCandidate::new(&doc, feature));
             } else if is_pad_envelope(feature) {
-                envelopes.push(ReliefFeatureCandidate::new(&doc, feature, resolution)?);
+                envelopes.push(ReliefFeatureCandidate::new(&doc, feature));
             }
         }
     }
@@ -173,7 +196,7 @@ fn collect_relief_feature_candidates(
 
 #[derive(Debug, Clone)]
 struct ReliefFeatureCandidate {
-    region: ContourSet,
+    contours: Vec<ContourBuf>,
     bbox: BBox,
     plating: PlatingKind,
     padstack_ref: Option<Symbol>,
@@ -181,21 +204,21 @@ struct ReliefFeatureCandidate {
 }
 
 impl ReliefFeatureCandidate {
-    fn new(
-        doc: &GeometryDocument,
-        feature: &Feature<Symbol>,
-        resolution: Resolution,
-    ) -> anyhow::Result<Self> {
-        Ok(Self {
-            region: ContourSet::from_filled_contours(
-                &doc.placed_feature_contours(feature),
-                resolution,
-            )?,
+    fn new(doc: &GeometryDocument, feature: &Feature<Symbol>) -> Self {
+        Self {
+            contours: doc.placed_feature_contours(feature),
             bbox: feature.bbox,
             plating: feature.intent.plating,
             padstack_ref: feature.padstack_ref,
             net: feature.net,
-        })
+        }
+    }
+
+    fn region(&self, resolution: Resolution) -> Result<ContourSet> {
+        Ok(ContourSet::from_filled_contours(
+            &self.contours,
+            resolution,
+        )?)
     }
 }
 
@@ -246,7 +269,9 @@ fn score_line_strip(line: VScoreLine, resolution: Resolution) -> ContourSet {
 
 fn envelope_matches_cutout(
     envelope: &ReliefFeatureCandidate,
+    envelope_region: &ContourSet,
     cutout: &ReliefFeatureCandidate,
+    cutout_region: &ContourSet,
 ) -> bool {
     if !envelope.bbox.intersects(cutout.bbox) {
         return false;
@@ -262,5 +287,5 @@ fn envelope_matches_cutout(
     {
         return true;
     }
-    !envelope.region.intersection(&cutout.region).is_empty()
+    !envelope_region.intersection(cutout_region).is_empty()
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -107,43 +107,34 @@ fn board_array_relief_features(
         .iter()
         .map(|line| score_line_strip(*line, resolution))
         .collect::<Vec<_>>();
-    // Regions are prepared only for candidates near a score line: on a dense
-    // panel almost every hole is nowhere near one.
-    let near_score_line = |candidate: &ReliefFeatureCandidate| {
+    // Regions are prepared only near a score line: on a dense panel almost
+    // every hole is nowhere near one.
+    let crossing = prepare_candidates(cutouts, resolution, |cutout| {
         strips
             .iter()
-            .any(|strip| candidate.bbox.intersects(strip.bbox))
-    };
-    let mut crossing = Vec::new();
-    for cutout in cutouts.into_iter().filter(near_score_line) {
-        let region = cutout.region(resolution)?;
-        if strips
+            .any(|strip| cutout.bbox.intersects(strip.bbox))
+    })?
+    .into_iter()
+    .filter(|cutout| {
+        strips
             .iter()
-            .any(|strip| !region.intersection(strip).is_empty())
-        {
-            crossing.push((cutout, region));
-        }
-    }
-    let envelopes = envelopes
-        .into_iter()
-        .filter(|envelope| {
-            crossing
-                .iter()
-                .any(|(cutout, _)| envelope.bbox.intersects(cutout.bbox))
-        })
-        .map(|envelope| Ok((envelope.region(resolution)?, envelope)))
-        .collect::<Result<Vec<_>>>()?;
+            .any(|strip| !cutout.region.intersection(strip).is_empty())
+    })
+    .collect::<Vec<_>>();
+    let envelopes = prepare_candidates(envelopes, resolution, |envelope| {
+        crossing
+            .iter()
+            .any(|cutout| envelope.bbox.intersects(cutout.bbox))
+    })?;
     // Every blocker joins one batched union: unioning them one at a time is
     // quadratic in the number of cutouts on dense panels.
     let mut blockers = Vec::new();
-    for (cutout, region) in crossing {
+    for cutout in crossing {
         if plated_like(cutout.plating) {
             let matches = envelopes
                 .iter()
-                .filter(|(envelope_region, envelope)| {
-                    envelope_matches_cutout(envelope, envelope_region, &cutout, &region)
-                })
-                .map(|(envelope_region, _)| envelope_region.clone())
+                .filter(|envelope| envelope.matches_cutout(&cutout))
+                .map(|envelope| envelope.region.clone())
                 .collect::<Vec<_>>();
             if matches.is_empty() {
                 bail!(
@@ -156,7 +147,7 @@ fn board_array_relief_features(
             }
             blockers.extend(matches);
         } else {
-            blockers.push(region);
+            blockers.push(cutout.region);
         }
     }
     let score_blockers = ContourSet::union_all(resolution, blockers)?;
@@ -194,9 +185,33 @@ fn collect_relief_feature_candidates(
     Ok((cutouts, envelopes))
 }
 
+/// Prepare the region of every candidate `keep` selects.
+fn prepare_candidates(
+    candidates: Vec<ReliefFeatureCandidate>,
+    resolution: Resolution,
+    keep: impl Fn(&ReliefFeatureCandidate) -> bool,
+) -> Result<Vec<ReliefRegion>> {
+    candidates
+        .into_iter()
+        .filter(keep)
+        .map(|candidate| candidate.prepare(resolution))
+        .collect()
+}
+
+/// A through cutout or pad envelope as its source contours.
 #[derive(Debug, Clone)]
 struct ReliefFeatureCandidate {
     contours: Vec<ContourBuf>,
+    bbox: BBox,
+    plating: PlatingKind,
+    padstack_ref: Option<Symbol>,
+    net: Option<Symbol>,
+}
+
+/// A candidate with its region prepared.
+#[derive(Debug, Clone)]
+struct ReliefRegion {
+    region: ContourSet,
     bbox: BBox,
     plating: PlatingKind,
     padstack_ref: Option<Symbol>,
@@ -214,11 +229,36 @@ impl ReliefFeatureCandidate {
         }
     }
 
-    fn region(&self, resolution: Resolution) -> Result<ContourSet> {
-        Ok(ContourSet::from_filled_contours(
-            &self.contours,
-            resolution,
-        )?)
+    fn prepare(self, resolution: Resolution) -> Result<ReliefRegion> {
+        Ok(ReliefRegion {
+            region: ContourSet::from_filled_contours(&self.contours, resolution)?,
+            bbox: self.bbox,
+            plating: self.plating,
+            padstack_ref: self.padstack_ref,
+            net: self.net,
+        })
+    }
+}
+
+impl ReliefRegion {
+    /// Whether this pad envelope belongs to `cutout`: same net when both are
+    /// known, the same padstack, or overlapping copper.
+    fn matches_cutout(&self, cutout: &ReliefRegion) -> bool {
+        if !self.bbox.intersects(cutout.bbox) {
+            return false;
+        }
+        if let (Some(envelope_net), Some(cutout_net)) = (self.net, cutout.net)
+            && envelope_net != cutout_net
+        {
+            return false;
+        }
+        if let (Some(envelope_padstack), Some(cutout_padstack)) =
+            (self.padstack_ref, cutout.padstack_ref)
+            && envelope_padstack == cutout_padstack
+        {
+            return true;
+        }
+        !self.region.intersection(&cutout.region).is_empty()
     }
 }
 
@@ -265,27 +305,4 @@ fn score_line_strip(line: VScoreLine, resolution: Resolution) -> ContourSet {
         ),
     };
     ContourSet::rectangle(bbox, resolution)
-}
-
-fn envelope_matches_cutout(
-    envelope: &ReliefFeatureCandidate,
-    envelope_region: &ContourSet,
-    cutout: &ReliefFeatureCandidate,
-    cutout_region: &ContourSet,
-) -> bool {
-    if !envelope.bbox.intersects(cutout.bbox) {
-        return false;
-    }
-    if let (Some(envelope_net), Some(cutout_net)) = (envelope.net, cutout.net)
-        && envelope_net != cutout_net
-    {
-        return false;
-    }
-    if let (Some(envelope_padstack), Some(cutout_padstack)) =
-        (envelope.padstack_ref, cutout.padstack_ref)
-        && envelope_padstack == cutout_padstack
-    {
-        return true;
-    }
-    !envelope_region.intersection(cutout_region).is_empty()
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -2,7 +2,7 @@ pub mod dxf;
 pub mod render;
 
 use anyhow::{Context, Result, bail};
-use ipc2581::{Ipc2581, Symbol, types::LayerFunction};
+use ipc2581::{Symbol, types::LayerFunction};
 use pcb_ir::dialects::ipc::{
     ArtworkScope, BoardArrayFabricationProfile, BoardArrayReliefFeatures, Feature, FeatureBucket,
     FeatureDomain, FeatureKind, PlatingKind,
@@ -11,8 +11,9 @@ use pcb_ir::dialects::ipc::{
         vscore_lines_for,
     },
 };
-use pcb_ir::geom::{BBox, ContourBuf, ContourSet, Point, Polarity};
-use pcb_ir::import::ipc2581::{ImportedDesign, LayerId, import_design};
+use pcb_ir::geom::Resolution;
+use pcb_ir::geom::{BBox, ContourSet, Point, Polarity};
+use pcb_ir::import::ipc2581::{ImportedDesign, LayerId};
 
 pub use pcb_ir::import::ipc2581::{extract_layer, extract_layer_for_view, extract_layout};
 pub(crate) use pcb_ir::import::ipc2581::{is_panel_step, step_repeat_transform};
@@ -23,14 +24,6 @@ pub(crate) type GeometryDocument =
 /// V-score centerlines per scoring layer (`VCut` and `Score` functions) for
 /// the given artwork scope.
 pub fn vscore_lines(
-    ipc: &Ipc2581,
-    scope: ArtworkScope,
-) -> Result<Vec<(ipc2581::Symbol, LayerFunction, VScoreLine)>> {
-    let imported = import_design(ipc)?;
-    vscore_lines_from_design(&imported, scope)
-}
-
-pub fn vscore_lines_from_design(
     imported: &ImportedDesign,
     scope: ArtworkScope,
 ) -> Result<Vec<(ipc2581::Symbol, LayerFunction, VScoreLine)>> {
@@ -60,62 +53,34 @@ pub fn vscore_lines_from_design(
     Ok(lines)
 }
 
-pub fn board_array_vscore_lines(ipc: &Ipc2581) -> Result<Vec<VScoreLine>> {
-    Ok(vscore_lines(ipc, ArtworkScope::ArrayFlattened)?
+pub fn board_array_vscore_lines(imported: &ImportedDesign) -> Result<Vec<VScoreLine>> {
+    Ok(vscore_lines(imported, ArtworkScope::ArrayFlattened)?
         .into_iter()
         .map(|(_, _, line)| line)
         .collect())
 }
 
-pub fn board_array_vscore_lines_from_design(imported: &ImportedDesign) -> Result<Vec<VScoreLine>> {
-    Ok(
-        vscore_lines_from_design(imported, ArtworkScope::ArrayFlattened)?
-            .into_iter()
-            .map(|(_, _, line)| line)
-            .collect(),
-    )
-}
-
 pub fn board_array_fabrication_profile(
-    ipc: &Ipc2581,
+    imported: &ImportedDesign,
     layout: &GeometryDocument,
     score_lines: &[VScoreLine],
+    resolution: Resolution,
 ) -> Result<BoardArrayFabricationProfile> {
-    let (profile, _) = board_array_fabrication_profile_with_debug(ipc, layout, score_lines)?;
+    let (profile, _) =
+        board_array_fabrication_profile_with_debug(imported, layout, score_lines, resolution)?;
     Ok(profile)
 }
 
 pub fn board_array_fabrication_profile_with_debug(
-    ipc: &Ipc2581,
+    imported: &ImportedDesign,
     layout: &GeometryDocument,
     score_lines: &[VScoreLine],
+    resolution: Resolution,
 ) -> Result<(
     BoardArrayFabricationProfile,
     pcb_ir::dialects::ipc::relief::VScoreReliefDebug,
 )> {
-    let imported = import_design(ipc)?;
-    board_array_fabrication_profile_from_design_with_debug(&imported, layout, score_lines)
-}
-
-pub fn board_array_fabrication_profile_from_design(
-    imported: &ImportedDesign,
-    layout: &GeometryDocument,
-    score_lines: &[VScoreLine],
-) -> Result<BoardArrayFabricationProfile> {
-    let (profile, _) =
-        board_array_fabrication_profile_from_design_with_debug(imported, layout, score_lines)?;
-    Ok(profile)
-}
-
-pub fn board_array_fabrication_profile_from_design_with_debug(
-    imported: &ImportedDesign,
-    layout: &GeometryDocument,
-    score_lines: &[VScoreLine],
-) -> Result<(
-    BoardArrayFabricationProfile,
-    pcb_ir::dialects::ipc::relief::VScoreReliefDebug,
-)> {
-    let relief_features = board_array_relief_features(imported, score_lines)?;
+    let relief_features = board_array_relief_features(imported, score_lines, resolution)?;
     Ok(pcb_ir::dialects::ipc::board_array_fabrication_profile(
         layout,
         score_lines,
@@ -123,28 +88,38 @@ pub fn board_array_fabrication_profile_from_design_with_debug(
             relief_features,
             debug: true,
         },
+        resolution,
     )?)
 }
 
 fn board_array_relief_features(
     imported: &ImportedDesign,
     score_lines: &[VScoreLine],
+    resolution: Resolution,
 ) -> Result<BoardArrayReliefFeatures> {
     if score_lines.is_empty() {
         return Ok(BoardArrayReliefFeatures::default());
     }
 
-    let (cutouts, envelopes) = collect_relief_feature_candidates(imported)?;
-    let mut score_blockers = Vec::new();
-    for cutout in cutouts
-        .into_iter()
-        .filter(|cutout| payloads_touch_score_lines(&cutout.payloads, score_lines))
-    {
+    let resolution = resolution.with_tolerance(DEFAULT_RELIEF_TOLERANCE_MM);
+    let (cutouts, envelopes) = collect_relief_feature_candidates(imported, resolution)?;
+    let mut score_blockers = ContourSet::empty(resolution);
+    for cutout in cutouts {
+        if !score_lines.iter().any(|line| {
+            !cutout
+                .region
+                .intersection(&score_line_strip(*line, resolution))
+                .is_empty()
+        }) {
+            continue;
+        }
         if plated_like(cutout.plating) {
-            let matches = envelopes
-                .iter()
-                .filter(|envelope| envelope_matches_cutout(envelope, &cutout))
-                .collect::<Vec<_>>();
+            let mut matches = Vec::new();
+            for envelope in &envelopes {
+                if envelope_matches_cutout(envelope, &cutout) {
+                    matches.push(envelope);
+                }
+            }
             if matches.is_empty() {
                 bail!(
                     "plated edge cutout at [{:.3}, {:.3}]..[{:.3}, {:.3}] has no matching pad envelope for V-score relief generation",
@@ -155,21 +130,21 @@ fn board_array_relief_features(
                 );
             }
             for envelope in matches {
-                score_blockers.extend(envelope.payloads.clone());
+                score_blockers = score_blockers.union(&envelope.region);
             }
         } else {
-            score_blockers.extend(cutout.payloads);
+            score_blockers = score_blockers.union(&cutout.region);
         }
     }
 
-    let blockers = ContourSet::from_filled_contours(&score_blockers, DEFAULT_RELIEF_TOLERANCE_MM);
     Ok(BoardArrayReliefFeatures {
-        score_blockers: blockers.to_contours(),
+        score_blockers: score_blockers.to_contours(),
     })
 }
 
 fn collect_relief_feature_candidates(
     imported: &ImportedDesign,
+    resolution: Resolution,
 ) -> Result<(Vec<ReliefFeatureCandidate>, Vec<ReliefFeatureCandidate>)> {
     let mut cutouts = Vec::new();
     let mut envelopes = Vec::new();
@@ -186,9 +161,9 @@ fn collect_relief_feature_candidates(
             .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
         for feature in &doc.features {
             if is_through_cutout(feature) {
-                cutouts.push(ReliefFeatureCandidate::new(&doc, feature));
+                cutouts.push(ReliefFeatureCandidate::new(&doc, feature, resolution)?);
             } else if is_pad_envelope(feature) {
-                envelopes.push(ReliefFeatureCandidate::new(&doc, feature));
+                envelopes.push(ReliefFeatureCandidate::new(&doc, feature, resolution)?);
             }
         }
     }
@@ -198,7 +173,7 @@ fn collect_relief_feature_candidates(
 
 #[derive(Debug, Clone)]
 struct ReliefFeatureCandidate {
-    payloads: Vec<ContourBuf>,
+    region: ContourSet,
     bbox: BBox,
     plating: PlatingKind,
     padstack_ref: Option<Symbol>,
@@ -206,19 +181,22 @@ struct ReliefFeatureCandidate {
 }
 
 impl ReliefFeatureCandidate {
-    fn new(doc: &GeometryDocument, feature: &Feature<Symbol>) -> Self {
-        Self {
-            payloads: feature_contours(doc, feature),
+    fn new(
+        doc: &GeometryDocument,
+        feature: &Feature<Symbol>,
+        resolution: Resolution,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            region: ContourSet::from_filled_contours(
+                &doc.placed_feature_contours(feature),
+                resolution,
+            )?,
             bbox: feature.bbox,
             plating: feature.intent.plating,
             padstack_ref: feature.padstack_ref,
             net: feature.net,
-        }
+        })
     }
-}
-
-fn feature_contours(doc: &GeometryDocument, feature: &Feature<Symbol>) -> Vec<ContourBuf> {
-    doc.placed_feature_contours(feature)
 }
 
 fn relief_feature_layer(layer_function: LayerFunction) -> bool {
@@ -251,21 +229,7 @@ fn plated_like(plating: PlatingKind) -> bool {
     )
 }
 
-fn payloads_touch_score_lines(payloads: &[ContourBuf], score_lines: &[VScoreLine]) -> bool {
-    if payloads.is_empty() {
-        return false;
-    }
-    let bbox = payloads
-        .iter()
-        .fold(BBox::empty(), |bbox, payload| bbox.union(payload.bbox));
-    let region = ContourSet::from_filled_contours(payloads, DEFAULT_RELIEF_TOLERANCE_MM);
-    score_lines.iter().any(|line| {
-        let strip = score_line_strip(*line);
-        bbox.intersects(strip.bbox) && !region.intersection(&strip).is_empty()
-    })
-}
-
-fn score_line_strip(line: VScoreLine) -> ContourSet {
+fn score_line_strip(line: VScoreLine, resolution: Resolution) -> ContourSet {
     let width = DEFAULT_SCORE_ALIGNMENT_TOLERANCE_MM.max(line.width / 2.0);
     let bbox = BBox {
         min: Point::new(
@@ -277,7 +241,7 @@ fn score_line_strip(line: VScoreLine) -> ContourSet {
             line.start.y.max(line.end.y) + width,
         ),
     };
-    ContourSet::rectangle(bbox, DEFAULT_RELIEF_TOLERANCE_MM)
+    ContourSet::rectangle(bbox, resolution)
 }
 
 fn envelope_matches_cutout(
@@ -298,11 +262,5 @@ fn envelope_matches_cutout(
     {
         return true;
     }
-    payloads_intersect(&envelope.payloads, &cutout.payloads)
-}
-
-fn payloads_intersect(left: &[ContourBuf], right: &[ContourBuf]) -> bool {
-    let left_region = ContourSet::from_filled_contours(left, DEFAULT_RELIEF_TOLERANCE_MM);
-    let right_region = ContourSet::from_filled_contours(right, DEFAULT_RELIEF_TOLERANCE_MM);
-    !left_region.intersection(&right_region).is_empty()
+    !envelope.region.intersection(&cutout.region).is_empty()
 }

--- a/crates/pcb-ipc2581-tools/src/geometry/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/mod.rs
@@ -109,18 +109,18 @@ fn board_array_relief_features(
         .collect::<Vec<_>>();
     // Regions are prepared only near a score line: on a dense panel almost
     // every hole is nowhere near one.
-    let crossing = prepare_candidates(cutouts, resolution, |cutout| {
+    let mut crossing = Vec::new();
+    for cutout in prepare_candidates(cutouts, resolution, |cutout| {
         strips
             .iter()
             .any(|strip| cutout.bbox.intersects(strip.bbox))
-    })?
-    .into_iter()
-    .filter(|cutout| {
-        strips
-            .iter()
-            .any(|strip| !cutout.region.intersection(strip).is_empty())
-    })
-    .collect::<Vec<_>>();
+    })? {
+        if strips.iter().try_fold(false, |hit, strip| {
+            Ok::<_, anyhow::Error>(hit || overlaps(&cutout.region, strip)?)
+        })? {
+            crossing.push(cutout);
+        }
+    }
     let envelopes = prepare_candidates(envelopes, resolution, |envelope| {
         crossing
             .iter()
@@ -131,11 +131,12 @@ fn board_array_relief_features(
     let mut blockers = Vec::new();
     for cutout in crossing {
         if plated_like(cutout.plating) {
-            let matches = envelopes
-                .iter()
-                .filter(|envelope| envelope.matches_cutout(&cutout))
-                .map(|envelope| envelope.region.clone())
-                .collect::<Vec<_>>();
+            let mut matches = Vec::new();
+            for envelope in &envelopes {
+                if envelope.matches_cutout(&cutout)? {
+                    matches.push(envelope.region.clone());
+                }
+            }
             if matches.is_empty() {
                 bail!(
                     "plated edge cutout at [{:.3}, {:.3}]..[{:.3}, {:.3}] has no matching pad envelope for V-score relief generation",
@@ -243,23 +244,27 @@ impl ReliefFeatureCandidate {
 impl ReliefRegion {
     /// Whether this pad envelope belongs to `cutout`: same net when both are
     /// known, the same padstack, or overlapping copper.
-    fn matches_cutout(&self, cutout: &ReliefRegion) -> bool {
+    fn matches_cutout(&self, cutout: &ReliefRegion) -> Result<bool> {
         if !self.bbox.intersects(cutout.bbox) {
-            return false;
+            return Ok(false);
         }
         if let (Some(envelope_net), Some(cutout_net)) = (self.net, cutout.net)
             && envelope_net != cutout_net
         {
-            return false;
+            return Ok(false);
         }
         if let (Some(envelope_padstack), Some(cutout_padstack)) =
             (self.padstack_ref, cutout.padstack_ref)
             && envelope_padstack == cutout_padstack
         {
-            return true;
+            return Ok(true);
         }
-        !self.region.intersection(&cutout.region).is_empty()
+        overlaps(&self.region, &cutout.region)
     }
+}
+
+fn overlaps(region: &ContourSet, other: &ContourSet) -> Result<bool> {
+    Ok(!region.intersection(other)?.is_empty())
 }
 
 fn relief_feature_layer(layer_function: LayerFunction) -> bool {

--- a/crates/pcb-ipc2581-tools/src/geometry/render.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/render.rs
@@ -1,5 +1,7 @@
 use anyhow::Context;
 use ipc2581::Symbol;
+use pcb_ir::geom::{GeometryAccuracy, Resolution};
+use pcb_ir::render::RenderOptions;
 
 pub use crate::layers::layer_role;
 use ipc2581::types::LayerFunction;
@@ -19,34 +21,43 @@ pub fn prepare_layer(
     imported: &ImportedDesign,
     layer_name: &str,
     view: ArtworkScope,
+    resolution: Resolution,
 ) -> anyhow::Result<GeometryDocument> {
     let layer = imported
         .layer_id(layer_name)
         .with_context(|| format!("IPC-2581 layer '{layer_name}' was not found"))?;
     let mut geometry = imported.materialize_layer(layer, view)?;
-    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut geometry);
+    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut geometry, resolution)?;
     pcb_ir::dialects::ipc::validate_artwork_ready(&geometry)
         .map_err(anyhow::Error::msg)
         .with_context(|| format!("IPC-2581 layer '{layer_name}' is not artwork-ready"))?;
     Ok(geometry)
 }
 
+/// Render a prepared layer as SVG, drawing anything the target cannot carry
+/// natively within `accuracy`.
 pub fn render_layer_svg(
     geometry: &GeometryDocument,
     include_profiles: bool,
     profile_set: ProfileSet,
-) -> String {
-    let artwork = layer_artwork(geometry, include_profiles, profile_set);
-    pcb_ir::render::artwork_svg(&artwork, &pcb_ir::render::RenderOptions::default())
+    accuracy: GeometryAccuracy,
+) -> anyhow::Result<String> {
+    let artwork = layer_artwork(geometry, include_profiles, profile_set)?;
+    Ok(pcb_ir::render::artwork_svg(
+        &artwork,
+        &RenderOptions::default().with_accuracy(accuracy),
+    )?)
 }
 
 pub fn render_layer_png(
     geometry: &GeometryDocument,
     include_profiles: bool,
     profile_set: ProfileSet,
+    accuracy: GeometryAccuracy,
 ) -> Result<Vec<u8>, String> {
-    let artwork = layer_artwork(geometry, include_profiles, profile_set);
-    pcb_ir::render::artwork_png(&artwork, &pcb_ir::render::RenderOptions::default())
+    let artwork = layer_artwork(geometry, include_profiles, profile_set)
+        .map_err(|error| error.to_string())?;
+    pcb_ir::render::artwork_png(&artwork, &RenderOptions::default().with_accuracy(accuracy))
 }
 
 #[cfg(feature = "cli")]
@@ -54,37 +65,47 @@ pub fn render_layer_terminal(
     geometry: &GeometryDocument,
     include_profiles: bool,
     profile_set: ProfileSet,
+    accuracy: GeometryAccuracy,
 ) -> Result<(), String> {
-    let artwork = layer_artwork(geometry, include_profiles, profile_set);
-    pcb_ir::render::artwork_to_terminal(&artwork, &pcb_ir::render::RenderOptions::default())
+    let artwork = layer_artwork(geometry, include_profiles, profile_set)
+        .map_err(|error| error.to_string())?;
+    pcb_ir::render::artwork_to_terminal(&artwork, &RenderOptions::default().with_accuracy(accuracy))
 }
 
-fn layer_has_content(geometry: &GeometryDocument) -> bool {
-    let mask = layer_mask(geometry, false, ProfileSet::RootOnly);
-    mask.layers
+fn layer_has_content(geometry: &GeometryDocument, resolution: Resolution) -> anyhow::Result<bool> {
+    let mask = layer_mask(geometry, false, ProfileSet::RootOnly, resolution)?;
+    Ok(mask
+        .layers
         .first()
         .map(|layer| !layer.shapes.is_empty() && !layer.bbox.is_empty())
-        .unwrap_or(false)
+        .unwrap_or(false))
 }
 
-pub fn layer_has_native_content(geometry: &GeometryDocument) -> bool {
-    let Some(mut native) = native_layer_document(geometry) else {
-        return false;
+pub fn layer_has_native_content(
+    geometry: &GeometryDocument,
+    resolution: Resolution,
+) -> anyhow::Result<bool> {
+    let Some(mut native) = native_layer_document(geometry)? else {
+        return Ok(false);
     };
-    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut native);
-    layer_has_content(&native)
+    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut native, resolution)?;
+    layer_has_content(&native, resolution)
 }
 
 /// Restrict a single-layer document to the features native to its source
 /// layer, dropping borrowed features. Returns `None` when nothing is native.
-pub fn native_layer_document(geometry: &GeometryDocument) -> Option<GeometryDocument> {
-    let layer = geometry.layers.first()?;
+pub fn native_layer_document(
+    geometry: &GeometryDocument,
+) -> anyhow::Result<Option<GeometryDocument>> {
+    let Some(layer) = geometry.layers.first() else {
+        return Ok(None);
+    };
     let source_layer_ref = layer.source_layer_ref;
     let mut native = geometry.clone();
     pcb_ir::dialects::ipc::process::retain_features(&mut native, |feature| {
         feature.source_layer_ref == Some(source_layer_ref)
     });
-    (!native.features.is_empty()).then_some(native)
+    Ok((!native.features.is_empty()).then_some(native))
 }
 
 /// Lower a single-layer geometry document to artwork, with the display
@@ -93,7 +114,7 @@ pub fn layer_artwork(
     geometry: &GeometryDocument,
     include_profiles: bool,
     profile_set: ProfileSet,
-) -> ArtworkDocument {
+) -> anyhow::Result<ArtworkDocument> {
     let layer = &geometry.layers[0];
     let mut artwork = pcb_ir::dialects::ipc::lower_layer_to_artwork(
         geometry,
@@ -102,21 +123,21 @@ pub fn layer_artwork(
         Side::None,
     );
     if include_profiles {
-        append_display_profiles(&mut artwork, geometry, profile_set, layer.layer_function);
+        append_display_profiles(&mut artwork, geometry, profile_set, layer.layer_function)?;
     }
-    artwork
+    Ok(artwork)
 }
 
 pub fn layer_mask(
     geometry: &GeometryDocument,
     include_profiles: bool,
     profile_set: ProfileSet,
-) -> mask::Document<LayerFunction> {
-    pcb_ir::dialects::artwork::compose_to_mask(&layer_artwork(
-        geometry,
-        include_profiles,
-        profile_set,
-    ))
+    resolution: Resolution,
+) -> anyhow::Result<mask::Document<LayerFunction>> {
+    Ok(pcb_ir::dialects::artwork::compose_to_mask(
+        &layer_artwork(geometry, include_profiles, profile_set)?,
+        resolution,
+    )?)
 }
 
 fn append_display_profiles(
@@ -124,7 +145,7 @@ fn append_display_profiles(
     geometry: &GeometryDocument,
     profile_set: ProfileSet,
     layer_function: LayerFunction,
-) {
+) -> anyhow::Result<()> {
     let profile_layer = artwork.push_layer(pcb_ir::dialects::artwork::Layer {
         name: "Profile".to_string(),
         role: LayerRole::Profile,
@@ -141,7 +162,7 @@ fn append_display_profiles(
             geometry,
             occurrence.profile.outer_path,
             occurrence.transform,
-        );
+        )?;
         for cutout in occurrence.profile.cutouts.slice(&geometry.profile_cutouts) {
             append_display_profile_path(
                 artwork,
@@ -149,11 +170,13 @@ fn append_display_profiles(
                 geometry,
                 cutout.path,
                 occurrence.transform,
-            );
+            )?;
         }
     }
 
     pcb_ir::dialects::artwork::normalize_bounds(artwork);
+
+    Ok(())
 }
 
 fn append_display_profile_path(
@@ -162,7 +185,7 @@ fn append_display_profile_path(
     geometry: &GeometryDocument,
     path: u32,
     transform: pcb_ir::geom::Affine2,
-) {
+) -> anyhow::Result<()> {
     let path = artwork.push_path(
         Paint::Stroke(StrokeStyle::round(DISPLAY_PROFILE_STROKE_WIDTH_MM)),
         geometry.transformed_path_contours(path, transform),
@@ -179,4 +202,6 @@ fn append_display_profile_path(
             meta: None,
         },
     );
+
+    Ok(())
 }

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1,3 +1,4 @@
+use pcb_ir::geom::{GeometryAccuracy, Resolution};
 use std::collections::{HashMap, HashSet};
 #[cfg(feature = "cli")]
 use std::fmt::Write as _;
@@ -7,7 +8,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
 use gerberx2::{GerberLayer, write_layer};
-use ipc2581::Ipc2581;
 use ipc2581::types::{
     FillProperty, LayerFunction, Side as IpcSide, StandardPrimitive,
     ecad::{Layer, Step},
@@ -30,15 +30,10 @@ use pcb_ir::dialects::ipc::{
 };
 use pcb_ir::dialects::{LayerRole, Side as IrSide};
 use pcb_ir::geom::path::ContourBuf;
-#[cfg(feature = "cli")]
-use pcb_ir::geom::path::{PathCmd, PathOp};
 use pcb_ir::geom::{
     Affine2, BBox, LineCap, LineJoin, LinePattern, Paint, Point, Polarity, Span, StrokeStyle,
 };
-use pcb_ir::import::ipc2581::{ImportedDesign, LayerId, import_design};
-
-#[cfg(feature = "cli")]
-use pcb_ir::geom::Arc;
+use pcb_ir::import::ipc2581::{ImportedDesign, LayerId};
 
 type IpcGeometryDocument = pcb_ir::dialects::ipc::Document<ipc2581::Symbol, LayerFunction>;
 
@@ -71,23 +66,11 @@ impl Default for ProfileGerberStyle {
     }
 }
 
-pub fn build_gerber_x2_files(ipc: &Ipc2581, view: ArtworkScope) -> Result<Vec<GerberX2File>> {
-    build_gerber_x2_files_with_options(ipc, view, &GerberExportOptions::default())
-}
-
-pub fn build_gerber_x2_files_with_options(
-    ipc: &Ipc2581,
-    view: ArtworkScope,
-    options: &GerberExportOptions,
-) -> Result<Vec<GerberX2File>> {
-    let imported = import_design(ipc)?;
-    build_gerber_x2_files_from_design_with_options(&imported, view, options)
-}
-
-pub(crate) fn build_gerber_x2_files_from_design_with_options(
+pub fn build_gerber_x2_files(
     imported: &ImportedDesign,
     view: ArtworkScope,
     options: &GerberExportOptions,
+    resolution: Resolution,
 ) -> Result<Vec<GerberX2File>> {
     // With no repeated instances, a board-array request denotes this board
     // itself. Use the board path so its Step/Profile remains authoritative
@@ -118,12 +101,18 @@ pub(crate) fn build_gerber_x2_files_from_design_with_options(
             view,
         };
         let artwork = if view == ArtworkScope::ArrayFlattened {
-            hierarchical_artwork_from_ipc_layer(imported, plan.layer_id, layer_name, spec)?
+            hierarchical_artwork_from_ipc_layer(
+                imported,
+                plan.layer_id,
+                layer_name,
+                spec,
+                resolution,
+            )?
         } else {
             let mut doc = imported
                 .materialize_layer(plan.layer_id, view)
                 .with_context(|| format!("failed to extract IPC-2581 layer '{layer_name}'"))?;
-            pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut doc);
+            pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut doc, resolution)?;
             if let Err(error) = pcb_ir::dialects::ipc::validate_artwork_ready(&doc) {
                 bail!("IPC-2581 layer '{layer_name}' is not artwork-ready: {error}");
             }
@@ -134,7 +123,7 @@ pub(crate) fn build_gerber_x2_files_from_design_with_options(
         {
             continue;
         }
-        let layer = lower_artwork_layer(&artwork)?;
+        let layer = lower_artwork_layer(&artwork, resolution.accuracy)?;
         if plan.role == GerberLayerRole::Profile && layer.objects.is_empty() {
             continue;
         }
@@ -149,8 +138,11 @@ pub(crate) fn build_gerber_x2_files_from_design_with_options(
         files.extend(board_array_profile_gerber_files(
             imported,
             options.relief_debug_dir.as_deref(),
+            resolution,
         )?);
-    } else if !has_profile_plan && let Some(file) = synthetic_profile_gerber_file(imported, view)? {
+    } else if !has_profile_plan
+        && let Some(file) = synthetic_profile_gerber_file(imported, view, resolution.accuracy)?
+    {
         files.push(file);
     }
 
@@ -547,7 +539,7 @@ fn artwork_from_ipc_layer(
             doc,
             spec.view.profile_set(),
             ProfileGerberStyle::default(),
-        );
+        )?;
     }
     Ok(artwork)
 }
@@ -565,6 +557,7 @@ fn hierarchical_artwork_from_ipc_layer(
     layer: LayerId,
     layer_name: &str,
     spec: GerberArtworkSpec,
+    resolution: Resolution,
 ) -> Result<GerberArtwork> {
     let root = primary_step(imported)?;
     let mut artwork = GerberArtwork::new();
@@ -584,7 +577,8 @@ fn hierarchical_artwork_from_ipc_layer(
         side: spec.side,
     };
     let mut blocks = HashMap::from([(root.name, None)]);
-    let objects = build_step_artwork_objects(&context, root, &mut artwork, &mut blocks)?;
+    let objects =
+        build_step_artwork_objects(&context, root, &mut artwork, &mut blocks, resolution)?;
     for object in objects {
         artwork.push_object(artwork_layer, object);
     }
@@ -608,6 +602,7 @@ fn build_step_artwork_block(
     step: &Step,
     artwork: &mut GerberArtwork,
     blocks: &mut HashMap<ipc2581::Symbol, Option<u32>>,
+    resolution: Resolution,
 ) -> Result<u32> {
     match blocks.get(&step.name).copied() {
         Some(Some(block)) => return Ok(block),
@@ -618,7 +613,7 @@ fn build_step_artwork_block(
         None => {}
     }
     blocks.insert(step.name, None);
-    let objects = build_step_artwork_objects(context, step, artwork, blocks)?;
+    let objects = build_step_artwork_objects(context, step, artwork, blocks, resolution)?;
     let block = artwork.push_block();
     for object in objects {
         artwork.push_block_object(block, object);
@@ -632,6 +627,7 @@ fn build_step_artwork_objects(
     step: &Step,
     artwork: &mut GerberArtwork,
     blocks: &mut HashMap<ipc2581::Symbol, Option<u32>>,
+    resolution: Resolution,
 ) -> Result<Vec<ArtworkObject<ObjectAttributes>>> {
     let children = step
         .step_repeats
@@ -648,7 +644,7 @@ fn build_step_artwork_objects(
                         context.imported.resolve(repeat.step_ref)
                     )
                 })?;
-            let child = build_step_artwork_block(context, child_step, artwork, blocks)?;
+            let child = build_step_artwork_block(context, child_step, artwork, blocks, resolution)?;
             Ok((child, repeat))
         })
         .collect::<Result<Vec<_>>>()?;
@@ -667,7 +663,7 @@ fn build_step_artwork_objects(
                 context.layer_name
             )
         })?;
-    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut local);
+    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut local, resolution)?;
     if let Err(error) = pcb_ir::dialects::ipc::validate_artwork_ready(&local) {
         bail!(
             "IPC-2581 Step '{}' layer '{}' is not artwork-ready: {error}",
@@ -790,6 +786,7 @@ struct GerberArtworkSpec {
 fn synthetic_profile_gerber_file(
     imported: &ImportedDesign,
     view: ArtworkScope,
+    accuracy: GeometryAccuracy,
 ) -> Result<Option<GerberX2File>> {
     let doc = &imported.geometry;
     let mut artwork = GerberArtwork::new();
@@ -811,12 +808,12 @@ fn synthetic_profile_gerber_file(
         doc,
         view.profile_set(),
         ProfileGerberStyle::default(),
-    );
+    )?;
     if artwork.layers[artwork_layer as usize].objects.is_empty() {
         return Ok(None);
     }
 
-    let layer = lower_artwork_layer(&artwork)?;
+    let layer = lower_artwork_layer(&artwork, accuracy)?;
     let contents = write_layer(&layer)?;
     Ok(Some(GerberX2File {
         filename: "Edge_Cuts.gm1".to_string(),
@@ -828,29 +825,30 @@ fn synthetic_profile_gerber_file(
 fn board_array_profile_gerber_files(
     imported: &ImportedDesign,
     relief_debug_dir: Option<&Path>,
+    resolution: Resolution,
 ) -> Result<Vec<GerberX2File>> {
     let doc = &imported.geometry;
-    let score_lines = geometry::board_array_vscore_lines_from_design(imported)?;
+    let score_lines = geometry::board_array_vscore_lines(imported)?;
     #[cfg(not(feature = "cli"))]
     if relief_debug_dir.is_some() {
         bail!("filesystem debug output requires the cli feature");
     }
     #[cfg(feature = "cli")]
     let profile = if let Some(debug_dir) = relief_debug_dir {
-        let (profile, relief_debug) =
-            geometry::board_array_fabrication_profile_from_design_with_debug(
-                imported,
-                doc,
-                &score_lines,
-            )?;
+        let (profile, relief_debug) = geometry::board_array_fabrication_profile_with_debug(
+            imported,
+            doc,
+            &score_lines,
+            resolution,
+        )?;
         write_vscore_relief_debug(debug_dir, &relief_debug)?;
         profile
     } else {
-        geometry::board_array_fabrication_profile_from_design(imported, doc, &score_lines)?
+        geometry::board_array_fabrication_profile(imported, doc, &score_lines, resolution)?
     };
     #[cfg(not(feature = "cli"))]
     let profile =
-        geometry::board_array_fabrication_profile_from_design(imported, doc, &score_lines)?;
+        geometry::board_array_fabrication_profile(imported, doc, &score_lines, resolution)?;
     if profile.purpose == LayoutPurpose::Product {
         let mut contour_groups = profile.array_outlines;
         contour_groups.push(profile.material_removal);
@@ -859,6 +857,7 @@ fn board_array_profile_gerber_files(
             "Board_Array_Profile.gm1",
             contour_groups,
             GerberPart::Array,
+            resolution.accuracy,
         )?
         .into_iter()
         .collect());
@@ -870,18 +869,21 @@ fn board_array_profile_gerber_files(
             "Fab_Panel_Outline.gm1",
             profile.array_outlines,
             GerberPart::FabricationPanel,
+            resolution.accuracy,
         )?,
         profile_gerber_file(
             "Assembly Panel Outlines",
             "Assembly_Panel_Outlines.gm1",
             profile.assembly_panel_outlines,
             GerberPart::FabricationPanel,
+            resolution.accuracy,
         )?,
         profile_gerber_file(
             "Board Cutouts",
             "Board_Cutouts.gm1",
             vec![profile.material_removal],
             GerberPart::FabricationPanel,
+            resolution.accuracy,
         )?,
     ]
     .into_iter()
@@ -894,6 +896,7 @@ fn profile_gerber_file(
     filename: &str,
     contour_groups: Vec<Vec<ContourBuf>>,
     part: GerberPart,
+    accuracy: GeometryAccuracy,
 ) -> Result<Option<GerberX2File>> {
     let mut artwork = GerberArtwork::new();
     let artwork_layer = artwork.push_layer(pcb_ir::dialects::artwork::Layer {
@@ -919,7 +922,7 @@ fn profile_gerber_file(
         return Ok(None);
     }
 
-    let layer = lower_artwork_layer(&artwork)?;
+    let layer = lower_artwork_layer(&artwork, accuracy)?;
     let contents = write_layer(&layer)?;
     Ok(Some(GerberX2File {
         filename: filename.to_string(),
@@ -1101,84 +1104,8 @@ fn write_debug_path(
 
 #[cfg(feature = "cli")]
 fn debug_path_data(payloads: &[ContourBuf]) -> Option<String> {
-    let mut data = String::new();
-    for payload in payloads {
-        append_debug_path_cmds(&mut data, &payload.cmds);
-    }
+    let data = pcb_ir::render::svg_path_data(payloads);
     (!data.is_empty()).then_some(data)
-}
-
-#[cfg(feature = "cli")]
-fn append_debug_path_cmds(data: &mut String, cmds: &[PathCmd]) {
-    let mut current = Point::default();
-    for cmd in cmds {
-        match cmd.op {
-            PathOp::MoveTo => {
-                current = cmd.p0;
-                if !data.is_empty() {
-                    data.push(' ');
-                }
-                write!(data, "M{} {}", debug_num(cmd.p0.x), debug_num(cmd.p0.y)).unwrap();
-            }
-            PathOp::LineTo => {
-                current = cmd.p0;
-                write!(data, " L{} {}", debug_num(cmd.p0.x), debug_num(cmd.p0.y)).unwrap();
-            }
-            PathOp::ArcTo => {
-                write_debug_arc(data, current, cmd.p0, cmd.p1, cmd.clockwise);
-                current = cmd.p0;
-            }
-            PathOp::CubicTo => {
-                current = cmd.p2;
-                write!(
-                    data,
-                    " C{} {},{} {},{} {}",
-                    debug_num(cmd.p0.x),
-                    debug_num(cmd.p0.y),
-                    debug_num(cmd.p1.x),
-                    debug_num(cmd.p1.y),
-                    debug_num(cmd.p2.x),
-                    debug_num(cmd.p2.y)
-                )
-                .unwrap();
-            }
-            PathOp::Close => data.push_str(" Z"),
-        }
-    }
-}
-
-#[cfg(feature = "cli")]
-fn write_debug_arc(data: &mut String, start: Point, end: Point, center: Point, clockwise: bool) {
-    let radius = start.distance_to(center);
-    if radius <= 1e-9 {
-        write!(data, " L{} {}", debug_num(end.x), debug_num(end.y)).unwrap();
-        return;
-    }
-
-    let sweep_flag = if clockwise { 0 } else { 1 };
-    if start.distance_to(end) <= 1e-9 {
-        let midpoint = Point::new(2.0 * center.x - start.x, 2.0 * center.y - start.y);
-        write_debug_svg_arc(data, radius, 0, sweep_flag, midpoint);
-        write_debug_svg_arc(data, radius, 0, sweep_flag, end);
-        return;
-    }
-
-    let large_arc =
-        u8::from(Arc::new(start, end, center, clockwise).sweep_radians() > std::f64::consts::PI);
-    write_debug_svg_arc(data, radius, large_arc, sweep_flag, end);
-}
-
-#[cfg(feature = "cli")]
-fn write_debug_svg_arc(data: &mut String, radius: f64, large_arc: u8, sweep_flag: u8, end: Point) {
-    write!(
-        data,
-        " A{} {} 0 {large_arc} {sweep_flag} {} {}",
-        debug_num(radius),
-        debug_num(radius),
-        debug_num(end.x),
-        debug_num(end.y)
-    )
-    .unwrap();
 }
 
 #[cfg(feature = "cli")]
@@ -1206,7 +1133,7 @@ fn append_profile_occurrences(
     doc: &IpcGeometryDocument,
     profile_set: ProfileSet,
     style: ProfileGerberStyle,
-) {
+) -> anyhow::Result<()> {
     for occurrence in profile_occurrences_for(doc, profile_set) {
         append_profile_path(
             artwork,
@@ -1215,7 +1142,7 @@ fn append_profile_occurrences(
             occurrence.profile.outer_path,
             occurrence.transform,
             style,
-        );
+        )?;
         append_profile_cutouts(
             artwork,
             layer,
@@ -1223,8 +1150,9 @@ fn append_profile_occurrences(
             occurrence.profile,
             occurrence.transform,
             style,
-        );
+        )?;
     }
+    Ok(())
 }
 
 fn append_profile_cutouts(
@@ -1234,10 +1162,11 @@ fn append_profile_cutouts(
     profile: &pcb_ir::dialects::ipc::StepProfile,
     transform: Affine2,
     style: ProfileGerberStyle,
-) {
+) -> anyhow::Result<()> {
     for cutout in profile.cutouts.slice(&doc.profile_cutouts) {
-        append_profile_path(artwork, layer, doc, cutout.path, transform, style);
+        append_profile_path(artwork, layer, doc, cutout.path, transform, style)?;
     }
+    Ok(())
 }
 
 fn append_profile_path(
@@ -1247,13 +1176,15 @@ fn append_profile_path(
     path: u32,
     transform: Affine2,
     style: ProfileGerberStyle,
-) {
+) -> anyhow::Result<()> {
     append_profile_payloads(
         artwork,
         layer,
         doc.transformed_path_contours(path, transform),
         style,
     );
+
+    Ok(())
 }
 
 fn append_profile_payloads(
@@ -1641,14 +1572,39 @@ fn fiducial_aperture_function(feature: &Feature<ipc2581::Symbol>) -> Vec<String>
 mod tests {
     use super::*;
     use crate::ipc2581 as ipc;
-    #[cfg(feature = "cli")]
-    use crate::manufacturing::{ManufacturingExportOptions, export_manufacturing_package};
-    use crate::manufacturing::{ManufacturingFileKind, build_manufacturing_package};
+    use crate::manufacturing::{
+        ManufacturingExportOptions, ManufacturingFileKind, ManufacturingPackage,
+        build_manufacturing_package,
+    };
+    use ipc2581::Ipc2581;
+    use pcb_ir::import::ipc2581::import_design;
     #[cfg(feature = "cli")]
     use std::io::{Cursor, Read};
 
+    fn gerber_files(ipc: &Ipc2581, view: ArtworkScope) -> Result<Vec<GerberX2File>> {
+        build_gerber_x2_files(
+            &import_design(ipc)?,
+            view,
+            &GerberExportOptions::default(),
+            Resolution::default(),
+        )
+    }
+
+    fn manufacturing_package(ipc: &Ipc2581, view: ArtworkScope) -> Result<ManufacturingPackage> {
+        build_manufacturing_package(
+            &import_design(ipc)?,
+            &ManufacturingExportOptions {
+                view,
+                relief_debug_dir: None,
+            },
+            Resolution::default(),
+        )
+    }
+
     #[test]
     fn negative_set_before_a_later_fill_is_repainted_by_it() {
+        let resolution = Resolution::default();
+
         // Sequential set semantics: a fill written after the clear repaints
         // the cleared area, so the fill survives intact.
         let ipc = ipc::Ipc2581::parse(
@@ -1712,7 +1668,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
         let copper = files
             .iter()
             .find(|file| file.filename == "F_Cu.gtl")
@@ -1720,20 +1676,28 @@ mod tests {
         let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();
 
         let mask = pcb_ir::dialects::artwork::compose_to_mask(
-            &gerberx2::geometry::extract_document(&parsed),
-        );
+            &gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap(),
+            resolution,
+        )
+        .unwrap();
         let mut rings = Vec::new();
         for layer in &mask.layers {
             for shape in mask.shapes(layer) {
-                rings.extend(pcb_ir::geom::region::rings_from_contours(
-                    &mask.arena.path_contours(shape),
-                ));
+                rings.extend(
+                    pcb_ir::geom::ContourSet::from_contours(
+                        &mask.arena.path_contours(shape),
+                        pcb_ir::geom::FillRule::NonZero,
+                        resolution.strict(),
+                    )
+                    .unwrap()
+                    .rings,
+                );
             }
         }
-        let copper_area = pcb_ir::geom::ContourSet::new(
+        let copper_area = pcb_ir::geom::ContourSet::from_rings(
             rings,
             pcb_ir::geom::FillRule::NonZero,
-            pcb_ir::geom::tol::REGION_MM,
+            resolution,
         )
         .area();
         // The 6x6 fill paints after the clear and survives whole.
@@ -1746,6 +1710,8 @@ mod tests {
 
     #[test]
     fn catalogue_pads_flash_through_shared_apertures() {
+        let resolution = Resolution::default();
+
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -1800,7 +1766,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
         let copper = files
             .iter()
             .find(|file| file.filename == "F_Cu.gtl")
@@ -1821,20 +1787,28 @@ mod tests {
 
         let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();
         let mask = pcb_ir::dialects::artwork::compose_to_mask(
-            &gerberx2::geometry::extract_document(&parsed),
-        );
+            &gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap(),
+            resolution,
+        )
+        .unwrap();
         let mut rings = Vec::new();
         for layer in &mask.layers {
             for shape in mask.shapes(layer) {
-                rings.extend(pcb_ir::geom::region::rings_from_contours(
-                    &mask.arena.path_contours(shape),
-                ));
+                rings.extend(
+                    pcb_ir::geom::ContourSet::from_contours(
+                        &mask.arena.path_contours(shape),
+                        pcb_ir::geom::FillRule::NonZero,
+                        resolution.strict(),
+                    )
+                    .unwrap()
+                    .rings,
+                );
             }
         }
-        let copper_area = pcb_ir::geom::ContourSet::new(
+        let copper_area = pcb_ir::geom::ContourSet::from_rings(
             rings,
             pcb_ir::geom::FillRule::NonZero,
-            pcb_ir::geom::tol::REGION_MM,
+            resolution,
         )
         .area();
         let corner_deficit = 0.25 * 0.25 * (4.0 - std::f64::consts::PI);
@@ -1847,6 +1821,8 @@ mod tests {
 
     #[test]
     fn oversized_corner_radius_clamps_to_the_obround_image() {
+        let resolution = Resolution::default();
+
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -1892,27 +1868,35 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
         let copper = files
             .iter()
             .find(|file| file.filename == "F_Cu.gtl")
             .unwrap();
         let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();
         let mask = pcb_ir::dialects::artwork::compose_to_mask(
-            &gerberx2::geometry::extract_document(&parsed),
-        );
+            &gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap(),
+            resolution,
+        )
+        .unwrap();
         let mut rings = Vec::new();
         for layer in &mask.layers {
             for shape in mask.shapes(layer) {
-                rings.extend(pcb_ir::geom::region::rings_from_contours(
-                    &mask.arena.path_contours(shape),
-                ));
+                rings.extend(
+                    pcb_ir::geom::ContourSet::from_contours(
+                        &mask.arena.path_contours(shape),
+                        pcb_ir::geom::FillRule::NonZero,
+                        resolution.strict(),
+                    )
+                    .unwrap()
+                    .rings,
+                );
             }
         }
-        let copper_area = pcb_ir::geom::ContourSet::new(
+        let copper_area = pcb_ir::geom::ContourSet::from_rings(
             rings,
             pcb_ir::geom::FillRule::NonZero,
-            pcb_ir::geom::tol::REGION_MM,
+            resolution,
         )
         .area();
         // The radius clamps to height / 2, so the pad images as a 2x1 obround.
@@ -1926,6 +1910,8 @@ mod tests {
 
     #[test]
     fn negative_set_after_an_overlay_pad_erases_it_natively() {
+        let resolution = Resolution::default();
+
         // Sequential set semantics: the clear paints after the pad, erasing
         // the overlap, and exports natively as clear polarity.
         let ipc = ipc::Ipc2581::parse(
@@ -1988,7 +1974,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
         let copper = files
             .iter()
             .find(|file| file.filename == "F_Cu.gtl")
@@ -2003,20 +1989,28 @@ mod tests {
         );
 
         let mask = pcb_ir::dialects::artwork::compose_to_mask(
-            &gerberx2::geometry::extract_document(&parsed),
-        );
+            &gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap(),
+            resolution,
+        )
+        .unwrap();
         let mut rings = Vec::new();
         for layer in &mask.layers {
             for shape in mask.shapes(layer) {
-                rings.extend(pcb_ir::geom::region::rings_from_contours(
-                    &mask.arena.path_contours(shape),
-                ));
+                rings.extend(
+                    pcb_ir::geom::ContourSet::from_contours(
+                        &mask.arena.path_contours(shape),
+                        pcb_ir::geom::FillRule::NonZero,
+                        resolution.strict(),
+                    )
+                    .unwrap()
+                    .rings,
+                );
             }
         }
-        let copper_area = pcb_ir::geom::ContourSet::new(
+        let copper_area = pcb_ir::geom::ContourSet::from_rings(
             rings,
             pcb_ir::geom::FillRule::NonZero,
-            pcb_ir::geom::tol::REGION_MM,
+            resolution,
         )
         .area();
         let expected = std::f64::consts::PI * (1.0 - 0.25);
@@ -2075,7 +2069,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
         let copper = files
             .iter()
             .find(|file| file.filename == "F_Cu.gtl")
@@ -2170,6 +2164,8 @@ mod tests {
 
     #[test]
     fn assembly_gerbers_preserve_phantom_patterns_for_boards_and_arrays() {
+        let resolution = Resolution::default();
+
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -2202,7 +2198,7 @@ mod tests {
         )
         .unwrap();
 
-        let board_files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let board_files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
         let board_fab = board_files
             .iter()
             .find(|file| file.filename == "F_Fab.gbr")
@@ -2231,7 +2227,7 @@ mod tests {
             2
         );
 
-        let array_files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+        let array_files = gerber_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
         let array_fab = array_files
             .iter()
             .find(|file| file.filename == "F_Fab.gbr")
@@ -2241,7 +2237,7 @@ mod tests {
         assert!(array_fab.contents.contains("%SRX2Y1I30J0*%"));
         let parsed = gerberx2::GerberX2::parse(&array_fab.contents).unwrap();
         assert_eq!(parsed.objects().len(), 8);
-        let artwork = gerberx2::geometry::extract_document(&parsed);
+        let artwork = gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
         assert!(artwork.blocks.is_empty());
         assert_eq!(artwork.objects.len(), 8);
     }
@@ -2313,7 +2309,7 @@ mod tests {
         )
         .unwrap();
 
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
         let edge_cuts = files
             .iter()
             .find(|file| file.filename == "Edge_Cuts.gm1")
@@ -2327,6 +2323,8 @@ mod tests {
 
     #[test]
     fn standalone_profile_export_matches_both_layout_targets() {
+        let resolution = Resolution::default();
+
         for outline_layer in [
             "",
             r#"<Layer name="Edge.Cuts" layerFunction="BOARD_OUTLINE" side="ALL" polarity="POSITIVE"/>"#,
@@ -2362,8 +2360,8 @@ mod tests {
 </IPC-2581>"#,
             ))
             .unwrap();
-            let board = build_manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
-            let array = build_manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+            let board = manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
+            let array = manufacturing_package(&ipc, ArtworkScope::ArrayFlattened).unwrap();
             assert_eq!(
                 board
                     .files
@@ -2385,7 +2383,8 @@ mod tests {
             assert!(profile.contains("%TF.FileFunction,Profile,NP*%"));
             assert!(profile.contains("%TF.Part,Single*%"));
             let parsed = gerberx2::GerberX2::parse(profile).unwrap();
-            let geometry = gerberx2::geometry::extract_document(&parsed);
+            let geometry =
+                gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
             geometry.validate().unwrap();
             assert_eq!(geometry.layers[0].objects.count, 8);
         }
@@ -2437,7 +2436,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
 
         assert!(files.iter().any(|file| file.filename == "F_Cu.gtl"));
         for file in &files {
@@ -2464,7 +2463,7 @@ mod tests {
                 .any(|object| matches!(object.kind, gerberx2::ObjectKind::Flash { .. }))
         );
 
-        let panel_target_files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+        let panel_target_files = gerber_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
         let panel_target_copper = panel_target_files
             .iter()
@@ -2526,7 +2525,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
 
         let mask = files
             .iter()
@@ -2557,6 +2556,8 @@ mod tests {
 
     #[test]
     fn gerber_export_places_pad_flashes_after_local_fill_cut_ins() {
+        let resolution = Resolution::default();
+
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -2614,7 +2615,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
 
         let copper = files
             .iter()
@@ -2643,8 +2644,8 @@ mod tests {
             .expect("standard circular pad should export as a flash");
         assert!(region_index < pad_flash_index);
 
-        let geometry = gerberx2::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
+        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry, resolution).unwrap();
         assert!(
             summary.area_mm2 > 96.7,
             "pad flash was not restored after local clear; area was {}",
@@ -2654,6 +2655,8 @@ mod tests {
 
     #[test]
     fn gerber_export_places_multi_contour_traces_after_local_fill_cut_ins() {
+        let resolution = Resolution::default();
+
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -2711,7 +2714,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
 
         let copper = files
             .iter()
@@ -2732,8 +2735,8 @@ mod tests {
         assert!(fill_end_index < trace_index);
 
         let parsed = gerberx2::GerberX2::parse(&copper.contents).unwrap();
-        let geometry = gerberx2::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
+        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry, resolution).unwrap();
         assert!(
             summary.area_mm2 > 97.0,
             "multi-contour trace was not restored after local clear; area was {}",
@@ -2789,7 +2792,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let package = build_manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
+        let package = manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
 
         assert!(
             !package
@@ -2884,15 +2887,8 @@ mod tests {
         ));
         let _ = std::fs::remove_file(&output_zip);
 
-        let package = export_manufacturing_package(
-            &ipc,
-            &ManufacturingExportOptions {
-                output: output_zip.clone(),
-                view: ArtworkScope::Board,
-                relief_debug_dir: None,
-            },
-        )
-        .unwrap();
+        let package = manufacturing_package(&ipc, ArtworkScope::Board).unwrap();
+        crate::manufacturing::write_manufacturing_package(&package, &output_zip).unwrap();
 
         assert!(output_zip.is_file());
         let zip_file = std::fs::File::open(&output_zip).unwrap();
@@ -2916,6 +2912,8 @@ mod tests {
 
     #[test]
     fn gerber_export_preserves_user_special_counter_holes() {
+        let resolution = Resolution::default();
+
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -2961,7 +2959,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
 
         let silk = files
             .iter()
@@ -2972,8 +2970,8 @@ mod tests {
             "positive compound region holes should not export as layer-global clear regions"
         );
         let parsed = gerberx2::GerberX2::parse(&silk.contents).unwrap();
-        let geometry = gerberx2::geometry::extract_document(&parsed);
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry);
+        let geometry = gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
+        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry, resolution).unwrap();
         assert!(
             (summary.area_mm2 - 12.0).abs() < 1e-6,
             "compound region should preserve its counter hole; area was {}",
@@ -2983,6 +2981,8 @@ mod tests {
 
     #[test]
     fn gerber_preserves_leaf_board_repeats_without_nesting() {
+        let resolution = Resolution::default();
+
         let ipc = ipc::Ipc2581::parse(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
@@ -3037,7 +3037,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
         let top = files
             .iter()
@@ -3058,7 +3058,7 @@ mod tests {
         assert!(!top.contents.contains("%LS"));
         let parsed = gerberx2::GerberX2::parse(&top.contents).unwrap();
         assert_eq!(parsed.objects().len(), 6);
-        let artwork = gerberx2::geometry::extract_document(&parsed);
+        let artwork = gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
         assert!(artwork.blocks.is_empty());
         assert_eq!(artwork.objects.len(), 6);
     }
@@ -3104,7 +3104,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
         assert!(files.iter().all(|file| file.filename != "V_Cut.gbr"));
         let profile = files
@@ -3185,7 +3185,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::ArrayFlattened).unwrap();
 
         let top = files
             .iter()
@@ -3219,10 +3219,12 @@ mod tests {
     #[cfg(feature = "cli")]
     #[test]
     fn real_board_export_parseback_and_svg_paths_smoke() {
+        let resolution = Resolution::default();
+
         let compressed = include_bytes!("../../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");
         let content = zstd::decode_all(Cursor::new(compressed)).unwrap();
         let ipc = ipc::Ipc2581::parse(std::str::from_utf8(&content).unwrap()).unwrap();
-        let files = build_gerber_x2_files(&ipc, ArtworkScope::Board).unwrap();
+        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
 
         assert!(files.len() >= 10);
         assert!(files.iter().any(|file| file.filename == "F_Cu.gtl"));
@@ -3230,17 +3232,18 @@ mod tests {
 
         for file in &files {
             let parsed = gerberx2::GerberX2::parse(&file.contents).unwrap();
-            let geometry = gerberx2::geometry::extract_document(&parsed);
+            let geometry =
+                gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
             geometry.validate().unwrap();
 
-            let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry);
+            let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry, resolution).unwrap();
             mask.validate().unwrap();
             let svg = pcb_ir::render::svg(&mask, &pcb_ir::render::RenderOptions::layer(0));
             assert!(svg.contains("<svg"), "{} did not render SVG", file.filename);
         }
 
         let mut layer = geometry::extract_layer(&ipc, "F.Cu").unwrap();
-        pcb_ir::dialects::ipc::process::compose_for_rendering(&mut layer);
+        pcb_ir::dialects::ipc::process::compose_for_rendering(&mut layer, resolution).unwrap();
         let artwork = pcb_ir::dialects::ipc::lower_layer_to_artwork(
             &layer,
             0,
@@ -3248,13 +3251,13 @@ mod tests {
             pcb_ir::dialects::Side::Top,
         );
         artwork.validate().unwrap();
-        let mask = pcb_ir::dialects::artwork::compose_to_mask(&artwork);
+        let mask = pcb_ir::dialects::artwork::compose_to_mask(&artwork, resolution).unwrap();
         mask.validate().unwrap();
         assert!(
             pcb_ir::render::svg(&mask, &pcb_ir::render::RenderOptions::layer(0)).contains("<svg")
         );
 
-        pcb_ir::dialects::ipc::process::flatten_layers_to_masks(&mut layer);
+        pcb_ir::dialects::ipc::process::flatten_layers_to_masks(&mut layer, resolution).unwrap();
         let flat_artwork = pcb_ir::dialects::ipc::lower_layer_to_artwork(
             &layer,
             0,
@@ -3262,7 +3265,8 @@ mod tests {
             pcb_ir::dialects::Side::Top,
         );
         flat_artwork.validate().unwrap();
-        let flat_mask = pcb_ir::dialects::artwork::compose_to_mask(&flat_artwork);
+        let flat_mask =
+            pcb_ir::dialects::artwork::compose_to_mask(&flat_artwork, resolution).unwrap();
         flat_mask.validate().unwrap();
         assert!(
             pcb_ir::render::svg(&flat_mask, &pcb_ir::render::RenderOptions::layer(0))

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1699,6 +1699,7 @@ mod tests {
             pcb_ir::geom::FillRule::NonZero,
             resolution,
         )
+        .unwrap()
         .area();
         // The 6x6 fill paints after the clear and survives whole.
         let expected = 36.0;
@@ -1810,6 +1811,7 @@ mod tests {
             pcb_ir::geom::FillRule::NonZero,
             resolution,
         )
+        .unwrap()
         .area();
         let corner_deficit = 0.25 * 0.25 * (4.0 - std::f64::consts::PI);
         let expected = 3.0 * (2.0 - corner_deficit);
@@ -1898,6 +1900,7 @@ mod tests {
             pcb_ir::geom::FillRule::NonZero,
             resolution,
         )
+        .unwrap()
         .area();
         // The radius clamps to height / 2, so the pad images as a 2x1 obround.
         let clamped = 0.5;
@@ -2012,6 +2015,7 @@ mod tests {
             pcb_ir::geom::FillRule::NonZero,
             resolution,
         )
+        .unwrap()
         .area();
         let expected = std::f64::consts::PI * (1.0 - 0.25);
         assert!(

--- a/crates/pcb-ipc2581-tools/src/gerber/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/mod.rs
@@ -1,6 +1,3 @@
 mod export;
 
-pub(crate) use export::build_gerber_x2_files_from_design_with_options;
-pub use export::{
-    GerberExportOptions, GerberX2File, build_gerber_x2_files, build_gerber_x2_files_with_options,
-};
+pub use export::{GerberExportOptions, GerberX2File, build_gerber_x2_files};

--- a/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
+++ b/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
@@ -4,12 +4,16 @@ use std::fs;
 #[cfg(feature = "cli")]
 use std::io::BufWriter;
 use std::io::{Cursor, Seek, Write};
-use std::path::{Path, PathBuf};
+#[cfg(feature = "cli")]
+use std::path::Path;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use gerberx2::GerberLayer;
 use pcb_ir::dialects::ipc::ArtworkScope;
-use pcb_ir::import::ipc2581::{ImportedDesign, import_design};
+use pcb_ir::import::ipc2581::ImportedDesign;
+#[cfg(feature = "cli")]
+use pcb_ir::import::ipc2581::import_design;
 use zip::{ZipWriter, write::FileOptions};
 
 use crate::gerber;

--- a/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
+++ b/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
@@ -1,3 +1,4 @@
+use pcb_ir::geom::Resolution;
 #[cfg(feature = "cli")]
 use std::fs;
 #[cfg(feature = "cli")]
@@ -7,7 +8,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use gerberx2::GerberLayer;
-use ipc2581::Ipc2581;
 use pcb_ir::dialects::ipc::ArtworkScope;
 use pcb_ir::import::ipc2581::{ImportedDesign, import_design};
 use zip::{ZipWriter, write::FileOptions};
@@ -18,8 +18,9 @@ use crate::ipc2581 as ipc;
 
 #[derive(Debug, Clone)]
 pub struct ManufacturingExportOptions {
-    pub output: PathBuf,
     pub view: ArtworkScope,
+    /// Write the V-score relief construction as debug SVGs into this
+    /// directory.
     pub relief_debug_dir: Option<PathBuf>,
 }
 
@@ -48,51 +49,19 @@ pub enum ManufacturingFileKind {
     Xnc,
 }
 
-#[cfg(feature = "cli")]
-pub fn export_manufacturing_package(
-    ipc: &Ipc2581,
-    options: &ManufacturingExportOptions,
-) -> Result<ManufacturingPackage> {
-    let package = build_manufacturing_package_with_options(ipc, options)?;
-    write_manufacturing_package(&package, &options.output)?;
-    Ok(package)
-}
-
+/// Every Gerber X2 layer plus the XNC drill files for one artwork scope.
 pub fn build_manufacturing_package(
-    ipc: &Ipc2581,
-    view: ArtworkScope,
-) -> Result<ManufacturingPackage> {
-    let imported = import_design(ipc)?;
-    build_manufacturing_package_from_design(&imported, view)
-}
-
-/// Export an already-imported design without repeating IPC ingestion.
-pub fn build_manufacturing_package_from_design(
     imported: &ImportedDesign,
-    view: ArtworkScope,
-) -> Result<ManufacturingPackage> {
-    build_manufacturing_package_inner(imported, view, None)
-}
-
-pub fn build_manufacturing_package_with_options(
-    ipc: &Ipc2581,
     options: &ManufacturingExportOptions,
+    resolution: Resolution,
 ) -> Result<ManufacturingPackage> {
-    let imported = import_design(ipc)?;
-    build_manufacturing_package_inner(&imported, options.view, options.relief_debug_dir.as_deref())
-}
-
-fn build_manufacturing_package_inner(
-    imported: &ImportedDesign,
-    view: ArtworkScope,
-    relief_debug_dir: Option<&Path>,
-) -> Result<ManufacturingPackage> {
-    let mut files = gerber::build_gerber_x2_files_from_design_with_options(
+    let mut files = gerber::build_gerber_x2_files(
         imported,
-        view,
+        options.view,
         &gerber::GerberExportOptions {
-            relief_debug_dir: relief_debug_dir.map(Path::to_path_buf),
+            relief_debug_dir: options.relief_debug_dir.clone(),
         },
+        resolution,
     )?
     .into_iter()
     .map(|file| ManufacturingFile {
@@ -102,10 +71,27 @@ fn build_manufacturing_package_inner(
     })
     .collect::<Vec<_>>();
     files.extend(super::drill::build_xnc_drill_files_from_design(
-        imported, view,
+        imported,
+        options.view,
     )?);
 
     Ok(ManufacturingPackage { files })
+}
+
+/// Parse, import, build, and write a manufacturing package to `output`: a
+/// zip when the path has a `.zip` extension, otherwise a directory.
+#[cfg(feature = "cli")]
+pub fn export_manufacturing_package(
+    input_file: &Path,
+    output: &Path,
+    options: &ManufacturingExportOptions,
+    resolution: Resolution,
+) -> Result<ManufacturingPackage> {
+    let content = crate::utils::file::load_ipc_file(input_file)?;
+    let ipc = ipc::Ipc2581::parse(&content)?;
+    let package = build_manufacturing_package(&import_design(&ipc)?, options, resolution)?;
+    write_manufacturing_package(&package, output)?;
+    Ok(package)
 }
 
 #[cfg(feature = "cli")]
@@ -171,16 +157,6 @@ fn write_zip<W: Write + Seek>(package: &ManufacturingPackage, writer: W) -> Resu
             .with_context(|| format!("failed to write {} to manufacturing zip", file.filename))?;
     }
     zip.finish().context("failed to finalize manufacturing zip")
-}
-
-#[cfg(feature = "cli")]
-pub fn execute_file_with_options(
-    input_file: &Path,
-    options: &ManufacturingExportOptions,
-) -> Result<ManufacturingPackage> {
-    let content = crate::utils::file::load_ipc_file(input_file)?;
-    let ipc = ipc::Ipc2581::parse(&content)?;
-    export_manufacturing_package(&ipc, options)
 }
 
 #[cfg(test)]

--- a/crates/pcb-ipc2581-tools/src/manufacturing/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/manufacturing/mod.rs
@@ -3,10 +3,7 @@ mod export;
 
 pub use export::{
     ManufacturingExportOptions, ManufacturingFile, ManufacturingFileKind, ManufacturingPackage,
-    build_manufacturing_package, build_manufacturing_package_from_design,
-    build_manufacturing_package_with_options,
+    build_manufacturing_package,
 };
 #[cfg(feature = "cli")]
-pub use export::{
-    execute_file_with_options, export_manufacturing_package, write_manufacturing_package,
-};
+pub use export::{export_manufacturing_package, write_manufacturing_package};

--- a/crates/pcb-ipc2581-tools/src/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/placement.rs
@@ -1,24 +1,15 @@
 use anyhow::Result;
 use pcb_ir::dialects::assembly::Scope;
 use pcb_ir::dialects::placement::{Document as PlacementDocument, lower_single_board};
-use pcb_ir::import::ipc2581::{ImportedDesign, import_design};
+use pcb_ir::import::ipc2581::ImportedDesign;
 
-use crate::accessors::IpcAccessor;
-
-pub fn extract_single_board_placements(accessor: &IpcAccessor<'_>) -> Result<PlacementDocument> {
-    let ipc = accessor.ipc();
-    let imported = import_design(ipc)?;
-    extract_single_board_placements_from_design(&imported)
-}
-
-pub fn extract_single_board_placements_from_design(
-    imported: &ImportedDesign,
-) -> Result<PlacementDocument> {
+pub fn extract_single_board_placements(imported: &ImportedDesign) -> Result<PlacementDocument> {
     lower_single_board(&imported.assembly_document(Scope::BoardArray)?)
 }
 
 #[cfg(test)]
 mod tests {
+    use pcb_ir::import::ipc2581::import_design;
     use std::io::Cursor;
 
     use ipc2581::Ipc2581;
@@ -55,7 +46,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let placements = extract_single_board_placements(&IpcAccessor::new(&ipc)).unwrap();
+        let placements = extract_single_board_placements(&import_design(&ipc).unwrap()).unwrap();
 
         assert_eq!(placements.components.len(), 1);
         let component = &placements.components[0];
@@ -72,7 +63,7 @@ mod tests {
         let xml = std::str::from_utf8(&xml).unwrap();
         let imported = import_design(&Ipc2581::parse(xml).unwrap()).unwrap();
 
-        let placements = extract_single_board_placements_from_design(&imported).unwrap();
+        let placements = extract_single_board_placements(&imported).unwrap();
         assert_eq!(placements.components.len(), 59);
         assert_eq!(
             placements
@@ -124,7 +115,7 @@ mod tests {
         )
         .unwrap();
 
-        let error = extract_single_board_placements(&IpcAccessor::new(&ipc)).unwrap_err();
+        let error = extract_single_board_placements(&import_design(&ipc).unwrap()).unwrap_err();
 
         assert!(
             error

--- a/crates/pcb-ipc2581-tools/src/warp.rs
+++ b/crates/pcb-ipc2581-tools/src/warp.rs
@@ -4,14 +4,16 @@
 //! supplies it with a stackup and the per-layer copper it needs.
 
 use anyhow::{Context, Result, bail};
+use pcb_ir::geom::Resolution;
 use pcb_ir::geom::warp::{
     LAMINATE_RELAXATION_DROP_K, Material, PanelField, StackLayer, ThermalStack, WarpEstimate,
     estimate_warp,
 };
 use pcb_ir::geom::{BBox, ContourSet, Point};
 
-use crate::copper_balance::composed_copper_image;
 use crate::ipc2581::Ipc2581;
+use pcb_ir::dialects::ipc::ArtworkScope;
+use pcb_ir::import::ipc2581::{ImportedDesign, import_design};
 
 /// Cells across the panel's longer side.
 ///
@@ -57,10 +59,11 @@ pub struct WarpAnalysis {
 ///
 /// Requires a stackup carrying a thickness for every layer: without it there is
 /// no neutral axis, no lever arms, and nothing to estimate.
-pub fn analyze(ipc: &Ipc2581) -> Result<WarpAnalysis> {
+pub fn analyze(ipc: &Ipc2581, resolution: Resolution) -> Result<WarpAnalysis> {
+    let imported = import_design(ipc)?;
     let (stack, copper_names) = physical_stack(ipc)?;
     let conductors = stack.conductor_weights();
-    let bounds = panel_bounds(ipc)?;
+    let bounds = panel_bounds(ipc, &imported, resolution)?;
     let sample_pitch_mm =
         (bounds.width().max(bounds.height()) / SAMPLES_ACROSS).max(MIN_SAMPLE_PITCH_MM);
     let columns = (bounds.width() / sample_pitch_mm).ceil().max(1.0) as usize;
@@ -70,7 +73,14 @@ pub fn analyze(ipc: &Ipc2581) -> Result<WarpAnalysis> {
     let layers = copper_names
         .iter()
         .map(|layer_name| {
-            let image: ContourSet = composed_copper_image(ipc, layer_name)
+            let image: ContourSet = imported
+                .composed_layer_image(
+                    imported
+                        .layer_id(layer_name)
+                        .context("missing copper layer")?,
+                    ArtworkScope::ArrayFlattened,
+                    resolution,
+                )
                 .with_context(|| format!("failed to extract copper on layer '{layer_name}'"))?;
             let coverage = image.grid_coverage(bounds, columns, rows);
             let mean = coverage.iter().sum::<f64>() / coverage.len() as f64;
@@ -180,11 +190,12 @@ pub(crate) fn physical_stack(ipc: &Ipc2581) -> Result<(ThermalStack, Vec<String>
     Ok((stack, copper_names))
 }
 
-fn panel_bounds(ipc: &Ipc2581) -> Result<BBox> {
+fn panel_bounds(ipc: &Ipc2581, imported: &ImportedDesign, resolution: Resolution) -> Result<BBox> {
     let layout =
         crate::geometry::extract_layout(ipc).context("failed to extract the panel outline")?;
-    let profile = crate::geometry::board_array_fabrication_profile(ipc, &layout, &[])
-        .context("failed to derive the panel profile")?;
+    let profile =
+        crate::geometry::board_array_fabrication_profile(imported, &layout, &[], resolution)
+            .context("failed to derive the panel profile")?;
     let outline = ContourSet::from_filled_contours(
         &profile
             .array_outlines
@@ -192,8 +203,8 @@ fn panel_bounds(ipc: &Ipc2581) -> Result<BBox> {
             .flatten()
             .cloned()
             .collect::<Vec<_>>(),
-        pcb_ir::geom::tol::REGION_MM,
-    );
+        resolution,
+    )?;
     if outline.is_empty() {
         bail!("panel has no outline to measure");
     }

--- a/crates/pcb-ir/src/dialects/artwork/compare.rs
+++ b/crates/pcb-ir/src/dialects/artwork/compare.rs
@@ -7,8 +7,9 @@
 
 use crate::dialects::artwork::{self, Document};
 use crate::dialects::mask;
+use crate::geom::BBox;
 use crate::geom::region::{self, Ring, Shape};
-use crate::geom::{BBox, FillRule};
+use crate::geom::{AccuracyError, Resolution};
 
 /// Tolerances for comparing two layer images.
 ///
@@ -77,13 +78,14 @@ pub fn compare_documents<A, B>(
     reference: &Document<Vec<String>, A>,
     candidate: &Document<Vec<String>, B>,
     tolerance: CompareTolerance,
-) -> CompareReport
+    resolution: Resolution,
+) -> Result<CompareReport, AccuracyError>
 where
     A: Clone,
     B: Clone,
 {
-    let reference_summary = summarize(reference);
-    let candidate_summary = summarize(candidate);
+    let reference_summary = summarize(reference, resolution)?;
+    let candidate_summary = summarize(candidate, resolution)?;
     let mut mismatches = Vec::new();
 
     if reference_summary.file_function != candidate_summary.file_function {
@@ -109,7 +111,7 @@ where
         ));
     }
 
-    let difference = difference_summary(reference, candidate);
+    let difference = difference_summary(reference, candidate, resolution)?;
     if difference.symmetric_area_mm2 > tolerance.area_mm2 {
         mismatches.push(format!(
             "symmetric difference area is {:.6} mm², tolerance={:.6}",
@@ -117,17 +119,20 @@ where
         ));
     }
 
-    CompareReport {
+    Ok(CompareReport {
         reference: reference_summary,
         candidate: candidate_summary,
         difference,
         mismatches,
-    }
+    })
 }
 
-pub fn summarize<A: Clone>(doc: &Document<Vec<String>, A>) -> Summary {
-    let mask = artwork::compose_to_mask(doc);
-    Summary {
+pub fn summarize<A: Clone>(
+    doc: &Document<Vec<String>, A>,
+    resolution: Resolution,
+) -> Result<Summary, AccuracyError> {
+    let mask = artwork::compose_to_mask(doc, resolution)?;
+    Ok(Summary {
         file_function: doc
             .layers
             .first()
@@ -138,10 +143,10 @@ pub fn summarize<A: Clone>(doc: &Document<Vec<String>, A>) -> Summary {
             .first()
             .map(|layer| layer.bbox)
             .unwrap_or_else(BBox::empty),
-        area_mm2: region::rings_area(&document_image_rings(&mask)),
+        area_mm2: region::rings_area(&document_image_rings(&mask, resolution)?),
         object_count: doc.objects.len(),
         path_count: doc.arena.paths.len(),
-    }
+    })
 }
 
 fn compare_bbox(
@@ -180,21 +185,28 @@ fn compare_bbox(
 fn difference_summary<A, B>(
     reference: &Document<Vec<String>, A>,
     candidate: &Document<Vec<String>, B>,
-) -> DifferenceSummary
+    resolution: Resolution,
+) -> Result<DifferenceSummary, AccuracyError>
 where
     A: Clone,
     B: Clone,
 {
-    let reference = document_image_rings(&artwork::compose_to_mask(reference));
-    let candidate = document_image_rings(&artwork::compose_to_mask(candidate));
+    let reference = document_image_rings(
+        &artwork::compose_to_mask(reference, resolution)?,
+        resolution,
+    )?;
+    let candidate = document_image_rings(
+        &artwork::compose_to_mask(candidate, resolution)?,
+        resolution,
+    )?;
     let reference_only = directional_difference_summary(reference.clone(), candidate.clone());
     let candidate_only = directional_difference_summary(candidate, reference);
     let symmetric_area_mm2 = reference_only.area_mm2 + candidate_only.area_mm2;
-    DifferenceSummary {
+    Ok(DifferenceSummary {
         reference_only,
         candidate_only,
         symmetric_area_mm2,
-    }
+    })
 }
 
 fn directional_difference_summary(
@@ -230,17 +242,14 @@ fn difference_component_summary(shape: Shape) -> Option<DifferenceComponentSumma
     })
 }
 
-fn document_image_rings<LayerMeta>(mask: &mask::Document<LayerMeta>) -> Vec<Ring> {
-    let mut rings = Vec::new();
+fn document_image_rings<LayerMeta>(
+    mask: &mask::Document<LayerMeta>,
+    resolution: Resolution,
+) -> Result<Vec<Ring>, AccuracyError> {
     let Some(layer) = mask.layers.first() else {
-        return rings;
+        return Ok(Vec::new());
     };
-    for shape in mask.shapes(layer) {
-        rings.extend(region::rings_from_contours(
-            &mask.arena.path_contours(shape),
-        ));
-    }
-    region::union_rings(rings, FillRule::NonZero)
+    Ok(mask.layer_region(layer, resolution.strict())?.rings)
 }
 
 #[cfg(test)]
@@ -248,6 +257,7 @@ mod tests {
     use super::*;
     use crate::dialects::artwork::{Geometry, Layer, Object};
     use crate::dialects::{LayerRole, Side};
+    use crate::geom::FillRule;
     use crate::geom::path::{ContourBuf, PathCmd};
     use crate::geom::{Affine2, Mirror, Paint, Point, Polarity, Span};
 
@@ -264,13 +274,21 @@ mod tests {
                 bbox_mm: 0.01,
                 area_mm2: 0.001,
             },
-        );
+            Resolution::default(),
+        )
+        .unwrap();
         assert!(report.is_match(), "{:#?}", report.mismatches);
 
         let mut reference = reference;
         reference.layers[0].meta = vec!["Copper".to_string(), "L1".to_string(), "Top".to_string()];
         candidate.layers[0].meta = vec!["Copper".to_string(), "L2".to_string(), "Inr".to_string()];
-        let report = compare_documents(&reference, &candidate, CompareTolerance::default());
+        let report = compare_documents(
+            &reference,
+            &candidate,
+            CompareTolerance::default(),
+            Resolution::default(),
+        )
+        .unwrap();
         assert!(!report.is_match());
         assert!(report.mismatches[0].contains("file function differs"));
     }
@@ -292,7 +310,9 @@ mod tests {
                 bbox_mm: 1.0,
                 area_mm2: 0.001,
             },
-        );
+            Resolution::default(),
+        )
+        .unwrap();
 
         assert!(!report.is_match());
         assert!(
@@ -317,7 +337,9 @@ mod tests {
                 bbox_mm: 1.0,
                 area_mm2: 0.001,
             },
-        );
+            Resolution::default(),
+        )
+        .unwrap();
 
         assert!(!report.is_match());
         assert!(
@@ -336,8 +358,12 @@ mod tests {
         let reference = self_cut_even_odd_doc(false);
         let candidate = self_cut_even_odd_doc(true);
 
-        let reference_area = summarize(&reference).area_mm2;
-        let candidate_area = summarize(&candidate).area_mm2;
+        let reference_area = summarize(&reference, Resolution::default())
+            .unwrap()
+            .area_mm2;
+        let candidate_area = summarize(&candidate, Resolution::default())
+            .unwrap()
+            .area_mm2;
 
         assert!(
             candidate_area >= reference_area,

--- a/crates/pcb-ir/src/dialects/artwork/legalize.rs
+++ b/crates/pcb-ir/src/dialects/artwork/legalize.rs
@@ -1,7 +1,7 @@
 //! Gerber importer legalization for ordered artwork.
 
 use super::{Aperture, ApertureShape, Document, Geometry, normalize_bounds};
-use crate::geom::path::{ContourBuf, transform_cmds};
+use crate::geom::path::ContourBuf;
 use crate::geom::{Affine2, Point};
 
 const TRANSFORM_EPSILON: f64 = 1e-9;
@@ -178,13 +178,21 @@ fn axis_aligned_dimensions(width: f64, height: f64, basis: Affine2) -> Option<(f
 
 fn contour_aperture(aperture: &Aperture, basis: Affine2) -> Aperture {
     let fill_rule = aperture.fill_rule();
-    let cmds = aperture
+    let contours = aperture
         .contours()
         .into_iter()
-        .flat_map(|contour| transform_cmds(contour.cmds, basis).cmds)
+        .map(|contour| contour.transformed(basis))
+        .collect::<Vec<_>>();
+    let uncertainty_mm = contours
+        .iter()
+        .map(|contour| contour.uncertainty_mm)
+        .fold(0.0, f64::max);
+    let cmds = contours
+        .into_iter()
+        .flat_map(|contour| contour.cmds)
         .collect();
     Aperture::solid(ApertureShape::Contour {
-        outline: ContourBuf::new(cmds),
+        outline: ContourBuf::new(cmds).with_uncertainty(uncertainty_mm),
         fill_rule,
     })
 }
@@ -195,6 +203,7 @@ mod tests {
     use crate::dialects::artwork::compare::{CompareTolerance, compare_documents};
     use crate::dialects::artwork::{Layer, Object};
     use crate::dialects::{LayerRole, Side};
+    use crate::geom::Resolution;
     use crate::geom::{BBox, Mirror, Polarity, Span};
 
     fn round_rect_document() -> Document<Vec<String>, ()> {
@@ -261,7 +270,9 @@ mod tests {
                 bbox_mm: 1e-6,
                 area_mm2: 1e-6,
             },
-        );
+            Resolution::default(),
+        )
+        .unwrap();
         assert!(report.is_match(), "{:#?}", report.mismatches);
     }
 }

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -584,8 +584,7 @@ pub(crate) fn compose_selected_attributed<
             let image = region::ContourSet::union_all(
                 resolution,
                 owners.iter().map(|(_, image)| image.clone()),
-            );
-            resolution.accuracy.check(image.uncertainty_mm)?;
+            )?;
             Ok(AttributedImage { image, owners })
         })
         .collect::<Result<_, AccuracyError>>()?;
@@ -680,8 +679,7 @@ pub fn compose_owner_regions<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone +
 
         let mut images = Vec::with_capacity(states.len());
         for (owner, state) in states {
-            let image = state.composer.finish();
-            resolution.accuracy.check(image.uncertainty_mm)?;
+            let image = state.composer.finish()?;
             if !image.is_empty() {
                 images.push((owner, image));
             }

--- a/crates/pcb-ir/src/dialects/artwork/mod.rs
+++ b/crates/pcb-ir/src/dialects/artwork/mod.rs
@@ -9,13 +9,14 @@
 pub mod compare;
 pub mod legalize;
 
+use crate::geom::{AccuracyError, GeometryAccuracy, Resolution};
 use std::collections::HashMap;
 use std::hash::Hash;
 
 use crate::dialects::mask;
 use crate::dialects::{LayerRole, Side};
 use crate::geom::path::ContourBuf;
-use crate::geom::region::{self, Ring};
+use crate::geom::region::{self};
 use crate::geom::{
     Affine2, BBox, Diagnostic, FillRule, Paint, PathArena, Point, Polarity, Span, StrokeStyle,
     shapes,
@@ -398,7 +399,7 @@ impl Aperture {
         let outer = match &self.shape {
             ApertureShape::Circle { diameter } => shapes::circle(*diameter),
             ApertureShape::Rectangle { width, height } => shapes::rect(*width, *height),
-            ApertureShape::Obround { width, height } => shapes::obround(*width, *height, true),
+            ApertureShape::Obround { width, height } => shapes::obround(*width, *height),
             ApertureShape::Polygon {
                 diameter,
                 vertices,
@@ -408,7 +409,7 @@ impl Aperture {
                 width,
                 height,
                 radius,
-            } => shapes::rounded_rect(*width, *height, *radius, shapes::ALL_CORNERS, true),
+            } => shapes::rounded_rect(*width, *height, *radius, shapes::ALL_CORNERS),
             ApertureShape::RoundedHex {
                 radius,
                 corner_radius,
@@ -486,22 +487,22 @@ pub fn normalize_bounds<LayerMeta, ObjectMeta>(doc: &mut Document<LayerMeta, Obj
 }
 
 /// Rewrite flashes and strokes into filled region objects.
-pub fn expand_native_geometry_to_regions<LayerMeta, ObjectMeta>(
+///
+/// Flashes and instances are exact; stroke outlines are the one
+/// approximation, prepared within `accuracy`.
+pub fn expand_native_geometry_to_regions<LayerMeta: Clone, ObjectMeta: Clone>(
     doc: Document<LayerMeta, ObjectMeta>,
-) -> Document<LayerMeta, ObjectMeta>
-where
-    LayerMeta: Clone,
-    ObjectMeta: Clone,
-{
+    accuracy: GeometryAccuracy,
+) -> Result<Document<LayerMeta, ObjectMeta>, AccuracyError> {
     let mut doc = if doc.blocks.is_empty() {
         doc
     } else {
         expand_instances(&doc)
     };
-    expand_strokes_to_regions(&mut doc);
+    expand_strokes_to_regions(&mut doc, accuracy)?;
     expand_flashes_to_regions(&mut doc);
     normalize_bounds(&mut doc);
-    doc
+    Ok(doc)
 }
 
 /// Compose ordered dark/clear objects into final positive per-layer images.
@@ -542,8 +543,8 @@ pub fn paint_ordered<ObjectMeta>(objects: &[Object<ObjectMeta>]) -> Vec<&Object<
 /// always exactly `image`.
 #[derive(Debug)]
 pub struct AttributedImage<Owner> {
-    pub image: Vec<Ring>,
-    pub owners: Vec<(Owner, Vec<Ring>)>,
+    pub image: region::ContourSet,
+    pub owners: Vec<(Owner, region::ContourSet)>,
 }
 
 /// Ordered artwork composition with caller-defined ownership.
@@ -555,8 +556,9 @@ pub struct AttributedImage<Owner> {
 pub fn compose_attributed<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone + Eq + Hash>(
     doc: &Document<LayerMeta, ObjectMeta>,
     owner: impl Fn(&ObjectMeta) -> Owner,
-) -> (Vec<AttributedImage<Owner>>, Vec<Diagnostic>) {
-    compose_selected_attributed(doc, |meta| Some(owner(meta)))
+    resolution: Resolution,
+) -> Result<(Vec<AttributedImage<Owner>>, Vec<Diagnostic>), AccuracyError> {
+    compose_selected_attributed(doc, |meta| Some(owner(meta)), resolution)
 }
 
 /// Ordered artwork composition for only the owners selected by the caller,
@@ -572,35 +574,40 @@ pub(crate) fn compose_selected_attributed<
 >(
     doc: &Document<LayerMeta, ObjectMeta>,
     owner: impl Fn(&ObjectMeta) -> Option<Owner>,
-) -> (Vec<AttributedImage<Owner>>, Vec<Diagnostic>) {
-    let (layers, diagnostics) = compose_selected_owners(doc, owner);
+    resolution: Resolution,
+) -> Result<(Vec<AttributedImage<Owner>>, Vec<Diagnostic>), AccuracyError> {
+    let resolution = resolution.strict();
+    let (layers, diagnostics) = compose_owner_regions(doc, owner, resolution)?;
     let layers = layers
         .into_iter()
-        .map(|owners| AttributedImage {
-            image: region::union_rings(
-                owners
-                    .iter()
-                    .flat_map(|(_, image)| image.iter().cloned())
-                    .collect(),
-                FillRule::NonZero,
-            ),
-            owners,
+        .map(|owners| {
+            let image = region::ContourSet::union_all(
+                resolution,
+                owners.iter().map(|(_, image)| image.clone()),
+            );
+            resolution.accuracy.check(image.uncertainty_mm)?;
+            Ok(AttributedImage { image, owners })
         })
-        .collect();
-    (layers, diagnostics)
+        .collect::<Result<_, AccuracyError>>()?;
+    Ok((layers, diagnostics))
 }
 
 /// One layer's owner images in first-paint order; every image is a
 /// regularized ring set.
-pub type OwnerImages<Owner> = Vec<(Owner, Vec<Ring>)>;
+pub type OwnerImages<Owner> = Vec<(Owner, region::ContourSet)>;
 
-/// Each layer's owner images from the ordered paint fold, for only the
-/// owners selected by the caller.
-pub fn compose_selected_owners<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone + Eq + Hash>(
+pub type OwnerRegionLayers<Owner> = Vec<Vec<(Owner, region::ContourSet)>>;
+
+/// Compose owner regions from retained source curves at one resolution.
+/// This is where artwork is prepared: the returned regions carry the cost
+/// of strokes, flattening and paint folds, and every region derived from
+/// them inherits the budget.
+pub fn compose_owner_regions<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone + Eq + Hash>(
     doc: &Document<LayerMeta, ObjectMeta>,
     owner: impl Fn(&ObjectMeta) -> Option<Owner>,
-) -> (Vec<OwnerImages<Owner>>, Vec<Diagnostic>) {
-    let doc = expand_native_geometry_to_regions(doc.clone());
+    resolution: Resolution,
+) -> Result<(OwnerRegionLayers<Owner>, Vec<Diagnostic>), AccuracyError> {
+    let doc = expand_native_geometry_to_regions(doc.clone(), resolution.accuracy)?;
     struct OwnerState {
         composer: region::PaintComposer,
         bbox: BBox,
@@ -633,7 +640,7 @@ pub fn compose_selected_owners<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone
                 }
                 Polarity::Clear => None,
             };
-            let image = object_image_rings(&doc, object);
+            let image = object_image_region(&doc, object, resolution.strict())?;
             if image.is_empty() {
                 continue;
             }
@@ -648,7 +655,7 @@ pub fn compose_selected_owners<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone
                             states.push((
                                 owner,
                                 OwnerState {
-                                    composer: region::PaintComposer::default(),
+                                    composer: region::PaintComposer::new(resolution),
                                     bbox: BBox::empty(),
                                 },
                             ));
@@ -671,23 +678,24 @@ pub fn compose_selected_owners<LayerMeta: Clone, ObjectMeta: Clone, Owner: Clone
             }
         }
 
-        layers.push(
-            states
-                .into_iter()
-                .filter_map(|(owner, state)| {
-                    let image = state.composer.finish();
-                    (!image.is_empty()).then_some((owner, image))
-                })
-                .collect::<Vec<_>>(),
-        );
+        let mut images = Vec::with_capacity(states.len());
+        for (owner, state) in states {
+            let image = state.composer.finish();
+            resolution.accuracy.check(image.uncertainty_mm)?;
+            if !image.is_empty() {
+                images.push((owner, image));
+            }
+        }
+        layers.push(images);
     }
-    (layers, doc.diagnostics)
+    Ok((layers, doc.diagnostics))
 }
 
 pub fn compose_to_mask<LayerMeta: Clone, ObjectMeta: Clone>(
     doc: &Document<LayerMeta, ObjectMeta>,
-) -> mask::Document<LayerMeta> {
-    let (images, diagnostics) = compose_attributed(doc, |_| ());
+    resolution: Resolution,
+) -> Result<mask::Document<LayerMeta>, AccuracyError> {
+    let (images, diagnostics) = compose_attributed(doc, |_| (), resolution)?;
     let mut mask = mask::Document::new();
 
     for layer in &doc.layers {
@@ -702,17 +710,20 @@ pub fn compose_to_mask<LayerMeta: Clone, ObjectMeta: Clone>(
     }
 
     for (layer_index, image) in images.into_iter().enumerate() {
-        let contours = region::rings_to_contours(image.image);
+        let contours = image.image.to_contours();
         if !contours.is_empty() {
             mask.push_shape(layer_index as u32, FillRule::NonZero, contours);
         }
     }
 
     mask.diagnostics.extend(diagnostics);
-    mask
+    Ok(mask)
 }
 
-fn expand_strokes_to_regions<LayerMeta, ObjectMeta>(doc: &mut Document<LayerMeta, ObjectMeta>) {
+fn expand_strokes_to_regions<LayerMeta, ObjectMeta>(
+    doc: &mut Document<LayerMeta, ObjectMeta>,
+    accuracy: GeometryAccuracy,
+) -> Result<(), AccuracyError> {
     for object_index in 0..doc.objects.len() {
         let Geometry::Stroke { path: path_index } = doc.objects[object_index].geometry else {
             continue;
@@ -725,9 +736,9 @@ fn expand_strokes_to_regions<LayerMeta, ObjectMeta>(doc: &mut Document<LayerMeta
             doc.warn("Skipping artwork stroke with fill paint");
             continue;
         };
-        let Some(contours) =
-            crate::geom::path::stroke_to_fill(&doc.arena.path_contours(&path), stroke.into())
-        else {
+        let source = doc.arena.path_contours(&path);
+        let contours = crate::geom::path::stroke_to_fill(&source, stroke.into(), accuracy)?;
+        let Some(contours) = contours else {
             continue;
         };
         let path_id = doc.push_path(
@@ -739,6 +750,7 @@ fn expand_strokes_to_regions<LayerMeta, ObjectMeta>(doc: &mut Document<LayerMeta
         doc.objects[object_index].geometry = Geometry::Region { path: path_id };
         doc.objects[object_index].bbox = doc.path_bbox(path_id);
     }
+    Ok(())
 }
 
 fn expand_flashes_to_regions<LayerMeta, ObjectMeta>(doc: &mut Document<LayerMeta, ObjectMeta>) {
@@ -757,7 +769,7 @@ fn expand_flashes_to_regions<LayerMeta, ObjectMeta>(doc: &mut Document<LayerMeta
         let contours = aperture
             .contours()
             .into_iter()
-            .map(|contour| crate::geom::path::transform_cmds(contour.cmds, transform))
+            .map(|contour| contour.transformed(transform))
             .collect::<Vec<_>>();
         let path_id = doc.push_path(
             Paint::Fill {
@@ -770,27 +782,20 @@ fn expand_flashes_to_regions<LayerMeta, ObjectMeta>(doc: &mut Document<LayerMeta
     }
 }
 
-fn object_image_rings<LayerMeta, ObjectMeta>(
+fn object_image_region<LayerMeta, ObjectMeta>(
     doc: &Document<LayerMeta, ObjectMeta>,
     object: &Object<ObjectMeta>,
-) -> Vec<Ring> {
-    match object.geometry {
-        Geometry::Region { path } => doc
-            .arena
-            .paths
-            .get(path as usize)
-            .map(|path| {
-                region::simplify_rings(
-                    region::rings_from_contours(&doc.arena.path_contours(path)),
-                    path.fill_rule().unwrap_or(FillRule::NonZero),
-                )
-            })
-            .unwrap_or_default(),
-        Geometry::Flash { .. }
-        | Geometry::Stroke { .. }
-        | Geometry::Instance { .. }
-        | Geometry::GridInstance { .. } => Vec::new(),
-    }
+    resolution: Resolution,
+) -> Result<region::ContourSet, AccuracyError> {
+    let Geometry::Region { path } = object.geometry else {
+        return Ok(region::ContourSet::empty(resolution));
+    };
+    let Some(path) = doc.arena.paths.get(path as usize) else {
+        return Ok(region::ContourSet::empty(resolution));
+    };
+    let contours = doc.arena.path_contours(path);
+    let rule = path.fill_rule().unwrap_or(FillRule::NonZero);
+    region::ContourSet::from_contours(&contours, rule, resolution)
 }
 
 fn geometry_bbox<LayerMeta, ObjectMeta>(
@@ -814,8 +819,8 @@ fn geometry_bbox<LayerMeta, ObjectMeta>(
                 aperture
                     .contours()
                     .into_iter()
-                    .map(|contour| crate::geom::path::transform_cmds(contour.cmds, transform))
-                    .fold(BBox::empty(), |bbox, contour| bbox.union(contour.bbox))
+                    .map(|contour| contour.bbox.transformed(transform))
+                    .fold(BBox::empty(), |bbox, bound| bbox.union(bound))
             })
             .unwrap_or_else(BBox::empty),
         Geometry::Instance { block, transform } => doc
@@ -1300,7 +1305,7 @@ mod tests {
             Object::new(Polarity::Dark, Geometry::Stroke { path }),
         );
 
-        let mask = compose_to_mask(&doc);
+        let mask = compose_to_mask(&doc, Resolution::default()).unwrap();
 
         assert_eq!(mask.layers.len(), 1);
         assert_eq!(mask.layers[0].shapes.len(), 1);
@@ -1354,13 +1359,14 @@ mod tests {
             stage_object(Polarity::Dark, cutout, PaintStage::FinalCutout),
         );
 
-        let mask = compose_to_mask(&doc);
+        let mask = compose_to_mask(&doc, Resolution::default()).unwrap();
         let shape = mask.layers[0].shapes.slice(&mask.arena.paths)[0];
         let image = region::ContourSet::from_contours(
             &mask.arena.path_contours(&shape),
             FillRule::NonZero,
-            crate::geom::tol::REGION_MM,
-        );
+            Resolution::default(),
+        )
+        .unwrap();
 
         // The overlay trace follows the clear in paint order and survives.
         assert!(image.contains_point(Point::new(5.0, 5.0)));
@@ -1414,14 +1420,11 @@ mod tests {
             object(Polarity::Dark, overlap, PaintStage::Overlay, "C"),
         );
 
-        let (mut layers, diagnostics) = compose_attributed(&doc, |meta| *meta);
+        let (mut layers, diagnostics) =
+            compose_attributed(&doc, |meta| *meta, Resolution::default()).unwrap();
         assert!(diagnostics.is_empty());
         let composed = layers.remove(0);
-        let physical = region::ContourSet::new(
-            composed.image,
-            FillRule::NonZero,
-            crate::geom::tol::REGION_MM,
-        );
+        let physical = composed.image;
         assert_eq!(
             composed
                 .owners
@@ -1430,16 +1433,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["A", "B", "C"]
         );
-        let owners = composed
-            .owners
-            .into_iter()
-            .map(|(owner, rings)| {
-                (
-                    owner,
-                    region::ContourSet::new(rings, FillRule::NonZero, crate::geom::tol::REGION_MM),
-                )
-            })
-            .collect::<HashMap<_, _>>();
+        let owners = composed.owners.into_iter().collect::<HashMap<_, _>>();
 
         assert!(owners["A"].contains_point(Point::new(2.0, 2.0)));
         assert!(!owners["A"].contains_point(Point::new(5.0, 5.0)));
@@ -1449,8 +1443,12 @@ mod tests {
         assert!(physical.contains_point(Point::new(5.0, 5.0)));
         assert!(physical.contains_point(Point::new(8.5, 8.5)));
 
-        let (mut selected, diagnostics) =
-            compose_selected_attributed(&doc, |meta| (*meta != "C").then_some(*meta));
+        let (mut selected, diagnostics) = compose_selected_attributed(
+            &doc,
+            |meta| (*meta != "C").then_some(*meta),
+            Resolution::default(),
+        )
+        .unwrap();
         assert!(diagnostics.is_empty());
         let selected = selected.remove(0);
         assert_eq!(
@@ -1461,16 +1459,7 @@ mod tests {
                 .collect::<Vec<_>>(),
             ["A", "B"]
         );
-        let selected = selected
-            .owners
-            .into_iter()
-            .map(|(owner, rings)| {
-                (
-                    owner,
-                    region::ContourSet::new(rings, FillRule::NonZero, crate::geom::tol::REGION_MM),
-                )
-            })
-            .collect::<HashMap<_, _>>();
+        let selected = selected.owners.into_iter().collect::<HashMap<_, _>>();
         assert!(!selected["A"].contains_point(Point::new(5.0, 5.0)));
         assert!(selected["B"].contains_point(Point::new(5.0, 5.0)));
     }
@@ -1494,14 +1483,15 @@ mod tests {
             ),
         );
 
-        let mask = compose_to_mask(&doc);
+        let mask = compose_to_mask(&doc, Resolution::default()).unwrap();
         let expected = std::f64::consts::PI * (1.0 - 0.25);
         let shape = mask.layers[0].shapes.slice(&mask.arena.paths)[0];
         let area = region::ContourSet::from_contours(
             &mask.arena.path_contours(&shape),
             FillRule::NonZero,
-            crate::geom::tol::REGION_MM,
+            Resolution::default(),
         )
+        .unwrap()
         .area();
 
         assert!(

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -233,18 +233,17 @@ pub struct BoardArraySupportLayerGeometry<Symbol> {
     /// Canonical physical geometry, partitioned by copper reach. Each included
     /// support path contributes to exactly one bucket.
     pub obstacles: Vec<BoardArrayScopedObstacle<Symbol>>,
+    /// The resolution every bucket was prepared at, kept for layers whose
+    /// buckets are all empty.
+    pub resolution: Resolution,
 }
 
 impl<Symbol: Copy + PartialEq> BoardArraySupportLayerGeometry<Symbol> {
     /// Derive this source layer's physical obstacle region for one copper
     /// layer. The scoped buckets remain the sole stored geometry.
     pub fn region_for_layer(&self, layer: Symbol) -> Result<ContourSet, AccuracyError> {
-        let resolution = self
-            .obstacles
-            .first()
-            .map_or_else(Resolution::default, |obstacle| obstacle.region.resolution);
         ContourSet::union_all(
-            resolution,
+            self.resolution,
             self.obstacles
                 .iter()
                 .filter(|obstacle| obstacle.reach.includes(&layer))
@@ -390,14 +389,16 @@ pub fn board_array_balancing_region(
         .board_footprints
         .union(&input.material_removal)?
         .union(&input.support_features)?;
-    // Construction reserves the budget the inputs were prepared at: the two
-    // offsets that build the region each spend at most a quarter of it, so
-    // every checked quantity stays strictly separated from a constructed one.
+    // Construction reserves half the budget the inputs were prepared at: the
+    // two offsets that build the region each spend at most a quarter of it,
+    // so every checked quantity stays strictly separated from a constructed
+    // one.
     let numerical_guard_mm = input
         .panel_outer
         .budget()
         .min(raw_obstacles.budget())
-        .max_error_mm();
+        .max_error_mm()
+        / 2.0;
     let construction_clearance_mm = options.clearance_mm + numerical_guard_mm;
     let panel_keep_in = input.panel_outer.disk_erode(construction_clearance_mm)?;
     let obstacle_keep_out = raw_obstacles.disk_dilate(construction_clearance_mm)?;
@@ -659,6 +660,7 @@ fn collect_support_layer_geometry<Symbol: Copy + PartialEq, LayerFunction>(
         excluded_documentation_path_count: source_path_count.saturating_sub(paths.len()),
         unpainted_path_count,
         obstacles,
+        resolution,
     })
 }
 
@@ -886,7 +888,7 @@ mod tests {
         components.sort_by(|left, right| left.bbox.min.x.total_cmp(&right.bbox.min.x));
         assert_eq!(components.len(), 2);
         let gap = components[1].bbox.min.x - components[0].bbox.max.x;
-        let guard = GeometryAccuracy::default().max_error_mm();
+        let guard = GeometryAccuracy::default().max_error_mm() / 2.0;
         let expected = 0.1 + 2.0 * (0.5 + guard);
         assert!(
             (gap - expected).abs() <= 0.01,

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -388,8 +388,8 @@ pub fn board_array_balancing_region(
 
     let raw_obstacles = input
         .board_footprints
-        .union(&input.material_removal)
-        .union(&input.support_features);
+        .union(&input.material_removal)?
+        .union(&input.support_features)?;
     // Construction reserves the budget the inputs were prepared at: the two
     // offsets that build the region each spend at most a quarter of it, so
     // every checked quantity stays strictly separated from a constructed one.
@@ -401,9 +401,9 @@ pub fn board_array_balancing_region(
     let construction_clearance_mm = options.clearance_mm + numerical_guard_mm;
     let panel_keep_in = input.panel_outer.disk_erode(construction_clearance_mm)?;
     let obstacle_keep_out = raw_obstacles.disk_dilate(construction_clearance_mm)?;
-    let clearance_safe_region = panel_keep_in.difference(&obstacle_keep_out);
+    let clearance_safe_region = panel_keep_in.difference(&obstacle_keep_out)?;
     let opened_candidates = clearance_safe_region.disk_open(options.regularization_radius_mm)?;
-    let removed_by_opening = clearance_safe_region.difference(&opened_candidates);
+    let removed_by_opening = clearance_safe_region.difference(&opened_candidates)?;
     let gap_regularization = opened_candidates
         .disk_regularize_gaps(
             options.gap_radius_mm,
@@ -418,15 +418,15 @@ pub fn board_array_balancing_region(
     // construction guard used above.
     let swept_safe_region = safe_region.disk_dilate(options.clearance_mm)?;
     let regularization_violations = safe_region
-        .difference(&safe_region.disk_open(options.regularization_radius_mm)?)
+        .difference(&safe_region.disk_open(options.regularization_radius_mm)?)?
         .disk_open(numerical_guard_mm)?;
     let gap_violations = safe_region.disk_gap_violations(options.gap_radius_mm)?;
     let certificate = ClearanceCertificate {
-        safe_outside_clearance_region: safe_region.difference(&clearance_safe_region),
+        safe_outside_clearance_region: safe_region.difference(&clearance_safe_region)?,
         regularization_violations,
         gap_violations,
-        outside_panel: swept_safe_region.difference(&input.panel_outer),
-        obstacle_overlap: swept_safe_region.intersection(&raw_obstacles),
+        outside_panel: swept_safe_region.difference(&input.panel_outer)?,
+        obstacle_overlap: swept_safe_region.intersection(&raw_obstacles)?,
         swept_safe_region,
     };
 
@@ -748,6 +748,7 @@ mod tests {
             result
                 .safe_region
                 .difference(&result.intermediates.clearance_safe_region)
+                .unwrap()
                 .area()
                 <= result.safe_region.tolerance().powi(2)
         );
@@ -756,6 +757,7 @@ mod tests {
                 .intermediates
                 .clearance_safe_region
                 .difference(&result.safe_region)
+                .unwrap()
                 .area()
                 > 0.0
         );
@@ -763,6 +765,7 @@ mod tests {
             result
                 .safe_region
                 .difference(&result.intermediates.panel_keep_in)
+                .unwrap()
                 .area()
                 <= result.safe_region.tolerance().powi(2)
         );
@@ -770,6 +773,7 @@ mod tests {
             result
                 .safe_region
                 .intersection(&result.intermediates.obstacle_keep_out)
+                .unwrap()
                 .area()
                 <= result.safe_region.tolerance().powi(2)
         );
@@ -800,7 +804,8 @@ mod tests {
         let larger_outside_smaller = larger
             .intermediates
             .clearance_safe_region
-            .difference(&smaller.intermediates.clearance_safe_region);
+            .difference(&smaller.intermediates.clearance_safe_region)
+            .unwrap();
         assert!(
             larger_outside_smaller.area() <= larger_outside_smaller.tolerance().powi(2),
             "larger clearance added {:.9} mm² to the maximal region",
@@ -837,7 +842,8 @@ mod tests {
         let larger_outside_smaller = larger
             .intermediates
             .opened_candidates
-            .difference(&smaller.intermediates.opened_candidates);
+            .difference(&smaller.intermediates.opened_candidates)
+            .unwrap();
         assert!(
             larger_outside_smaller.area() <= larger_outside_smaller.tolerance().powi(2),
             "larger feature disk added {:.9} mm² to the opened region",
@@ -911,6 +917,7 @@ mod tests {
                 .intermediates
                 .clearance_safe_region
                 .difference(&baseline.intermediates.clearance_safe_region)
+                .unwrap()
                 .is_empty()
         );
         assert!(
@@ -1179,6 +1186,7 @@ mod tests {
                 bbox(7.0, 1.0, 8.0, 2.0),
                 Resolution::default()
             ))
+            .unwrap()
             .is_empty()
         );
         assert!(
@@ -1187,10 +1195,11 @@ mod tests {
                     bbox(1.0, 1.0, 2.0, 2.0),
                     Resolution::default()
                 ))
+                .unwrap()
                 .is_empty()
         );
         assert!(
-            (top.intersection(&bottom).area() - 1.0).abs() <= 1e-6,
+            (top.intersection(&bottom).unwrap().area() - 1.0).abs() <= 1e-6,
             "only through-stack geometry should be shared"
         );
     }
@@ -1292,9 +1301,16 @@ mod tests {
             result
                 .safe_region
                 .intersection(&input.board_footprints)
+                .unwrap()
                 .is_empty()
         );
-        assert!(result.safe_region.difference(&usable_region).is_empty());
+        assert!(
+            result
+                .safe_region
+                .difference(&usable_region)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -390,14 +390,14 @@ pub fn board_array_balancing_region(
         .board_footprints
         .union(&input.material_removal)
         .union(&input.support_features);
-    // Construction reserves twice the budget the inputs were prepared at, so
+    // Construction reserves the budget the inputs were prepared at: the two
+    // offsets that build the region each spend at most a quarter of it, so
     // every checked quantity stays strictly separated from a constructed one.
-    let numerical_guard_mm = 2.0
-        * input
-            .panel_outer
-            .budget()
-            .min(raw_obstacles.budget())
-            .max_error_mm();
+    let numerical_guard_mm = input
+        .panel_outer
+        .budget()
+        .min(raw_obstacles.budget())
+        .max_error_mm();
     let construction_clearance_mm = options.clearance_mm + numerical_guard_mm;
     let panel_keep_in = input.panel_outer.disk_erode(construction_clearance_mm)?;
     let obstacle_keep_out = raw_obstacles.disk_dilate(construction_clearance_mm)?;
@@ -721,7 +721,8 @@ mod tests {
         SpecRef, StepProfile,
     };
     use crate::geom::{
-        Affine2, BBox, ContourBuf, LineCap, Paint, PathCmd, Point, Polarity, Span, StrokeStyle,
+        Affine2, BBox, ContourBuf, GeometryAccuracy, LineCap, Paint, PathCmd, Point, Polarity,
+        Span, StrokeStyle,
     };
 
     type TestDocument = Document<u32, ()>;
@@ -879,9 +880,11 @@ mod tests {
         components.sort_by(|left, right| left.bbox.min.x.total_cmp(&right.bbox.min.x));
         assert_eq!(components.len(), 2);
         let gap = components[1].bbox.min.x - components[0].bbox.max.x;
+        let guard = GeometryAccuracy::default().max_error_mm();
+        let expected = 0.1 + 2.0 * (0.5 + guard);
         assert!(
-            (gap - 1.15).abs() <= 0.01,
-            "expected physical stroke plus two 0.525 mm clearances, got {gap:.9} mm"
+            (gap - expected).abs() <= 0.01,
+            "expected physical stroke plus two guarded clearances ({expected} mm), got {gap:.9} mm"
         );
         assert_eq!(result.safe_region.connected_components().len(), 2);
         assert!(

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -238,7 +238,7 @@ pub struct BoardArraySupportLayerGeometry<Symbol> {
 impl<Symbol: Copy + PartialEq> BoardArraySupportLayerGeometry<Symbol> {
     /// Derive this source layer's physical obstacle region for one copper
     /// layer. The scoped buckets remain the sole stored geometry.
-    pub fn region_for_layer(&self, layer: Symbol) -> ContourSet {
+    pub fn region_for_layer(&self, layer: Symbol) -> Result<ContourSet, AccuracyError> {
         let resolution = self
             .obstacles
             .first()
@@ -266,23 +266,27 @@ pub struct BoardArrayBalancingCollection<Symbol> {
 impl<Symbol: Copy + PartialEq> BoardArrayBalancingCollection<Symbol> {
     /// Derive the geometry-only input for one copper layer from the canonical
     /// scoped support geometry.
-    pub fn input_for_layer(&self, layer: Symbol) -> BoardArrayBalancingInput {
-        let support_features = self.support_features_for_layer(layer);
-        BoardArrayBalancingInput {
+    pub fn input_for_layer(
+        &self,
+        layer: Symbol,
+    ) -> Result<BoardArrayBalancingInput, AccuracyError> {
+        let support_features = self.support_features_for_layer(layer)?;
+        Ok(BoardArrayBalancingInput {
             panel_outer: self.panel_outer.clone(),
             board_footprints: self.board_footprints.clone(),
             material_removal: self.material_removal.clone(),
             support_features,
-        }
+        })
     }
 
     /// Union support geometry whose physical reach includes `layer`.
-    pub fn support_features_for_layer(&self, layer: Symbol) -> ContourSet {
+    pub fn support_features_for_layer(&self, layer: Symbol) -> Result<ContourSet, AccuracyError> {
         ContourSet::union_all(
             self.panel_outer.resolution,
             self.support_layers
                 .iter()
-                .map(|source| source.region_for_layer(layer)),
+                .map(|source| source.region_for_layer(layer))
+                .collect::<Result<Vec<_>, _>>()?,
         )
     }
 
@@ -1055,8 +1059,13 @@ mod tests {
         assert!((collection.panel_outer.area() - 200.0).abs() <= 1e-6);
         assert!((collection.board_footprints.area() - 12.0).abs() <= 1e-6);
         assert!((collection.material_removal.area() - 1.0).abs() <= 1e-6);
-        assert!((collection.support_features_for_layer(100).area() - 1.0).abs() <= 1e-6);
-        assert!(collection.support_features_for_layer(200).is_empty());
+        assert!((collection.support_features_for_layer(100).unwrap().area() - 1.0).abs() <= 1e-6);
+        assert!(
+            collection
+                .support_features_for_layer(200)
+                .unwrap()
+                .is_empty()
+        );
         assert!(!collection.has_same_support_scope(100, 200));
         assert!(collection.has_same_support_scope(200, 300));
     }
@@ -1095,7 +1104,7 @@ mod tests {
             Resolution::default(),
         )
         .unwrap();
-        let region = geometry.region_for_layer(100);
+        let region = geometry.region_for_layer(100).unwrap();
 
         assert_eq!(geometry.feature_count, 1);
         assert_eq!(geometry.path_count, 1);
@@ -1157,8 +1166,8 @@ mod tests {
             Resolution::default(),
         )
         .unwrap();
-        let top = geometry.region_for_layer(100);
-        let bottom = geometry.region_for_layer(200);
+        let top = geometry.region_for_layer(100).unwrap();
+        let bottom = geometry.region_for_layer(200).unwrap();
 
         assert!((top.area() - 2.0).abs() <= 1e-6);
         assert!((bottom.area() - 2.0).abs() <= 1e-6);
@@ -1248,7 +1257,7 @@ mod tests {
         assert_eq!(geometry.source_path_count, 2);
         assert_eq!(geometry.path_count, 1);
         assert_eq!(geometry.excluded_documentation_path_count, 1);
-        assert!(geometry.region_for_layer(100).bbox.max.y < 1.0);
+        assert!(geometry.region_for_layer(100).unwrap().bbox.max.y < 1.0);
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -30,6 +30,7 @@
 //! gaps admit a disk of radius `v`, without component ranking or
 //! feature-specific rules.
 
+use crate::geom::{AccuracyError, Resolution};
 use std::fmt;
 
 use crate::dialects::Side;
@@ -37,7 +38,7 @@ use crate::dialects::ipc::{
     BoardArrayFabricationProfile, Document, Feature, FeatureSpan, LayoutPurpose,
     ProfileOccurrenceRole, ProfileSet, profile_occurrences_for, relief::is_vcut_operation_feature,
 };
-use crate::geom::{ContourSet, FillRule, Paint, tol};
+use crate::geom::{ContourSet, FillRule, Paint};
 
 /// Default Euclidean clearance from every protected feature.
 pub const DEFAULT_BALANCING_CLEARANCE_MM: f64 = 0.5;
@@ -47,10 +48,6 @@ pub const DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM: f64 = 0.5;
 
 /// Half the default minimum width of a two-sided void gap.
 pub const DEFAULT_BALANCING_GAP_RADIUS_MM: f64 = 0.5;
-
-/// Conservative allowance for curve flattening and round-offset construction.
-pub const DEFAULT_BALANCING_NUMERICAL_GUARD_MM: f64 =
-    2.0 * tol::STROKE_OUTLINE_MM + tol::FLATTEN_MM;
 
 /// Inputs to the geometry-only safe-region computation.
 #[derive(Debug, Clone)]
@@ -117,8 +114,6 @@ pub struct BalancingRegionOptions {
     /// Radius of the rolling-disk test for two-sided void gaps. The minimum
     /// nominal gap width is twice this radius.
     pub gap_radius_mm: f64,
-    /// Additional conservative allowance for numerical approximation.
-    pub numerical_guard_mm: f64,
 }
 
 impl Default for BalancingRegionOptions {
@@ -127,15 +122,7 @@ impl Default for BalancingRegionOptions {
             clearance_mm: DEFAULT_BALANCING_CLEARANCE_MM,
             regularization_radius_mm: DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM,
             gap_radius_mm: DEFAULT_BALANCING_GAP_RADIUS_MM,
-            numerical_guard_mm: DEFAULT_BALANCING_NUMERICAL_GUARD_MM,
         }
-    }
-}
-
-impl BalancingRegionOptions {
-    /// `clearance_mm + numerical_guard_mm`.
-    pub fn construction_clearance_mm(self) -> f64 {
-        self.clearance_mm + self.numerical_guard_mm
     }
 }
 
@@ -252,12 +239,17 @@ impl<Symbol: Copy + PartialEq> BoardArraySupportLayerGeometry<Symbol> {
     /// Derive this source layer's physical obstacle region for one copper
     /// layer. The scoped buckets remain the sole stored geometry.
     pub fn region_for_layer(&self, layer: Symbol) -> ContourSet {
-        self.obstacles
-            .iter()
-            .filter(|obstacle| obstacle.reach.includes(&layer))
-            .fold(ContourSet::empty(tol::REGION_MM), |region, obstacle| {
-                region.union(&obstacle.region)
-            })
+        let resolution = self
+            .obstacles
+            .first()
+            .map_or_else(Resolution::default, |obstacle| obstacle.region.resolution);
+        ContourSet::union_all(
+            resolution,
+            self.obstacles
+                .iter()
+                .filter(|obstacle| obstacle.reach.includes(&layer))
+                .map(|obstacle| obstacle.region.clone()),
+        )
     }
 }
 
@@ -286,11 +278,12 @@ impl<Symbol: Copy + PartialEq> BoardArrayBalancingCollection<Symbol> {
 
     /// Union support geometry whose physical reach includes `layer`.
     pub fn support_features_for_layer(&self, layer: Symbol) -> ContourSet {
-        self.support_layers
-            .iter()
-            .fold(ContourSet::empty(tol::REGION_MM), |region, source| {
-                region.union(&source.region_for_layer(layer))
-            })
+        ContourSet::union_all(
+            self.panel_outer.resolution,
+            self.support_layers
+                .iter()
+                .map(|source| source.region_for_layer(layer)),
+        )
     }
 
     /// Whether two copper layers select the same canonical support-obstacle
@@ -306,10 +299,10 @@ impl<Symbol: Copy + PartialEq> BoardArrayBalancingCollection<Symbol> {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum BalancingRegionError {
+    Accuracy(AccuracyError),
     InvalidClearance(f64),
     InvalidRegularizationRadius(f64),
     InvalidGapRadius(f64),
-    InvalidNumericalGuard(f64),
     EmptyPanelOutline,
     EmptyBoardFootprints,
     EmptyAssemblyPanels,
@@ -321,6 +314,7 @@ pub enum BalancingRegionError {
 impl fmt::Display for BalancingRegionError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Accuracy(error) => error.fmt(f),
             Self::InvalidClearance(value) => write!(
                 f,
                 "balancing-region clearance must be finite and positive; got {value}"
@@ -332,10 +326,6 @@ impl fmt::Display for BalancingRegionError {
             Self::InvalidGapRadius(value) => write!(
                 f,
                 "balancing-region gap radius must be finite and positive; got {value}"
-            ),
-            Self::InvalidNumericalGuard(value) => write!(
-                f,
-                "balancing-region numerical guard must be finite and non-negative; got {value}"
             ),
             Self::EmptyPanelOutline => {
                 write!(f, "board array has no usable root panel outline")
@@ -396,17 +386,25 @@ pub fn board_array_balancing_region(
         .board_footprints
         .union(&input.material_removal)
         .union(&input.support_features);
-    let construction_clearance_mm = options.construction_clearance_mm();
-    let panel_keep_in = input.panel_outer.disk_erode(construction_clearance_mm);
-    let obstacle_keep_out = raw_obstacles.disk_dilate(construction_clearance_mm);
+    // Construction reserves twice the budget the inputs were prepared at, so
+    // every checked quantity stays strictly separated from a constructed one.
+    let numerical_guard_mm = 2.0
+        * input
+            .panel_outer
+            .budget()
+            .min(raw_obstacles.budget())
+            .max_error_mm();
+    let construction_clearance_mm = options.clearance_mm + numerical_guard_mm;
+    let panel_keep_in = input.panel_outer.disk_erode(construction_clearance_mm)?;
+    let obstacle_keep_out = raw_obstacles.disk_dilate(construction_clearance_mm)?;
     let clearance_safe_region = panel_keep_in.difference(&obstacle_keep_out);
-    let opened_candidates = clearance_safe_region.disk_open(options.regularization_radius_mm);
+    let opened_candidates = clearance_safe_region.disk_open(options.regularization_radius_mm)?;
     let removed_by_opening = clearance_safe_region.difference(&opened_candidates);
     let gap_regularization = opened_candidates
         .disk_regularize_gaps(
             options.gap_radius_mm,
             options.regularization_radius_mm,
-            options.numerical_guard_mm,
+            numerical_guard_mm,
         )
         .map_err(|error| BalancingRegionError::GapRegularization(error.to_string()))?;
     let safe_region = gap_regularization.kept;
@@ -414,11 +412,11 @@ pub fn board_array_balancing_region(
 
     // Certify against the nominal requirement, independently of the
     // construction guard used above.
-    let swept_safe_region = safe_region.disk_dilate(options.clearance_mm);
+    let swept_safe_region = safe_region.disk_dilate(options.clearance_mm)?;
     let regularization_violations = safe_region
-        .difference(&safe_region.disk_open(options.regularization_radius_mm))
-        .disk_open(options.numerical_guard_mm);
-    let gap_violations = safe_region.disk_gap_violations(options.gap_radius_mm);
+        .difference(&safe_region.disk_open(options.regularization_radius_mm)?)
+        .disk_open(numerical_guard_mm)?;
+    let gap_violations = safe_region.disk_gap_violations(options.gap_radius_mm)?;
     let certificate = ClearanceCertificate {
         safe_outside_clearance_region: safe_region.difference(&clearance_safe_region),
         regularization_violations,
@@ -453,6 +451,7 @@ pub fn collect_board_array_balancing_input<'a, Symbol, LayerFunction>(
     fabrication_profile: &BoardArrayFabricationProfile,
     copper_layers: &[BoardArrayCopperLayer<Symbol>],
     support_documents: impl IntoIterator<Item = BoardArraySupportDocument<'a, Symbol, LayerFunction>>,
+    resolution: Resolution,
 ) -> Result<BoardArrayBalancingCollection<Symbol>, BalancingRegionError>
 where
     Symbol: Copy + PartialEq + 'a,
@@ -463,6 +462,7 @@ where
         fabrication_profile,
         copper_layers,
         support_documents,
+        resolution,
     )?;
     let unpainted_path_count = collection
         .support_layers
@@ -490,6 +490,7 @@ pub fn collect_fab_panel_balancing_input(
     usable_region: ContourSet,
     fabrication_profile: &BoardArrayFabricationProfile,
 ) -> Result<BoardArrayBalancingInput, BalancingRegionError> {
+    let resolution = usable_region.resolution;
     if fabrication_profile.purpose != LayoutPurpose::FabricationPanel {
         return Err(BalancingRegionError::NotAFabricationPanel);
     }
@@ -499,7 +500,7 @@ pub fn collect_fab_panel_balancing_input(
         .flatten()
         .cloned()
         .collect::<Vec<_>>();
-    let board_footprints = ContourSet::from_filled_contours(&panel_contours, tol::REGION_MM);
+    let board_footprints = ContourSet::from_filled_contours(&panel_contours, resolution)?;
     if board_footprints.is_empty() {
         return Err(BalancingRegionError::EmptyAssemblyPanels);
     }
@@ -510,9 +511,9 @@ pub fn collect_fab_panel_balancing_input(
         material_removal: ContourSet::from_contours(
             &fabrication_profile.material_removal,
             FillRule::NonZero,
-            tol::REGION_MM,
-        ),
-        support_features: ContourSet::empty(tol::REGION_MM),
+            resolution,
+        )?,
+        support_features: ContourSet::empty(resolution),
     })
 }
 
@@ -528,6 +529,7 @@ pub fn inspect_board_array_balancing_input<'a, Symbol, LayerFunction>(
     fabrication_profile: &BoardArrayFabricationProfile,
     copper_layers: &[BoardArrayCopperLayer<Symbol>],
     support_documents: impl IntoIterator<Item = BoardArraySupportDocument<'a, Symbol, LayerFunction>>,
+    resolution: Resolution,
 ) -> Result<BoardArrayBalancingCollection<Symbol>, BalancingRegionError>
 where
     Symbol: Copy + PartialEq + 'a,
@@ -539,7 +541,7 @@ where
         .flatten()
         .cloned()
         .collect::<Vec<_>>();
-    let panel_outer = ContourSet::from_filled_contours(&panel_contours, tol::REGION_MM);
+    let panel_outer = ContourSet::from_filled_contours(&panel_contours, resolution)?;
     if panel_outer.is_empty() {
         return Err(BalancingRegionError::EmptyPanelOutline);
     }
@@ -555,7 +557,7 @@ where
             layout.transformed_path_contours(occurrence.profile.outer_path, occurrence.transform),
         );
     }
-    let board_footprints = ContourSet::from_filled_contours(&board_contours, tol::REGION_MM);
+    let board_footprints = ContourSet::from_filled_contours(&board_contours, resolution)?;
     if board_instance_count == 0 || board_footprints.is_empty() {
         return Err(BalancingRegionError::EmptyBoardFootprints);
     }
@@ -563,12 +565,12 @@ where
     let material_removal = ContourSet::from_contours(
         &fabrication_profile.material_removal,
         FillRule::NonZero,
-        tol::REGION_MM,
-    );
+        resolution,
+    )?;
     let support_layers = support_documents
         .into_iter()
-        .map(|source| collect_support_layer_geometry(source, copper_layers))
-        .collect::<Vec<_>>();
+        .map(|source| collect_support_layer_geometry(source, copper_layers, resolution))
+        .collect::<Result<Vec<_>, _>>()?;
 
     Ok(BoardArrayBalancingCollection {
         panel_outer,
@@ -582,7 +584,8 @@ where
 fn collect_support_layer_geometry<Symbol: Copy + PartialEq, LayerFunction>(
     source: BoardArraySupportDocument<'_, Symbol, LayerFunction>,
     copper_layers: &[BoardArrayCopperLayer<Symbol>],
-) -> BoardArraySupportLayerGeometry<Symbol> {
+    resolution: Resolution,
+) -> Result<BoardArraySupportLayerGeometry<Symbol>, AccuracyError> {
     let source_path_count = source
         .document
         .features
@@ -638,13 +641,13 @@ fn collect_support_layer_geometry<Symbol: Copy + PartialEq, LayerFunction>(
                                 .map(move |path| (path, placement))
                         })
                 }),
-                tol::REGION_MM,
-            );
-            BoardArrayScopedObstacle { reach, region }
+                resolution,
+            )?;
+            Ok::<_, AccuracyError>(BoardArrayScopedObstacle { reach, region })
         })
-        .collect();
+        .collect::<Result<Vec<_>, _>>()?;
 
-    BoardArraySupportLayerGeometry {
+    Ok(BoardArraySupportLayerGeometry {
         source_feature_count: source.document.features.len(),
         feature_count: features.len(),
         source_path_count,
@@ -652,7 +655,7 @@ fn collect_support_layer_geometry<Symbol: Copy + PartialEq, LayerFunction>(
         excluded_documentation_path_count: source_path_count.saturating_sub(paths.len()),
         unpainted_path_count,
         obstacles,
-    }
+    })
 }
 
 /// Resolve physical feature span to copper reach without recognizing feature
@@ -696,12 +699,13 @@ fn validate_options(options: BalancingRegionOptions) -> Result<(), BalancingRegi
             options.gap_radius_mm,
         ));
     }
-    if !options.numerical_guard_mm.is_finite() || options.numerical_guard_mm < 0.0 {
-        return Err(BalancingRegionError::InvalidNumericalGuard(
-            options.numerical_guard_mm,
-        ));
-    }
     Ok(())
+}
+
+impl From<AccuracyError> for BalancingRegionError {
+    fn from(error: AccuracyError) -> Self {
+        Self::Accuracy(error)
+    }
 }
 
 #[cfg(test)]
@@ -720,7 +724,7 @@ mod tests {
 
     #[test]
     fn computes_and_certifies_safe_region() {
-        let input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
+        let input = balancing_input(0.0, ContourSet::empty(Resolution::default()));
 
         let result =
             board_array_balancing_region(&input, BalancingRegionOptions::default()).unwrap();
@@ -739,7 +743,8 @@ mod tests {
             result
                 .safe_region
                 .difference(&result.intermediates.clearance_safe_region)
-                .is_empty()
+                .area()
+                <= result.safe_region.tolerance().powi(2)
         );
         assert!(
             result
@@ -753,26 +758,27 @@ mod tests {
             result
                 .safe_region
                 .difference(&result.intermediates.panel_keep_in)
-                .is_empty()
+                .area()
+                <= result.safe_region.tolerance().powi(2)
         );
         assert!(
             result
                 .safe_region
                 .intersection(&result.intermediates.obstacle_keep_out)
-                .is_empty()
+                .area()
+                <= result.safe_region.tolerance().powi(2)
         );
     }
 
     #[test]
     fn larger_clearance_shrinks_clearance_safe_region_for_simple_fixture() {
-        let input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
+        let input = balancing_input(0.0, ContourSet::empty(Resolution::default()));
         let smaller = board_array_balancing_region(
             &input,
             BalancingRegionOptions {
                 clearance_mm: 0.25,
                 regularization_radius_mm: 0.5,
                 gap_radius_mm: 0.5,
-                numerical_guard_mm: 0.0,
             },
         )
         .unwrap();
@@ -782,7 +788,6 @@ mod tests {
                 clearance_mm: 1.0,
                 regularization_radius_mm: 0.5,
                 gap_radius_mm: 0.5,
-                numerical_guard_mm: 0.0,
             },
         )
         .unwrap();
@@ -792,7 +797,7 @@ mod tests {
             .clearance_safe_region
             .difference(&smaller.intermediates.clearance_safe_region);
         assert!(
-            larger_outside_smaller.is_empty(),
+            larger_outside_smaller.area() <= larger_outside_smaller.tolerance().powi(2),
             "larger clearance added {:.9} mm² to the maximal region",
             larger_outside_smaller.area()
         );
@@ -804,14 +809,13 @@ mod tests {
 
     #[test]
     fn larger_regularization_disk_shrinks_opened_region_for_simple_fixture() {
-        let input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
+        let input = balancing_input(0.0, ContourSet::empty(Resolution::default()));
         let smaller = board_array_balancing_region(
             &input,
             BalancingRegionOptions {
                 clearance_mm: 0.5,
                 regularization_radius_mm: 0.25,
                 gap_radius_mm: 0.5,
-                numerical_guard_mm: 0.0,
             },
         )
         .unwrap();
@@ -821,7 +825,6 @@ mod tests {
                 clearance_mm: 0.5,
                 regularization_radius_mm: 1.0,
                 gap_radius_mm: 0.5,
-                numerical_guard_mm: 0.0,
             },
         )
         .unwrap();
@@ -831,7 +834,7 @@ mod tests {
             .opened_candidates
             .difference(&smaller.intermediates.opened_candidates);
         assert!(
-            larger_outside_smaller.is_empty(),
+            larger_outside_smaller.area() <= larger_outside_smaller.tolerance().powi(2),
             "larger feature disk added {:.9} mm² to the opened region",
             larger_outside_smaller.area()
         );
@@ -844,10 +847,16 @@ mod tests {
     #[test]
     fn regularization_does_not_inflate_obstacle_clearance() {
         let input = BoardArrayBalancingInput {
-            panel_outer: ContourSet::rectangle(bbox(0.0, 0.0, 30.0, 20.0), tol::REGION_MM),
-            board_footprints: ContourSet::rectangle(bbox(2.0, 2.0, 4.0, 4.0), tol::REGION_MM),
-            material_removal: ContourSet::empty(tol::REGION_MM),
-            support_features: ContourSet::rectangle(bbox(14.95, 0.0, 15.05, 20.0), tol::REGION_MM),
+            panel_outer: ContourSet::rectangle(bbox(0.0, 0.0, 30.0, 20.0), Resolution::default()),
+            board_footprints: ContourSet::rectangle(
+                bbox(2.0, 2.0, 4.0, 4.0),
+                Resolution::default(),
+            ),
+            material_removal: ContourSet::empty(Resolution::default()),
+            support_features: ContourSet::rectangle(
+                bbox(14.95, 0.0, 15.05, 20.0),
+                Resolution::default(),
+            ),
         };
         let result = board_array_balancing_region(
             &input,
@@ -855,7 +864,6 @@ mod tests {
                 clearance_mm: 0.5,
                 regularization_radius_mm: 1.0,
                 gap_radius_mm: 0.5,
-                numerical_guard_mm: 0.025,
             },
         )
         .unwrap();
@@ -882,8 +890,9 @@ mod tests {
 
     #[test]
     fn adding_an_obstacle_shrinks_clearance_safe_region_for_simple_fixture() {
-        let baseline_input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
-        let added_obstacle = ContourSet::rectangle(bbox(10.0, 1.0, 11.0, 9.0), tol::REGION_MM);
+        let baseline_input = balancing_input(0.0, ContourSet::empty(Resolution::default()));
+        let added_obstacle =
+            ContourSet::rectangle(bbox(10.0, 1.0, 11.0, 9.0), Resolution::default());
         let blocked_input = balancing_input(0.0, added_obstacle);
         let options = BalancingRegionOptions::default();
 
@@ -905,8 +914,8 @@ mod tests {
 
     #[test]
     fn translation_preserves_safe_region_area_and_certificate() {
-        let original = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
-        let translated = balancing_input(37.0, ContourSet::empty(tol::REGION_MM));
+        let original = balancing_input(0.0, ContourSet::empty(Resolution::default()));
+        let translated = balancing_input(37.0, ContourSet::empty(Resolution::default()));
 
         let original =
             board_array_balancing_region(&original, BalancingRegionOptions::default()).unwrap();
@@ -936,12 +945,12 @@ mod tests {
 
     #[test]
     fn an_empty_safe_region_is_valid() {
-        let panel = ContourSet::rectangle(bbox(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let panel = ContourSet::rectangle(bbox(0.0, 0.0, 10.0, 10.0), Resolution::default());
         let input = BoardArrayBalancingInput {
             panel_outer: panel.clone(),
             board_footprints: panel,
-            material_removal: ContourSet::empty(tol::REGION_MM),
-            support_features: ContourSet::empty(tol::REGION_MM),
+            material_removal: ContourSet::empty(Resolution::default()),
+            support_features: ContourSet::empty(Resolution::default()),
         };
 
         let result =
@@ -953,7 +962,7 @@ mod tests {
 
     #[test]
     fn rejects_invalid_options_and_required_empty_inputs() {
-        let input = balancing_input(0.0, ContourSet::empty(tol::REGION_MM));
+        let input = balancing_input(0.0, ContourSet::empty(Resolution::default()));
         assert_eq!(
             board_array_balancing_region(
                 &input,
@@ -961,7 +970,6 @@ mod tests {
                     clearance_mm: 0.0,
                     regularization_radius_mm: 0.5,
                     gap_radius_mm: 0.5,
-                    numerical_guard_mm: 0.0,
                 }
             )
             .unwrap_err(),
@@ -974,7 +982,6 @@ mod tests {
                     clearance_mm: 0.5,
                     regularization_radius_mm: 0.0,
                     gap_radius_mm: 0.5,
-                    numerical_guard_mm: 0.0,
                 }
             )
             .unwrap_err(),
@@ -987,28 +994,13 @@ mod tests {
                     clearance_mm: 0.5,
                     regularization_radius_mm: 1.0,
                     gap_radius_mm: 0.0,
-                    numerical_guard_mm: 0.0,
                 }
             )
             .unwrap_err(),
             BalancingRegionError::InvalidGapRadius(0.0)
         );
-        assert_eq!(
-            board_array_balancing_region(
-                &input,
-                BalancingRegionOptions {
-                    clearance_mm: 0.5,
-                    regularization_radius_mm: 0.5,
-                    gap_radius_mm: 0.5,
-                    numerical_guard_mm: -0.1,
-                }
-            )
-            .unwrap_err(),
-            BalancingRegionError::InvalidNumericalGuard(-0.1)
-        );
-
         let mut empty_panel = input.clone();
-        empty_panel.panel_outer = ContourSet::empty(tol::REGION_MM);
+        empty_panel.panel_outer = ContourSet::empty(Resolution::default());
         assert_eq!(
             board_array_balancing_region(&empty_panel, BalancingRegionOptions::default())
                 .unwrap_err(),
@@ -1016,7 +1008,7 @@ mod tests {
         );
 
         let mut empty_boards = input;
-        empty_boards.board_footprints = ContourSet::empty(tol::REGION_MM);
+        empty_boards.board_footprints = ContourSet::empty(Resolution::default());
         assert_eq!(
             board_array_balancing_region(&empty_boards, BalancingRegionOptions::default())
                 .unwrap_err(),
@@ -1053,6 +1045,7 @@ mod tests {
                 &support,
                 BoardArraySupportLayerPolicy::AllPaintedFeatures,
             )],
+            Resolution::default(),
         )
         .unwrap();
 
@@ -1099,7 +1092,9 @@ mod tests {
                 BoardArraySupportLayerPolicy::AllPaintedFeatures,
             ),
             &[BoardArrayCopperLayer::new(100, Side::Top)],
-        );
+            Resolution::default(),
+        )
+        .unwrap();
         let region = geometry.region_for_layer(100);
 
         assert_eq!(geometry.feature_count, 1);
@@ -1159,7 +1154,9 @@ mod tests {
                 BoardArraySupportLayerPolicy::AllPaintedFeatures,
             ),
             &copper_layers,
-        );
+            Resolution::default(),
+        )
+        .unwrap();
         let top = geometry.region_for_layer(100);
         let bottom = geometry.region_for_layer(200);
 
@@ -1168,7 +1165,7 @@ mod tests {
         assert!(
             top.intersection(&ContourSet::rectangle(
                 bbox(7.0, 1.0, 8.0, 2.0),
-                tol::REGION_MM
+                Resolution::default()
             ))
             .is_empty()
         );
@@ -1176,7 +1173,7 @@ mod tests {
             bottom
                 .intersection(&ContourSet::rectangle(
                     bbox(1.0, 1.0, 2.0, 2.0),
-                    tol::REGION_MM
+                    Resolution::default()
                 ))
                 .is_empty()
         );
@@ -1242,7 +1239,9 @@ mod tests {
                 BoardArraySupportLayerPolicy::VCutOperationsOnly,
             ),
             &[BoardArrayCopperLayer::new(100, Side::Top)],
-        );
+            Resolution::default(),
+        )
+        .unwrap();
 
         assert_eq!(geometry.source_feature_count, 2);
         assert_eq!(geometry.feature_count, 1);
@@ -1254,7 +1253,8 @@ mod tests {
 
     #[test]
     fn fab_panel_collector_uses_assembly_panels_as_the_only_footprints() {
-        let usable_region = ContourSet::rectangle(bbox(10.0, 10.0, 90.0, 60.0), tol::REGION_MM);
+        let usable_region =
+            ContourSet::rectangle(bbox(10.0, 10.0, 90.0, 60.0), Resolution::default());
         let profile = BoardArrayFabricationProfile {
             purpose: LayoutPurpose::FabricationPanel,
             array_outlines: vec![vec![rectangle_contour(0.0, 0.0, 100.0, 70.0)]],
@@ -1287,7 +1287,8 @@ mod tests {
 
     #[test]
     fn fab_panel_collector_rejects_wrong_purpose_and_missing_panels() {
-        let usable_region = ContourSet::rectangle(bbox(0.0, 0.0, 50.0, 50.0), tol::REGION_MM);
+        let usable_region =
+            ContourSet::rectangle(bbox(0.0, 0.0, 50.0, 50.0), Resolution::default());
         let mut profile = BoardArrayFabricationProfile {
             purpose: LayoutPurpose::Product,
             array_outlines: vec![vec![rectangle_contour(0.0, 0.0, 60.0, 60.0)]],
@@ -1326,6 +1327,7 @@ mod tests {
                 &support,
                 BoardArraySupportLayerPolicy::AllPaintedFeatures,
             )],
+            Resolution::default(),
         )
         .unwrap_err();
 
@@ -1336,15 +1338,15 @@ mod tests {
         BoardArrayBalancingInput {
             panel_outer: ContourSet::rectangle(
                 bbox(offset_x, 0.0, offset_x + 20.0, 10.0),
-                tol::REGION_MM,
+                Resolution::default(),
             ),
             board_footprints: ContourSet::rectangle(
                 bbox(offset_x + 2.0, 2.0, offset_x + 8.0, 8.0),
-                tol::REGION_MM,
+                Resolution::default(),
             ),
             material_removal: ContourSet::rectangle(
                 bbox(offset_x + 17.0, 4.0, offset_x + 18.0, 6.0),
-                tol::REGION_MM,
+                Resolution::default(),
             ),
             support_features,
         }

--- a/crates/pcb-ir/src/dialects/ipc/document.rs
+++ b/crates/pcb-ir/src/dialects/ipc/document.rs
@@ -108,6 +108,9 @@ impl<Symbol, LayerFunction> Document<Symbol, LayerFunction> {
 impl<Symbol: Copy + Eq + std::hash::Hash, LayerFunction: Clone> Document<Symbol, LayerFunction> {
     /// Consume a source layer into its final painted image through the
     /// artwork dialect, prepared at `resolution`.
+    ///
+    /// Imaging tolerates geometry a native writer would reject, such as
+    /// zero-radius arcs; callers exporting artwork validate separately.
     pub fn into_layer_image(
         mut self,
         layer_index: usize,
@@ -116,7 +119,6 @@ impl<Symbol: Copy + Eq + std::hash::Hash, LayerFunction: Clone> Document<Symbol,
         resolution: Resolution,
     ) -> anyhow::Result<crate::geom::ContourSet> {
         super::process::normalize_for_artwork(&mut self, resolution)?;
-        super::validate_artwork_ready(&self).map_err(anyhow::Error::msg)?;
         let artwork = super::lower_layer_to_artwork(&self, layer_index, role, side);
         let (mut layers, _) =
             crate::dialects::artwork::compose_owner_regions(&artwork, |_| Some(()), resolution)?;

--- a/crates/pcb-ir/src/dialects/ipc/document.rs
+++ b/crates/pcb-ir/src/dialects/ipc/document.rs
@@ -2,7 +2,7 @@ use crate::dialects::ipc::feature::{Feature, FeaturePlacementGroup, FeatureSet, 
 use crate::dialects::ipc::layout::{LayoutGraph, StepProfile, StepProfileCutout};
 use crate::dialects::ipc::spec::{Spec, SpecItem, SpecProperty, SpecRef};
 use crate::geom::path::ContourBuf;
-use crate::geom::{Affine2, BBox, Diagnostic, Paint, PathArena};
+use crate::geom::{Affine2, BBox, Diagnostic, Paint, PathArena, Resolution};
 
 const IDENTITY_PLACEMENT: [Affine2; 1] = [Affine2::IDENTITY];
 
@@ -44,7 +44,7 @@ impl<Symbol, LayerFunction> Document<Symbol, LayerFunction> {
         self.arena.push_path(paint, contours)
     }
 
-    /// Detach the contours of a path, transformed into another frame.
+    /// Detach the contours of a path, transformed exactly into another frame.
     pub fn transformed_path_contours(&self, path: u32, transform: Affine2) -> Vec<ContourBuf> {
         let path = self.arena.path(path);
         if transform.is_identity() {
@@ -102,6 +102,31 @@ impl<Symbol, LayerFunction> Document<Symbol, LayerFunction> {
 
     pub fn warn(&mut self, message: impl Into<String>) {
         self.diagnostics.push(Diagnostic::warning(message));
+    }
+}
+
+impl<Symbol: Copy + Eq + std::hash::Hash, LayerFunction: Clone> Document<Symbol, LayerFunction> {
+    /// Consume a source layer into its final painted image through the
+    /// artwork dialect, prepared at `resolution`.
+    pub fn into_layer_image(
+        mut self,
+        layer_index: usize,
+        role: crate::dialects::LayerRole,
+        side: crate::dialects::Side,
+        resolution: Resolution,
+    ) -> anyhow::Result<crate::geom::ContourSet> {
+        super::process::normalize_for_artwork(&mut self, resolution)?;
+        super::validate_artwork_ready(&self).map_err(anyhow::Error::msg)?;
+        let artwork = super::lower_layer_to_artwork(&self, layer_index, role, side);
+        let (mut layers, _) =
+            crate::dialects::artwork::compose_owner_regions(&artwork, |_| Some(()), resolution)?;
+        Ok(layers
+            .pop()
+            .and_then(|mut owners| owners.pop())
+            .map_or_else(
+                || crate::geom::ContourSet::empty(resolution),
+                |(_, region)| region,
+            ))
     }
 }
 

--- a/crates/pcb-ir/src/dialects/ipc/lower.rs
+++ b/crates/pcb-ir/src/dialects/ipc/lower.rs
@@ -670,7 +670,7 @@ fn compose_board_array_fabrication_profile(
     let mut material_removal = ContourSet::empty(resolution);
 
     for contours in &input.source_material_removal {
-        material_removal.union_assign(&ContourSet::from_filled_contours(contours, resolution)?);
+        material_removal.union_assign(&ContourSet::from_filled_contours(contours, resolution)?)?;
     }
 
     let mut relief_debug = relief::VScoreReliefDebug::default();
@@ -690,7 +690,7 @@ fn compose_board_array_fabrication_profile(
         } else {
             relief::vscore_route_reliefs(&relief_input)?
         };
-        material_removal.union_assign(&ContourSet::from_filled_contours(&reliefs, resolution)?);
+        material_removal.union_assign(&ContourSet::from_filled_contours(&reliefs, resolution)?)?;
     }
 
     Ok((
@@ -848,17 +848,24 @@ mod tests {
         let resolution = Resolution::default().with_tolerance(0.001);
         let mut region = ContourSet::empty(resolution);
 
-        region.union_assign(
-            &ContourSet::from_filled_contours(
-                &[reversed_rectangle_contour(0.0, 0.0, 2.0, 2.0)],
-                resolution,
-            )
-            .unwrap(),
-        );
-        region.union_assign(
-            &ContourSet::from_filled_contours(&[rectangle_contour(1.0, 0.0, 4.0, 2.0)], resolution)
+        region
+            .union_assign(
+                &ContourSet::from_filled_contours(
+                    &[reversed_rectangle_contour(0.0, 0.0, 2.0, 2.0)],
+                    resolution,
+                )
                 .unwrap(),
-        );
+            )
+            .unwrap();
+        region
+            .union_assign(
+                &ContourSet::from_filled_contours(
+                    &[rectangle_contour(1.0, 0.0, 4.0, 2.0)],
+                    resolution,
+                )
+                .unwrap(),
+            )
+            .unwrap();
 
         let bbox = region
             .to_contours()

--- a/crates/pcb-ir/src/dialects/ipc/lower.rs
+++ b/crates/pcb-ir/src/dialects/ipc/lower.rs
@@ -1,6 +1,7 @@
 //! Lowerings out of the IPC dialect: per-layer artwork, NC drill/rout
 //! documents, and fabrication profiles.
 
+use crate::geom::Resolution;
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -15,7 +16,7 @@ use crate::dialects::ipc::layout::{LayoutPurpose, StepProfile};
 use crate::dialects::ipc::{Document, relief};
 use crate::dialects::{LayerRole, Side};
 use crate::dialects::{artwork, nc};
-use crate::geom::path::{ContourBuf, transform_cmds};
+use crate::geom::path::ContourBuf;
 use crate::geom::{
     Affine2, BBox, ContourSet, FillRule, Paint, Point, Polarity, Span, StrokeStyle, tol,
 };
@@ -358,8 +359,8 @@ pub fn contour_flash_aperture<Symbol, LayerFunction>(
     let local = doc
         .arena
         .path_contours(path)
-        .iter()
-        .map(|contour| transform_cmds(contour.cmds.iter().copied(), inverse))
+        .into_iter()
+        .map(|contour| contour.transformed(inverse))
         .collect::<Vec<_>>();
     let [outline] = local.try_into().ok()?;
     Some(artwork::ApertureShape::Contour {
@@ -573,6 +574,7 @@ pub fn board_array_fabrication_profile<Symbol, LayerFunction>(
     doc: &Document<Symbol, LayerFunction>,
     score_lines: &[relief::VScoreLine],
     options: FabricationProfileOptions,
+    resolution: Resolution,
 ) -> Result<(BoardArrayFabricationProfile, relief::VScoreReliefDebug), relief::VScoreReliefError> {
     let Some((_, root_panel)) = root_panel_step(doc) else {
         return Ok((
@@ -582,7 +584,7 @@ pub fn board_array_fabrication_profile<Symbol, LayerFunction>(
     };
 
     let input = collect_board_array_fabrication_profile_input(doc, root_panel.purpose);
-    compose_board_array_fabrication_profile(input, score_lines, options)
+    compose_board_array_fabrication_profile(input, score_lines, options, resolution)
 }
 
 #[derive(Debug, Clone, Default)]
@@ -659,17 +661,16 @@ fn compose_board_array_fabrication_profile(
     input: BoardArrayFabricationProfileInput,
     score_lines: &[relief::VScoreLine],
     options: FabricationProfileOptions,
+    resolution: Resolution,
 ) -> Result<(BoardArrayFabricationProfile, relief::VScoreReliefDebug), relief::VScoreReliefError> {
     // M = source cutouts ∪ board cutouts ∪ V-score relief material.
     // Store M as a `ContourSet` until the end so every contribution is merged
     // with the same regularized Boolean union.
-    let mut material_removal = ContourSet::empty(relief::DEFAULT_RELIEF_TOLERANCE_MM);
+    let resolution = resolution.with_tolerance(relief::DEFAULT_RELIEF_TOLERANCE_MM);
+    let mut material_removal = ContourSet::empty(resolution);
 
     for contours in &input.source_material_removal {
-        material_removal.union_assign(&ContourSet::from_filled_contours(
-            contours,
-            relief::DEFAULT_RELIEF_TOLERANCE_MM,
-        ));
+        material_removal.union_assign(&ContourSet::from_filled_contours(contours, resolution)?);
     }
 
     let mut relief_debug = relief::VScoreReliefDebug::default();
@@ -680,7 +681,7 @@ fn compose_board_array_fabrication_profile(
             score_blockers: options.relief_features.score_blockers,
             score_lines: score_lines.to_vec(),
             tool_diameter_mm: relief::DEFAULT_ROUTE_TOOL_DIAMETER_MM,
-            tolerance_mm: relief::DEFAULT_RELIEF_TOLERANCE_MM,
+            resolution,
         };
         let reliefs = if options.debug {
             let output = relief::vscore_route_reliefs_with_debug(&relief_input)?;
@@ -689,10 +690,7 @@ fn compose_board_array_fabrication_profile(
         } else {
             relief::vscore_route_reliefs(&relief_input)?
         };
-        material_removal.union_assign(&ContourSet::from_filled_contours(
-            &reliefs,
-            relief::DEFAULT_RELIEF_TOLERANCE_MM,
-        ));
+        material_removal.union_assign(&ContourSet::from_filled_contours(&reliefs, resolution)?);
     }
 
     Ok((
@@ -847,16 +845,20 @@ mod tests {
 
     #[test]
     fn material_removal_union_is_winding_insensitive() {
-        let mut region = ContourSet::empty(0.001);
+        let resolution = Resolution::default().with_tolerance(0.001);
+        let mut region = ContourSet::empty(resolution);
 
-        region.union_assign(&ContourSet::from_filled_contours(
-            &[reversed_rectangle_contour(0.0, 0.0, 2.0, 2.0)],
-            0.001,
-        ));
-        region.union_assign(&ContourSet::from_filled_contours(
-            &[rectangle_contour(1.0, 0.0, 4.0, 2.0)],
-            0.001,
-        ));
+        region.union_assign(
+            &ContourSet::from_filled_contours(
+                &[reversed_rectangle_contour(0.0, 0.0, 2.0, 2.0)],
+                resolution,
+            )
+            .unwrap(),
+        );
+        region.union_assign(
+            &ContourSet::from_filled_contours(&[rectangle_contour(1.0, 0.0, 4.0, 2.0)], resolution)
+                .unwrap(),
+        );
 
         let bbox = region
             .to_contours()
@@ -874,8 +876,13 @@ mod tests {
             assembly_panel_outlines: vec![vec![finished]],
             ..BoardArrayFabricationProfileInput::default()
         };
-        let (profile, _) =
-            compose_board_array_fabrication_profile(input, &[], Default::default()).unwrap();
+        let (profile, _) = compose_board_array_fabrication_profile(
+            input,
+            &[],
+            Default::default(),
+            Resolution::default(),
+        )
+        .unwrap();
 
         assert_eq!(profile.purpose, LayoutPurpose::FabricationPanel);
         assert!(profile.material_removal.is_empty());

--- a/crates/pcb-ir/src/dialects/ipc/mod.rs
+++ b/crates/pcb-ir/src/dialects/ipc/mod.rs
@@ -31,9 +31,9 @@ pub use balancing_region::{
     BoardArrayCopperLayer, BoardArrayCopperReach, BoardArrayScopedObstacle,
     BoardArraySupportDocument, BoardArraySupportLayerGeometry, BoardArraySupportLayerPolicy,
     ClearanceCertificate, DEFAULT_BALANCING_CLEARANCE_MM, DEFAULT_BALANCING_GAP_RADIUS_MM,
-    DEFAULT_BALANCING_NUMERICAL_GUARD_MM, DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM,
-    board_array_balancing_region, collect_board_array_balancing_input,
-    collect_fab_panel_balancing_input, inspect_board_array_balancing_input,
+    DEFAULT_BALANCING_REGULARIZATION_RADIUS_MM, board_array_balancing_region,
+    collect_board_array_balancing_input, collect_fab_panel_balancing_input,
+    inspect_board_array_balancing_input,
 };
 pub use document::{Document, Layer};
 pub use feature::{

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -974,7 +974,7 @@ fn subtract_region_from_feature<S, L>(
     }
 
     let near = ContourSet::from_regularized(near, cutters.resolution, cutters.uncertainty_mm);
-    let contours = subject.difference(&near).to_contours();
+    let contours = subject.difference(&near)?.to_contours();
     if contours.is_empty() {
         clear_feature_paths(doc, feature_index);
         return Ok(());

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -9,6 +9,7 @@
 //! - [`compose_for_rendering`]: destructive image composition (outlines
 //!   strokes, unions fills) for final rendering targets.
 
+use crate::geom::{AccuracyError, Resolution};
 use std::collections::HashMap;
 use std::hash::Hash;
 
@@ -16,9 +17,9 @@ use crate::dialects::ipc::Document;
 use crate::dialects::ipc::document::Layer;
 use crate::dialects::ipc::feature::{Feature, FeatureBucket, FeatureIntent, FeatureKind};
 use crate::geom::path::ContourBuf;
-use crate::geom::region::{self, Ring};
+use crate::geom::region::{self};
 use crate::geom::{
-    Affine2, BBox, ContourSet, FillRule, Paint, PaintKind, Path, Polarity, Span, tol,
+    Affine2, BBox, ContourSet, FillRule, Paint, PaintKind, Path, PathArena, Polarity, Span,
 };
 
 /// Run only structure-preserving cleanup passes.
@@ -46,16 +47,19 @@ where
 /// native: ordered artwork carries per-object polarity with exactly IPC's
 /// sequential paint semantics, so resolving them here would only flatten
 /// repeated clear instances into unshareable boundary geometry.
-pub fn normalize_for_artwork<S, L>(doc: &mut Document<S, L>)
-where
-    S: Copy + Eq + Hash,
-    L: Clone,
-{
+pub fn normalize_for_artwork<S: Copy + Eq + Hash, L: Clone>(
+    doc: &mut Document<S, L>,
+    resolution: Resolution,
+) -> Result<(), AccuracyError> {
     normalize_preserving(doc);
-    resolve_set_voids(doc);
-    subtract_layer_cutouts(doc);
+    resolve_set_voids(doc, resolution)?;
+    subtract_layer_cutouts(doc, resolution)?;
     compact(doc);
     normalize_bounds(doc);
+    for contour in &doc.arena.contours {
+        resolution.accuracy.check(contour.uncertainty_mm)?;
+    }
+    Ok(())
 }
 
 /// Resolve source geometry into a composed rendering image.
@@ -65,20 +69,25 @@ where
 /// contours. Negative polarity stays native — mask composition paints
 /// polarity runs sequentially. Use it only when a target needs a final
 /// painted image.
-pub fn compose_for_rendering<S, L>(doc: &mut Document<S, L>)
+pub fn compose_for_rendering<S, L>(
+    doc: &mut Document<S, L>,
+    resolution: Resolution,
+) -> Result<(), AccuracyError>
 where
     S: Copy + Eq + Hash,
     L: Clone,
 {
     expand_feature_placement_groups(doc);
     normalize_preserving(doc);
-    expand_stroked_paths_to_fills(doc);
-    union_feature_filled_paths(doc);
-    coalesce_related_trace_features(doc);
-    resolve_set_voids(doc);
-    subtract_layer_cutouts(doc);
+    expand_stroked_paths_to_fills(doc, resolution.accuracy)?;
+    union_feature_filled_paths(doc, resolution)?;
+    coalesce_related_trace_features(doc, resolution)?;
+    resolve_set_voids(doc, resolution)?;
+    subtract_layer_cutouts(doc, resolution)?;
     compact(doc);
     normalize_bounds(doc);
+
+    Ok(())
 }
 
 /// Drop unpainted paths from feature path spans.
@@ -295,16 +304,30 @@ pub fn retain_features<S: Clone, L>(
 
 /// Materialize shared IPC feature placement groups only for passes that need
 /// one independent feature image per occurrence. Structure-preserving
-/// pipelines and artwork lowering keep the groups compact.
+/// pipelines and artwork lowering keep the groups compact. Placement is an
+/// exact transform, so every occurrence keeps its source curves.
 pub fn expand_feature_placement_groups<S: Clone, L>(doc: &mut Document<S, L>) {
     if doc.feature_placement_groups.is_empty() {
         return;
     }
 
-    let mut old_features = std::mem::take(&mut doc.features)
-        .into_iter()
-        .map(Some)
-        .collect::<Vec<_>>();
+    let (expanded, mapping) = materialize_placement_groups(doc);
+
+    for layer in &mut doc.layers {
+        layer.features = expanded_span(layer.features, &mapping);
+    }
+    for set in &mut doc.feature_sets {
+        set.features = expanded_span(set.features, &mapping);
+    }
+    doc.features = expanded;
+    doc.feature_placement_groups.clear();
+    doc.feature_placements.clear();
+}
+
+type ExpandedFeatures<S> = (Vec<Feature<S>>, Vec<Span>);
+
+fn materialize_placement_groups<S: Clone, L>(doc: &mut Document<S, L>) -> ExpandedFeatures<S> {
+    let mut old_features = doc.features.iter().cloned().map(Some).collect::<Vec<_>>();
     let mut expanded = Vec::with_capacity(old_features.len());
     let mut mapping = vec![Span::EMPTY; old_features.len()];
 
@@ -338,7 +361,7 @@ pub fn expand_feature_placement_groups<S: Clone, L>(doc: &mut Document<S, L>) {
                             })
                             .unwrap_or(placement_index),
                     );
-                    materialize_feature_placement(doc, &mut instance, placement);
+                    materialize_feature_placement(&mut doc.arena, &mut instance, placement);
                     expanded.push(instance);
                 }
             }
@@ -351,31 +374,22 @@ pub fn expand_feature_placement_groups<S: Clone, L>(doc: &mut Document<S, L>) {
             mapping[feature_index] = Span::single(start);
         }
     }
-
-    for layer in &mut doc.layers {
-        layer.features = expanded_span(layer.features, &mapping);
-    }
-    for set in &mut doc.feature_sets {
-        set.features = expanded_span(set.features, &mapping);
-    }
-    doc.features = expanded;
-    doc.feature_placement_groups.clear();
-    doc.feature_placements.clear();
+    (expanded, mapping)
 }
 
-fn materialize_feature_placement<S, L>(
-    doc: &mut Document<S, L>,
+fn materialize_feature_placement<S>(
+    arena: &mut PathArena,
     feature: &mut Feature<S>,
     placement: Affine2,
 ) {
     let scale = placement.m00.hypot(placement.m10);
-    let path_start = doc.arena.paths.len() as u32;
+    let path_start = arena.paths.len() as u32;
     for path_index in feature.paths.indices() {
-        let path = doc.arena.paths[path_index as usize];
-        let contours = doc.arena.transformed_contour_bufs(path.contours, placement);
-        doc.arena.push_path(path.paint.scaled(scale), contours);
+        let path = arena.paths[path_index as usize];
+        let contours = arena.transformed_contour_bufs(path.contours, placement);
+        arena.push_path(path.paint.scaled(scale), contours);
     }
-    let paths = Span::new(path_start, doc.arena.paths.len() as u32 - path_start);
+    let paths = Span::new(path_start, arena.paths.len() as u32 - path_start);
     feature.placement_group = None;
     feature.transform = placement.concat(feature.transform);
     feature.center = placement.transform_point(feature.center);
@@ -385,7 +399,7 @@ fn materialize_feature_placement<S, L>(
     feature.stroke_width *= scale;
     feature.outer_diameter *= scale;
     feature.inner_diameter *= scale;
-    feature.bbox = doc.arena.paths_bbox(paths);
+    feature.bbox = arena.paths_bbox(paths);
 }
 
 fn expanded_span(span: Span, mapping: &[Span]) -> Span {
@@ -445,7 +459,10 @@ fn remap_span(span: Span, mapping: &[Option<u32>]) -> Span {
 /// rendering and Gerber export, so strokes, flashes, and polarity sequencing
 /// flatten exactly as they manufacture instead of through a second
 /// composition implementation.
-pub fn flatten_layers_to_masks<S, L>(doc: &mut Document<S, L>)
+pub fn flatten_layers_to_masks<S, L>(
+    doc: &mut Document<S, L>,
+    resolution: Resolution,
+) -> Result<(), AccuracyError>
 where
     S: Copy + Eq + Hash,
     L: Clone,
@@ -462,7 +479,7 @@ where
             crate::dialects::LayerRole::Other,
             crate::dialects::Side::None,
         );
-        let mask = crate::dialects::artwork::compose_to_mask(&artwork);
+        let mask = crate::dialects::artwork::compose_to_mask(&artwork, resolution)?;
         let contours = mask
             .layers
             .first()
@@ -508,6 +525,8 @@ where
 
     compact(doc);
     normalize_bounds(doc);
+
+    Ok(())
 }
 
 /// Merge a feature's identically painted paths into one compound path.
@@ -533,7 +552,10 @@ pub fn compose_feature_paths<S, L>(doc: &mut Document<S, L>) {
 }
 
 /// Convert copper-trace strokes into filled outlines.
-pub fn expand_stroked_paths_to_fills<S, L>(doc: &mut Document<S, L>) {
+pub fn expand_stroked_paths_to_fills<S, L>(
+    doc: &mut Document<S, L>,
+    accuracy: crate::geom::GeometryAccuracy,
+) -> Result<(), AccuracyError> {
     for feature_index in 0..doc.features.len() {
         let feature = &doc.features[feature_index];
         if !is_copper_trace_feature(feature) {
@@ -556,7 +578,8 @@ pub fn expand_stroked_paths_to_fills<S, L>(doc: &mut Document<S, L>) {
                     if let Some(contours) = crate::geom::path::stroke_to_fill(
                         &doc.arena.path_contours(&path),
                         stroke.into(),
-                    ) {
+                        accuracy,
+                    )? {
                         doc.arena.push_path(
                             Paint::Fill {
                                 rule: FillRule::NonZero,
@@ -572,10 +595,14 @@ pub fn expand_stroked_paths_to_fills<S, L>(doc: &mut Document<S, L>) {
         }
         doc.features[feature_index].paths = Span::new(start, doc.arena.paths.len() as u32 - start);
     }
+    Ok(())
 }
 
 /// Union a trace feature's filled paths into one region.
-pub fn union_feature_filled_paths<S, L>(doc: &mut Document<S, L>) {
+pub fn union_feature_filled_paths<S, L>(
+    doc: &mut Document<S, L>,
+    resolution: Resolution,
+) -> Result<(), AccuracyError> {
     for feature_index in 0..doc.features.len() {
         let feature = &doc.features[feature_index];
         if !is_copper_trace_feature(feature) {
@@ -590,12 +617,8 @@ pub fn union_feature_filled_paths<S, L>(doc: &mut Document<S, L>) {
             continue;
         };
 
-        let rings = feature_rings(doc, &doc.features[feature_index]);
-        if rings.len() < 2 {
-            continue;
-        }
-
-        let contours = region::rings_to_contours(region::union_rings(rings, fill_rule));
+        let image = feature_filled_region(doc, &doc.features[feature_index], resolution.strict())?;
+        let contours = image.to_contours();
         if contours.is_empty() {
             continue;
         }
@@ -607,6 +630,7 @@ pub fn union_feature_filled_paths<S, L>(doc: &mut Document<S, L>) {
             contours,
         );
     }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -619,7 +643,10 @@ struct TraceGroupKey<S> {
 }
 
 /// Union filled trace features that share a net, source set, and intent.
-pub fn coalesce_related_trace_features<S, L>(doc: &mut Document<S, L>)
+pub fn coalesce_related_trace_features<S, L>(
+    doc: &mut Document<S, L>,
+    resolution: Resolution,
+) -> Result<(), AccuracyError>
 where
     S: Copy + Eq + Hash,
     L: Clone,
@@ -659,15 +686,14 @@ where
                 continue;
             }
 
-            let rings = group
-                .iter()
-                .flat_map(|&feature_index| feature_rings(doc, &doc.features[feature_index]))
-                .collect::<Vec<_>>();
-            if rings.len() < 2 {
-                continue;
+            let mut composer = region::PaintComposer::new(resolution.strict());
+            for &feature_index in &group {
+                composer.push(
+                    Polarity::Dark,
+                    feature_filled_region(doc, &doc.features[feature_index], resolution.strict())?,
+                );
             }
-
-            let contours = region::rings_to_contours(region::union_rings(rings, key.fill_rule));
+            let contours = composer.finish().to_contours();
             if contours.is_empty() {
                 continue;
             }
@@ -685,11 +711,15 @@ where
             }
         }
     }
+    Ok(())
 }
 
 /// Resolve IPC set-void semantics: a feature flagged `clears_previous_in_set`
 /// subtracts its filled image from earlier positive features of the same set.
-pub fn resolve_set_voids<S, L>(doc: &mut Document<S, L>)
+pub fn resolve_set_voids<S, L>(
+    doc: &mut Document<S, L>,
+    resolution: Resolution,
+) -> Result<(), AccuracyError>
 where
     S: Clone,
     L: Clone,
@@ -717,11 +747,14 @@ where
                 }
 
                 if feature.flags.clears_previous_in_set {
-                    let cutters = feature_filled_rings(doc, &doc.features[feature_index]);
+                    let cutters = feature_filled_region(
+                        doc,
+                        &doc.features[feature_index],
+                        resolution.strict(),
+                    )?;
                     if !cutters.is_empty() {
-                        let bounds = ring_bounds(&cutters);
                         for subject_index in previous.iter().copied() {
-                            subtract_rings_from_feature(doc, subject_index, &cutters, &bounds);
+                            subtract_region_from_feature(doc, subject_index, &cutters)?;
                         }
                     }
                     clear_feature_paths(doc, feature_index);
@@ -734,6 +767,7 @@ where
             }
         }
     }
+    Ok(())
 }
 
 fn layer_features_by_set<S, L>(
@@ -751,7 +785,10 @@ fn layer_features_by_set<S, L>(
 }
 
 /// Subtract cutout features from every other feature on their layer.
-pub fn subtract_layer_cutouts<S, L>(doc: &mut Document<S, L>)
+pub fn subtract_layer_cutouts<S, L>(
+    doc: &mut Document<S, L>,
+    resolution: Resolution,
+) -> Result<(), AccuracyError>
 where
     S: Clone,
     L: Clone,
@@ -768,7 +805,7 @@ where
     }
     for layer_index in 0..doc.layers.len() {
         let layer = doc.layers[layer_index].clone();
-        let cutouts = layer_cutout_sets(doc, &layer);
+        let cutouts = layer_cutout_sets(doc, &layer, resolution)?;
         if cutouts.is_empty() {
             continue;
         }
@@ -784,19 +821,20 @@ where
                 continue;
             }
 
-            let cutters = cutouts
-                .iter()
-                .filter(|cutout| feature_bbox.intersects(cutout.bbox))
-                .flat_map(|cutout| cutout.rings.iter().cloned())
-                .collect::<Vec<_>>();
+            let cutters = ContourSet::union_all(
+                resolution.strict(),
+                cutouts
+                    .iter()
+                    .filter(|cutout| feature_bbox.intersects(cutout.bbox))
+                    .cloned(),
+            );
             if cutters.is_empty() {
                 continue;
             }
-
-            let bounds = ring_bounds(&cutters);
-            subtract_rings_from_feature(doc, feature_index, &cutters, &bounds);
+            subtract_region_from_feature(doc, feature_index, &cutters)?;
         }
     }
+    Ok(())
 }
 
 /// Split a lowered-primitive feature into per-paint-kind runs so each run can
@@ -906,55 +944,40 @@ fn clear_feature_paths<S, L>(doc: &mut Document<S, L>, feature_index: usize) {
     feature.primitive_ref = None;
 }
 
-fn ring_bounds(rings: &[Ring]) -> Vec<BBox> {
-    rings
-        .iter()
-        .map(|ring| rings_bbox(std::slice::from_ref(ring)))
-        .collect()
-}
-
-fn rings_bbox(rings: &[Ring]) -> BBox {
-    rings
-        .iter()
-        .flat_map(|ring| ring.iter())
-        .fold(BBox::empty(), |bbox, &[x, y]| {
-            bbox.union(BBox::new(
-                crate::geom::Point::new(x, y),
-                crate::geom::Point::new(x, y),
-            ))
-        })
-}
-
-fn subtract_rings_from_feature<S, L>(
+fn subtract_region_from_feature<S, L>(
     doc: &mut Document<S, L>,
     feature_index: usize,
-    cutters: &[Ring],
-    cutter_bounds: &[BBox],
-) {
-    let subject = feature_filled_rings(doc, &doc.features[feature_index]);
+    cutters: &ContourSet,
+) -> Result<(), AccuracyError> {
+    let subject = feature_filled_region(
+        doc,
+        &doc.features[feature_index],
+        cutters.resolution.strict(),
+    )?;
     if subject.is_empty() {
-        return;
+        return Ok(());
     }
 
     // Only cutters that can reach this feature participate; most features on
     // a layer are nowhere near any of them, and dense generated cutter sets
     // (balance void lattices) would otherwise make every subtraction sweep
     // the whole set.
-    let subject_bounds = rings_bbox(&subject);
     let near = cutters
+        .rings
         .iter()
-        .zip(cutter_bounds)
-        .filter(|(_, bounds)| bounds.intersects(subject_bounds))
+        .zip(&cutters.ring_bounds)
+        .filter(|(_, bounds)| bounds.intersects(subject.bbox))
         .map(|(ring, _)| ring.clone())
         .collect::<Vec<_>>();
     if near.is_empty() {
-        return;
+        return Ok(());
     }
 
-    let contours = region::rings_to_contours(region::difference_rings(subject, near));
+    let near = ContourSet::from_regularized(near, cutters.resolution, cutters.uncertainty_mm);
+    let contours = subject.difference(&near).to_contours();
     if contours.is_empty() {
         clear_feature_paths(doc, feature_index);
-        return;
+        return Ok(());
     }
 
     replace_feature_with_path(
@@ -965,59 +988,52 @@ fn subtract_rings_from_feature<S, L>(
         },
         contours,
     );
+
+    Ok(())
 }
 
-fn layer_cutout_sets<S, L>(doc: &Document<S, L>, layer: &Layer<S, L>) -> Vec<ContourSet> {
-    layer
+fn layer_cutout_sets<S, L>(
+    doc: &Document<S, L>,
+    layer: &Layer<S, L>,
+    resolution: Resolution,
+) -> Result<Vec<ContourSet>, AccuracyError> {
+    Ok(layer
         .features
         .slice(&doc.features)
         .iter()
         .filter(|feature| feature.bucket == FeatureBucket::Cutout)
-        .filter_map(|feature| {
-            let rings = feature_filled_rings(doc, feature);
-            if rings.is_empty() {
-                None
-            } else {
-                Some(ContourSet::new(rings, FillRule::NonZero, tol::REGION_MM))
-            }
-        })
-        .collect()
+        .map(|feature| feature_filled_region(doc, feature, resolution))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .filter(|region| !region.is_empty())
+        .collect())
 }
 
 /// The regularized filled image of a feature's fill paths, grouped by fill
 /// rule before the final union.
-fn feature_filled_rings<S, L>(doc: &Document<S, L>, feature: &Feature<S>) -> Vec<Ring> {
-    let mut groups: HashMap<FillRule, Vec<Ring>> = HashMap::new();
+fn feature_filled_region<S, L>(
+    doc: &Document<S, L>,
+    feature: &Feature<S>,
+    resolution: Resolution,
+) -> Result<ContourSet, AccuracyError> {
+    let mut groups: HashMap<FillRule, Vec<ContourBuf>> = HashMap::new();
     for path in feature.paths.slice(&doc.arena.paths) {
         if let Some(rule) = path.fill_rule() {
             groups
                 .entry(rule)
                 .or_default()
-                .extend(path_rings(doc, path));
+                .extend(doc.arena.path_contours(path));
         }
     }
 
-    let mut rings = groups
-        .into_iter()
-        .flat_map(|(fill_rule, rings)| region::simplify_rings(rings, fill_rule))
-        .collect::<Vec<_>>();
-    if rings.len() > 1 {
-        rings = region::simplify_rings(rings, FillRule::NonZero);
+    let mut composer = region::PaintComposer::new(resolution);
+    for (fill_rule, contours) in groups {
+        composer.push(
+            Polarity::Dark,
+            ContourSet::from_contours(&contours, fill_rule, resolution.strict())?,
+        );
     }
-    rings
-}
-
-fn feature_rings<S, L>(doc: &Document<S, L>, feature: &Feature<S>) -> Vec<Ring> {
-    feature
-        .paths
-        .slice(&doc.arena.paths)
-        .iter()
-        .flat_map(|path| path_rings(doc, path))
-        .collect()
-}
-
-fn path_rings<S, L>(doc: &Document<S, L>, path: &Path) -> Vec<Ring> {
-    region::rings_from_contours(&doc.arena.path_contours(path))
+    Ok(composer.finish())
 }
 
 /// Bounds of a set's own feature span, for sets with no linked features.
@@ -1070,7 +1086,7 @@ mod tests {
             ..copper_trace_feature()
         });
 
-        compose_for_rendering(&mut doc);
+        compose_for_rendering(&mut doc, Resolution::default()).unwrap();
 
         assert_eq!(doc.features[0].paths.len(), 1);
         let path = &doc.arena.paths[doc.features[0].paths.start as usize];
@@ -1122,7 +1138,7 @@ mod tests {
                 bbox: BBox::empty(),
             });
 
-        compose_for_rendering(&mut doc);
+        compose_for_rendering(&mut doc, Resolution::default()).unwrap();
 
         let feature_paths = doc.features[0].paths.slice(&doc.arena.paths);
         assert_eq!(feature_paths.len(), 1);
@@ -1187,7 +1203,7 @@ mod tests {
         });
         doc.layers.push(test_layer(Span::new(0, 3)));
 
-        compose_for_rendering(&mut doc);
+        compose_for_rendering(&mut doc, Resolution::default()).unwrap();
 
         assert_eq!(doc.features[0].paths.len(), 1);
         assert_eq!(doc.features[1].paths.len(), 0);
@@ -1223,7 +1239,7 @@ mod tests {
         });
         doc.layers.push(test_layer(Span::new(0, 2)));
 
-        compose_for_rendering(&mut doc);
+        compose_for_rendering(&mut doc, Resolution::default()).unwrap();
 
         // Both features keep their native geometry and polarity; the
         // sequential paint fold applies the subtraction at composition.
@@ -1238,13 +1254,15 @@ mod tests {
             crate::dialects::LayerRole::Copper,
             crate::dialects::Side::Top,
         );
-        let mask = crate::dialects::artwork::compose_to_mask(&artwork);
+        let mask =
+            crate::dialects::artwork::compose_to_mask(&artwork, Resolution::default()).unwrap();
         let shape = mask.layers[0].shapes.slice(&mask.arena.paths)[0];
         let image = crate::geom::region::ContourSet::from_contours(
             &mask.arena.path_contours(&shape),
             FillRule::NonZero,
-            crate::geom::tol::REGION_MM,
-        );
+            Resolution::default(),
+        )
+        .unwrap();
         assert!((image.area() - 12.0).abs() < 1e-6);
         assert!(!image.contains_point(Point::new(2.0, 2.0)));
     }
@@ -1275,7 +1293,7 @@ mod tests {
         });
         doc.layers.push(test_layer(Span::new(0, 2)));
 
-        compose_for_rendering(&mut doc);
+        compose_for_rendering(&mut doc, Resolution::default()).unwrap();
 
         let trace = &doc.features[0];
         let path = &doc.arena.paths[trace.paths.start as usize];
@@ -1420,8 +1438,8 @@ mod tests {
         });
         doc.layers.push(test_layer(Span::new(0, 2)));
 
-        compose_for_rendering(&mut doc);
-        flatten_layers_to_masks(&mut doc);
+        compose_for_rendering(&mut doc, Resolution::default()).unwrap();
+        flatten_layers_to_masks(&mut doc, Resolution::default()).unwrap();
 
         assert_eq!(doc.features[0].kind, FeatureKind::FlattenedBucket);
         assert_eq!(doc.features[0].bucket, FeatureBucket::Fill);
@@ -1454,14 +1472,14 @@ mod tests {
         });
         doc.layers.push(test_layer(Span::new(0, 1)));
 
-        compose_for_rendering(&mut doc);
+        compose_for_rendering(&mut doc, Resolution::default()).unwrap();
         let path = &doc.arena.paths[doc.features[0].paths.start as usize];
         assert!(
             path.stroke().is_some(),
             "precondition: stroke survives composition"
         );
 
-        flatten_layers_to_masks(&mut doc);
+        flatten_layers_to_masks(&mut doc, Resolution::default()).unwrap();
 
         assert_eq!(doc.features[0].kind, FeatureKind::FlattenedBucket);
         assert_eq!(doc.features[0].paths.len(), 1);
@@ -1500,16 +1518,17 @@ mod tests {
         });
         doc.layers.push(test_layer(Span::new(0, 2)));
 
-        compose_for_rendering(&mut doc);
-        flatten_layers_to_masks(&mut doc);
+        compose_for_rendering(&mut doc, Resolution::default()).unwrap();
+        flatten_layers_to_masks(&mut doc, Resolution::default()).unwrap();
 
         assert_eq!(doc.features[0].kind, FeatureKind::FlattenedBucket);
         let path = &doc.arena.paths[doc.features[0].paths.start as usize];
         let image = ContourSet::from_contours(
             &doc.arena.path_contours(path),
             FillRule::NonZero,
-            tol::REGION_MM,
-        );
+            Resolution::default(),
+        )
+        .unwrap();
         assert!(image.contains_point(Point::new(0.5, 0.5)));
         assert!(!image.contains_point(Point::new(2.0, 2.0)));
     }
@@ -1537,7 +1556,7 @@ mod tests {
         });
         doc.layers.push(test_layer(Span::single(0)));
 
-        flatten_layers_to_masks(&mut doc);
+        flatten_layers_to_masks(&mut doc, Resolution::default()).unwrap();
 
         assert!(doc.feature_placement_groups.is_empty());
         assert!(doc.feature_placements.is_empty());
@@ -1548,8 +1567,9 @@ mod tests {
         let image = ContourSet::from_contours(
             &doc.arena.path_contours(path),
             FillRule::NonZero,
-            tol::REGION_MM,
-        );
+            Resolution::default(),
+        )
+        .unwrap();
         assert!(image.contains_point(Point::new(10.5, 0.5)));
         assert!(image.contains_point(Point::new(20.5, 0.5)));
         assert!(!image.contains_point(Point::new(30.5, 0.5)));
@@ -1584,7 +1604,7 @@ mod tests {
         });
         doc.layers.push(test_layer(Span::new(0, 2)));
 
-        compose_for_rendering(&mut doc);
+        compose_for_rendering(&mut doc, Resolution::default()).unwrap();
 
         // The set void and the pre-subtraction positive path are gone.
         assert_eq!(doc.arena.paths.len(), 1);
@@ -1674,6 +1694,62 @@ mod tests {
                 .map(|feature| feature.bbox.min.x)
                 .collect::<Vec<_>>(),
             [10.0, 12.0, 20.0, 22.0]
+        );
+    }
+
+    #[test]
+    fn normalization_refines_curves_for_intersecting_cutouts() {
+        let mut doc = TestDoc::new();
+        let paint = Paint::Fill {
+            rule: FillRule::NonZero,
+        };
+        doc.push_path(paint, [crate::geom::shapes::circle(2.0).unwrap()]);
+        doc.features.push(Feature {
+            paths: Span::new(0, 1),
+            ..copper_trace_feature()
+        });
+        doc.push_path(paint, [rect_contour(0.0, -3.0, 3.0, 3.0)]);
+        doc.features.push(Feature {
+            paths: Span::new(1, 1),
+            ..Feature::new(FeatureKind::Slot, Polarity::Dark)
+        });
+        doc.layers.push(test_layer(Span::new(0, 2)));
+        let resolution = Resolution::default()
+            .with_accuracy(crate::geom::GeometryAccuracy::new(0.001).unwrap())
+            .strict();
+        normalize_for_artwork(&mut doc, resolution).unwrap();
+        let image = feature_filled_region(&doc, &doc.features[0], resolution).unwrap();
+        assert!(!image.is_empty());
+        assert!(image.uncertainty_mm <= 0.001);
+        assert!(image.contains_point(Point::new(-0.5, 0.0)));
+        assert!(!image.contains_point(Point::new(0.5, 0.0)));
+    }
+
+    #[test]
+    fn normalization_accepts_inherited_error_within_the_total_budget() {
+        let mut doc = TestDoc::new();
+        doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            [rect_contour(0.0, 0.0, 1.0, 1.0).with_uncertainty(0.008)],
+        );
+        doc.features.push(Feature {
+            paths: Span::new(0, 1),
+            ..copper_trace_feature()
+        });
+        doc.layers.push(test_layer(Span::new(0, 1)));
+        normalize_for_artwork(
+            &mut doc,
+            Resolution::default().with_accuracy(crate::geom::GeometryAccuracy::new(0.01).unwrap()),
+        )
+        .unwrap();
+        assert!(!doc.arena.contours.is_empty());
+        assert!(
+            doc.arena
+                .contours
+                .iter()
+                .all(|contour| (0.008..=0.01).contains(&contour.uncertainty_mm))
         );
     }
 

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -693,7 +693,7 @@ where
                     feature_filled_region(doc, &doc.features[feature_index], resolution.strict())?,
                 );
             }
-            let contours = composer.finish().to_contours();
+            let contours = composer.finish()?.to_contours();
             if contours.is_empty() {
                 continue;
             }
@@ -827,7 +827,7 @@ where
                     .iter()
                     .filter(|cutout| feature_bbox.intersects(cutout.bbox))
                     .cloned(),
-            );
+            )?;
             if cutters.is_empty() {
                 continue;
             }
@@ -1033,7 +1033,7 @@ fn feature_filled_region<S, L>(
             ContourSet::from_contours(&contours, fill_rule, resolution.strict())?,
         );
     }
-    Ok(composer.finish())
+    composer.finish()
 }
 
 /// Bounds of a set's own feature span, for sets with no linked features.

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -1819,4 +1819,40 @@ mod tests {
         assert_eq!(whole.len(), 1);
         assert_eq!(whole[0].primitive_ref, Some(PrimitiveRef::User(7)));
     }
+    #[test]
+    fn layer_imaging_tolerates_arcs_a_native_writer_rejects() {
+        // A zero-radius arc is not exportable artwork, but imaging the
+        // layer (copper balance, warp, DFM) must not fail on it.
+        let mut doc = TestDoc::new();
+        doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            [ContourBuf::new(vec![
+                PathCmd::move_to(Point::new(0.0, 0.0)),
+                PathCmd::line_to(Point::new(1.0, 0.0)),
+                PathCmd::arc_to(Point::new(1.0, 0.0), Point::new(1.0, 0.0), false),
+                PathCmd::line_to(Point::new(1.0, 1.0)),
+                PathCmd::line_to(Point::new(0.0, 1.0)),
+                PathCmd::close(),
+            ])],
+        );
+        let mut feature = copper_trace_feature();
+        feature.kind = FeatureKind::Polygon;
+        feature.paths = Span::new(0, 1);
+        doc.features.push(feature);
+        doc.layers.push(test_layer(Span::new(0, 1)));
+        assert!(validate_artwork_ready(&doc).is_err());
+
+        let image = doc
+            .into_layer_image(
+                0,
+                crate::dialects::LayerRole::Copper,
+                crate::dialects::Side::Top,
+                Resolution::default(),
+            )
+            .unwrap();
+
+        assert!((image.area() - 1.0).abs() < 1e-6);
+    }
 }

--- a/crates/pcb-ir/src/dialects/ipc/relief.rs
+++ b/crates/pcb-ir/src/dialects/ipc/relief.rs
@@ -26,11 +26,11 @@
 //! `T_i` is the legal tool-center region, `W_i` is the swept tool area, and
 //! `R_i` is the material-removal region emitted as closed profile contours.
 
+use crate::geom::{AccuracyError, Resolution};
 use std::fmt;
 
 use crate::dialects::ipc::{Document, SpecItemKind};
 use crate::geom::path::{ContourBuf, PathCmd, PathOp};
-use crate::geom::region::{Ring, rings_from_contours, simplify_rings};
 use crate::geom::{BBox, ContourSet, FillRule, PaintKind, Point};
 
 pub const DEFAULT_ROUTE_TOOL_DIAMETER_MM: f64 = 1.0;
@@ -44,19 +44,36 @@ pub struct VScoreReliefInput {
     pub score_blockers: Vec<ContourBuf>,
     pub score_lines: Vec<VScoreLine>,
     pub tool_diameter_mm: f64,
-    pub tolerance_mm: f64,
+    /// Significance of relief geometry and the budget it is prepared at.
+    pub resolution: Resolution,
 }
 
 impl VScoreReliefInput {
     pub fn new(board_boundaries: Vec<ContourBuf>, score_lines: Vec<VScoreLine>) -> Self {
+        Self::with_resolution(
+            board_boundaries,
+            score_lines,
+            Resolution::default().with_tolerance(DEFAULT_RELIEF_TOLERANCE_MM),
+        )
+    }
+
+    pub fn with_resolution(
+        board_boundaries: Vec<ContourBuf>,
+        score_lines: Vec<VScoreLine>,
+        resolution: Resolution,
+    ) -> Self {
         Self {
             board_boundaries,
             board_cutouts: Vec::new(),
             score_blockers: Vec::new(),
             score_lines,
             tool_diameter_mm: DEFAULT_ROUTE_TOOL_DIAMETER_MM,
-            tolerance_mm: DEFAULT_RELIEF_TOLERANCE_MM,
+            resolution,
         }
+    }
+
+    fn tolerance_mm(&self) -> f64 {
+        self.resolution.tolerance_mm
     }
 }
 
@@ -90,6 +107,7 @@ pub struct VScoreReliefDebugEntry {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum VScoreReliefError {
+    Accuracy(AccuracyError),
     EmptyScoreLines,
     InvalidToolDiameter(f64),
     InvalidTolerance(f64),
@@ -100,6 +118,7 @@ pub enum VScoreReliefError {
 impl fmt::Display for VScoreReliefError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Accuracy(error) => error.fmt(f),
             Self::EmptyScoreLines => write!(f, "V-score relief score lines are empty"),
             Self::InvalidToolDiameter(value) => {
                 write!(
@@ -144,8 +163,8 @@ fn vscore_route_reliefs_inner(
             input.tool_diameter_mm,
         ));
     }
-    if !input.tolerance_mm.is_finite() || input.tolerance_mm <= 0.0 {
-        return Err(VScoreReliefError::InvalidTolerance(input.tolerance_mm));
+    if !input.tolerance_mm().is_finite() || input.tolerance_mm() <= 0.0 {
+        return Err(VScoreReliefError::InvalidTolerance(input.tolerance_mm()));
     }
     if input.board_boundaries.is_empty() {
         return Err(VScoreReliefError::EmptyBoundary);
@@ -153,7 +172,7 @@ fn vscore_route_reliefs_inner(
 
     let protected_material = protected_board_material(input)?;
     let mut debug = VScoreReliefDebug::default();
-    let mut relief_contours = Vec::new();
+    let mut relief_region = ContourSet::empty(input.resolution);
     for boundary in &input.board_boundaries {
         let Some(boundary_relief) = boundary_pocket_relief(boundary, &protected_material, input)?
         else {
@@ -162,9 +181,12 @@ fn vscore_route_reliefs_inner(
         if include_debug {
             debug.entries.push(boundary_relief.debug_entry(boundary));
         }
-        relief_contours.extend(boundary_relief.geometry.material_removal.rings);
+        relief_region = relief_region.union(&boundary_relief.geometry.material_removal);
     }
-    let relief_region = ContourSet::new(relief_contours, FillRule::NonZero, input.tolerance_mm);
+    input
+        .resolution
+        .accuracy
+        .check(relief_region.uncertainty_mm)?;
     let relief_payloads = relief_region.to_contours();
     if include_debug {
         debug.merged_relief_contours = relief_payloads.clone();
@@ -308,7 +330,7 @@ fn append_contour_line_segments(cmds: &[PathCmd], lines: &mut Vec<VScoreLine>) {
                 }
                 current = first;
             }
-            PathOp::ArcTo | PathOp::CubicTo => current = cmd.end_point(),
+            PathOp::ArcTo | PathOp::EllipseTo | PathOp::CubicTo => current = cmd.end_point(),
         }
     }
 }
@@ -319,15 +341,17 @@ fn boundary_pocket_relief(
     input: &VScoreReliefInput,
 ) -> Result<Option<BoundaryRelief>, VScoreReliefError> {
     if boundary.bbox.is_empty()
-        || boundary.bbox.width() <= input.tolerance_mm
-        || boundary.bbox.height() <= input.tolerance_mm
+        || boundary.bbox.width() <= input.tolerance_mm()
+        || boundary.bbox.height() <= input.tolerance_mm()
     {
         return Err(VScoreReliefError::InvalidBoundary(
             "boundary has empty bounds",
         ));
     }
 
-    let score_tolerance = input.tolerance_mm.max(DEFAULT_SCORE_ALIGNMENT_TOLERANCE_MM);
+    let score_tolerance = input
+        .tolerance_mm()
+        .max(DEFAULT_SCORE_ALIGNMENT_TOLERANCE_MM);
     let Some(score_cell) =
         score_cell_for_boundary(boundary.bbox, &input.score_lines, score_tolerance)?
     else {
@@ -338,8 +362,8 @@ fn boundary_pocket_relief(
         &input.score_blockers,
         score_cell,
         score_tolerance,
-        input.tolerance_mm,
-    );
+        input.resolution,
+    )?;
     let protected_material = if score_blockers.is_empty() {
         base_protected_material.clone()
     } else {
@@ -353,8 +377,8 @@ fn boundary_pocket_relief(
         score_cell,
         input.tool_diameter_mm / 2.0,
         score_tolerance,
-        input.tolerance_mm,
-    );
+        input.resolution,
+    )?;
     let has_dead_space = !geometry.dead_space.is_empty();
 
     if has_dead_space && geometry.legal_tool_centers.is_empty() {
@@ -405,30 +429,30 @@ fn compute_relief_geometry(
     score_cell: BBox,
     tool_radius: f64,
     score_tolerance: f64,
-    area_tolerance: f64,
-) -> ReliefGeometry {
+    resolution: Resolution,
+) -> Result<ReliefGeometry, AccuracyError> {
     // C_i: the V-score cell around this board instance.
-    let score_cell_region = ContourSet::rectangle(score_cell, area_tolerance);
+    let score_cell_region = ContourSet::rectangle(score_cell, resolution);
     // B_i: this board instance before score-alignment tolerance is applied.
     let current_board = ContourSet::from_contours(
         std::slice::from_ref(boundary),
         FillRule::NonZero,
-        area_tolerance,
-    );
+        resolution,
+    )?;
     // B'_i: absorb tolerance-scale slivers along score-cell edges so tiny
     // source/score mismatches do not become false relief pockets.
-    let aligned_board = score_aligned_board_region(current_board, score_cell, score_tolerance)
+    let aligned_board = score_aligned_board_region(current_board, score_cell, score_tolerance)?
         .difference(score_blockers);
     // P_i = C_i \ B'_i.
     let dead_space = score_cell_region.difference(&aligned_board);
     let (legal_tool_centers, material_removal) =
-        tool_aware_material_removal(&dead_space, protected_material, tool_radius);
+        tool_aware_material_removal(&dead_space, protected_material, tool_radius)?;
 
-    ReliefGeometry {
+    Ok(ReliefGeometry {
         dead_space,
         legal_tool_centers,
         material_removal,
-    }
+    })
 }
 
 /// Compute the tool-center free region and resulting material-removal region.
@@ -441,30 +465,28 @@ fn tool_aware_material_removal(
     dead_space: &ContourSet,
     protected_material: &ContourSet,
     tool_radius: f64,
-) -> (ContourSet, ContourSet) {
+) -> Result<(ContourSet, ContourSet), AccuracyError> {
     // T_i = (P_i ⊕ D_r) \ (B ⊕ D_r).
-    let sacrificial_center_window = dead_space.disk_dilate(tool_radius);
-    let protected_clearance = protected_material.disk_dilate(tool_radius);
+    let sacrificial_center_window = dead_space.disk_dilate(tool_radius)?;
+    let protected_clearance = protected_material.disk_dilate(tool_radius)?;
     let legal_tool_centers = sacrificial_center_window.difference(&protected_clearance);
 
     // W_i = (T_i ⊕ D_r) \ B.
     let tool_sweep = legal_tool_centers
-        .clone()
-        .disk_dilate(tool_radius)
+        .disk_dilate(tool_radius)?
         .difference(protected_material);
 
     // R_i = P_i ∪ W_i.
     let material_removal = dead_space.union(&tool_sweep);
-    (legal_tool_centers, material_removal)
+    Ok((legal_tool_centers, material_removal))
 }
 
 /// Finished-board material that the route tool must not touch.
 fn protected_board_material(input: &VScoreReliefInput) -> Result<ContourSet, VScoreReliefError> {
-    let board_contours = finished_board_contours(&input.board_boundaries)?;
-    let mut board_region = ContourSet::new(board_contours, FillRule::NonZero, input.tolerance_mm);
+    let mut board_region = finished_board_region(&input.board_boundaries, input.resolution)?;
     if !input.board_cutouts.is_empty() {
         let cutout_region =
-            ContourSet::from_filled_contours(&input.board_cutouts, input.tolerance_mm);
+            ContourSet::from_filled_contours(&input.board_cutouts, input.resolution)?;
         board_region = board_region.difference(&cutout_region);
     }
     Ok(board_region)
@@ -474,23 +496,25 @@ fn score_blockers_for_cell(
     score_blockers: &[ContourBuf],
     score_cell: BBox,
     score_tolerance: f64,
-    area_tolerance: f64,
-) -> ContourSet {
+    resolution: Resolution,
+) -> Result<ContourSet, AccuracyError> {
     if score_blockers.is_empty() {
-        return ContourSet::empty(area_tolerance);
+        return Ok(ContourSet::empty(resolution));
     }
-    let score_strip = score_cell_strip_region(score_cell, score_tolerance, area_tolerance);
-    let selected = score_blockers
+    let score_strip = score_cell_strip_region(score_cell, score_tolerance, resolution);
+    let mut selected = Vec::new();
+    for payload in score_blockers
         .iter()
-        .filter(|payload| payload.bbox.intersects(score_strip.bbox))
-        .filter(|payload| {
-            !ContourSet::from_filled_contours(std::slice::from_ref(payload), area_tolerance)
-                .intersection(&score_strip)
-                .is_empty()
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    ContourSet::from_filled_contours(&selected, area_tolerance)
+        .filter(|p| p.bbox.intersects(score_strip.bbox))
+    {
+        if !ContourSet::from_filled_contours(std::slice::from_ref(payload), resolution)?
+            .intersection(&score_strip)
+            .is_empty()
+        {
+            selected.push(payload.clone());
+        }
+    }
+    ContourSet::from_filled_contours(&selected, resolution)
 }
 
 /// Snap tolerance-scale boundary slivers onto score-cell edges.
@@ -502,18 +526,18 @@ fn score_aligned_board_region(
     board: ContourSet,
     score_cell: BBox,
     score_tolerance: f64,
-) -> ContourSet {
-    let cell_strip = score_cell_strip_region(score_cell, score_tolerance, board.tolerance);
+) -> Result<ContourSet, AccuracyError> {
+    let cell_strip = score_cell_strip_region(score_cell, score_tolerance, board.resolution);
     if cell_strip.is_empty() {
-        return board;
+        return Ok(board);
     }
-    let dilated_board = board.disk_dilate(score_tolerance);
+    let dilated_board = board.disk_dilate(score_tolerance)?;
     let score_slivers = cell_strip.intersection(&dilated_board);
-    board.union(&score_slivers)
+    Ok(board.union(&score_slivers))
 }
 
-fn score_cell_strip_region(score_cell: BBox, width: f64, tolerance: f64) -> ContourSet {
-    let cell = ContourSet::rectangle(score_cell, tolerance);
+fn score_cell_strip_region(score_cell: BBox, width: f64, resolution: Resolution) -> ContourSet {
+    let cell = ContourSet::rectangle(score_cell, resolution);
     if score_cell.width() <= 2.0 * width || score_cell.height() <= 2.0 * width {
         return cell;
     }
@@ -521,21 +545,20 @@ fn score_cell_strip_region(score_cell: BBox, width: f64, tolerance: f64) -> Cont
         min: Point::new(score_cell.min.x + width, score_cell.min.y + width),
         max: Point::new(score_cell.max.x - width, score_cell.max.y - width),
     };
-    cell.difference(&ContourSet::rectangle(inner, tolerance))
+    cell.difference(&ContourSet::rectangle(inner, resolution))
 }
 
-fn finished_board_contours(boundaries: &[ContourBuf]) -> Result<Vec<Ring>, VScoreReliefError> {
-    let contours = boundaries
-        .iter()
-        .flat_map(|boundary| rings_from_contours(std::slice::from_ref(boundary)))
-        .collect::<Vec<_>>();
-    let contours = simplify_rings(contours, FillRule::NonZero);
-    if contours.is_empty() {
+fn finished_board_region(
+    boundaries: &[ContourBuf],
+    resolution: Resolution,
+) -> Result<ContourSet, VScoreReliefError> {
+    let region = ContourSet::from_contours(boundaries, FillRule::NonZero, resolution)?;
+    if region.is_empty() {
         Err(VScoreReliefError::InvalidBoundary(
             "boundary does not form a polygon",
         ))
     } else {
-        Ok(contours)
+        Ok(region)
     }
 }
 
@@ -648,6 +671,12 @@ fn rectangle_payload(bbox: BBox) -> ContourBuf {
             PathCmd::close(),
         ],
     )
+}
+
+impl From<AccuracyError> for VScoreReliefError {
+    fn from(error: AccuracyError) -> Self {
+        Self::Accuracy(error)
+    }
 }
 
 #[cfg(test)]

--- a/crates/pcb-ir/src/dialects/ipc/relief.rs
+++ b/crates/pcb-ir/src/dialects/ipc/relief.rs
@@ -172,7 +172,9 @@ fn vscore_route_reliefs_inner(
 
     let protected_material = protected_board_material(input)?;
     let mut debug = VScoreReliefDebug::default();
-    let mut relief_region = ContourSet::empty(input.resolution);
+    // Every board's removal joins one batched union: unioning them one at a
+    // time is quadratic in the board count.
+    let mut removals = Vec::new();
     for boundary in &input.board_boundaries {
         let Some(boundary_relief) = boundary_pocket_relief(boundary, &protected_material, input)?
         else {
@@ -181,12 +183,9 @@ fn vscore_route_reliefs_inner(
         if include_debug {
             debug.entries.push(boundary_relief.debug_entry(boundary));
         }
-        relief_region = relief_region.union(&boundary_relief.geometry.material_removal);
+        removals.push(boundary_relief.geometry.material_removal);
     }
-    input
-        .resolution
-        .accuracy
-        .check(relief_region.uncertainty_mm)?;
+    let relief_region = ContourSet::union_all(input.resolution, removals)?;
     let relief_payloads = relief_region.to_contours();
     if include_debug {
         debug.merged_relief_contours = relief_payloads.clone();

--- a/crates/pcb-ir/src/dialects/ipc/relief.rs
+++ b/crates/pcb-ir/src/dialects/ipc/relief.rs
@@ -366,7 +366,7 @@ fn boundary_pocket_relief(
     let protected_material = if score_blockers.is_empty() {
         base_protected_material.clone()
     } else {
-        base_protected_material.difference(&score_blockers)
+        base_protected_material.difference(&score_blockers)?
     };
 
     let geometry = compute_relief_geometry(
@@ -441,9 +441,9 @@ fn compute_relief_geometry(
     // B'_i: absorb tolerance-scale slivers along score-cell edges so tiny
     // source/score mismatches do not become false relief pockets.
     let aligned_board = score_aligned_board_region(current_board, score_cell, score_tolerance)?
-        .difference(score_blockers);
+        .difference(score_blockers)?;
     // P_i = C_i \ B'_i.
-    let dead_space = score_cell_region.difference(&aligned_board);
+    let dead_space = score_cell_region.difference(&aligned_board)?;
     let (legal_tool_centers, material_removal) =
         tool_aware_material_removal(&dead_space, protected_material, tool_radius)?;
 
@@ -468,15 +468,15 @@ fn tool_aware_material_removal(
     // T_i = (P_i ⊕ D_r) \ (B ⊕ D_r).
     let sacrificial_center_window = dead_space.disk_dilate(tool_radius)?;
     let protected_clearance = protected_material.disk_dilate(tool_radius)?;
-    let legal_tool_centers = sacrificial_center_window.difference(&protected_clearance);
+    let legal_tool_centers = sacrificial_center_window.difference(&protected_clearance)?;
 
     // W_i = (T_i ⊕ D_r) \ B.
     let tool_sweep = legal_tool_centers
         .disk_dilate(tool_radius)?
-        .difference(protected_material);
+        .difference(protected_material)?;
 
     // R_i = P_i ∪ W_i.
-    let material_removal = dead_space.union(&tool_sweep);
+    let material_removal = dead_space.union(&tool_sweep)?;
     Ok((legal_tool_centers, material_removal))
 }
 
@@ -486,7 +486,7 @@ fn protected_board_material(input: &VScoreReliefInput) -> Result<ContourSet, VSc
     if !input.board_cutouts.is_empty() {
         let cutout_region =
             ContourSet::from_filled_contours(&input.board_cutouts, input.resolution)?;
-        board_region = board_region.difference(&cutout_region);
+        board_region = board_region.difference(&cutout_region)?;
     }
     Ok(board_region)
 }
@@ -500,14 +500,14 @@ fn score_blockers_for_cell(
     if score_blockers.is_empty() {
         return Ok(ContourSet::empty(resolution));
     }
-    let score_strip = score_cell_strip_region(score_cell, score_tolerance, resolution);
+    let score_strip = score_cell_strip_region(score_cell, score_tolerance, resolution)?;
     let mut selected = Vec::new();
     for payload in score_blockers
         .iter()
         .filter(|p| p.bbox.intersects(score_strip.bbox))
     {
         if !ContourSet::from_filled_contours(std::slice::from_ref(payload), resolution)?
-            .intersection(&score_strip)
+            .intersection(&score_strip)?
             .is_empty()
         {
             selected.push(payload.clone());
@@ -526,19 +526,23 @@ fn score_aligned_board_region(
     score_cell: BBox,
     score_tolerance: f64,
 ) -> Result<ContourSet, AccuracyError> {
-    let cell_strip = score_cell_strip_region(score_cell, score_tolerance, board.resolution);
+    let cell_strip = score_cell_strip_region(score_cell, score_tolerance, board.resolution)?;
     if cell_strip.is_empty() {
         return Ok(board);
     }
     let dilated_board = board.disk_dilate(score_tolerance)?;
-    let score_slivers = cell_strip.intersection(&dilated_board);
-    Ok(board.union(&score_slivers))
+    let score_slivers = cell_strip.intersection(&dilated_board)?;
+    board.union(&score_slivers)
 }
 
-fn score_cell_strip_region(score_cell: BBox, width: f64, resolution: Resolution) -> ContourSet {
+fn score_cell_strip_region(
+    score_cell: BBox,
+    width: f64,
+    resolution: Resolution,
+) -> Result<ContourSet, AccuracyError> {
     let cell = ContourSet::rectangle(score_cell, resolution);
     if score_cell.width() <= 2.0 * width || score_cell.height() <= 2.0 * width {
-        return cell;
+        return Ok(cell);
     }
     let inner = BBox {
         min: Point::new(score_cell.min.x + width, score_cell.min.y + width),

--- a/crates/pcb-ir/src/dialects/ipc/validate.rs
+++ b/crates/pcb-ir/src/dialects/ipc/validate.rs
@@ -123,6 +123,7 @@ fn validate_path_arcs<Symbol, LayerFunction>(
                     validate_arc_command(feature_index, path_index, cmd_index, current, cmd)?;
                     current = cmd.p0;
                 }
+                PathOp::EllipseTo => current = cmd.p0,
                 PathOp::CubicTo => current = cmd.p2,
                 PathOp::Close => {}
             }

--- a/crates/pcb-ir/src/dialects/mask.rs
+++ b/crates/pcb-ir/src/dialects/mask.rs
@@ -70,9 +70,7 @@ impl<LayerMeta> Document<LayerMeta> {
                 resolution.strict(),
             )
         });
-        let image = ContourSet::union_all(resolution, shapes.collect::<Result<Vec<_>, _>>()?);
-        resolution.accuracy.check(image.uncertainty_mm)?;
-        Ok(image)
+        ContourSet::union_all(resolution, shapes.collect::<Result<Vec<_>, _>>()?)
     }
 
     pub fn shapes(&self, layer: &Layer<LayerMeta>) -> &[Path] {

--- a/crates/pcb-ir/src/dialects/mask.rs
+++ b/crates/pcb-ir/src/dialects/mask.rs
@@ -7,7 +7,9 @@
 
 use crate::dialects::{LayerRole, Side};
 use crate::geom::path::ContourBuf;
-use crate::geom::{BBox, Diagnostic, FillRule, Paint, Path, PathArena, Span};
+use crate::geom::{
+    AccuracyError, BBox, ContourSet, Diagnostic, FillRule, Paint, Path, PathArena, Resolution, Span,
+};
 
 #[derive(Debug, Clone, Default)]
 pub struct Document<LayerMeta = ()> {
@@ -53,6 +55,24 @@ impl<LayerMeta> Document<LayerMeta> {
         layer.shapes.count += 1;
         layer.bbox = layer.bbox.union(bbox);
         path
+    }
+
+    /// Prepare one layer's painted shapes as a single region.
+    pub fn layer_region(
+        &self,
+        layer: &Layer<LayerMeta>,
+        resolution: Resolution,
+    ) -> Result<ContourSet, AccuracyError> {
+        let shapes = self.shapes(layer).iter().map(|shape| {
+            ContourSet::from_contours(
+                &self.arena.path_contours(shape),
+                shape.fill_rule().unwrap_or(FillRule::NonZero),
+                resolution.strict(),
+            )
+        });
+        let image = ContourSet::union_all(resolution, shapes.collect::<Result<Vec<_>, _>>()?);
+        resolution.accuracy.check(image.uncertainty_mm)?;
+        Ok(image)
     }
 
     pub fn shapes(&self, layer: &Layer<LayerMeta>) -> &[Path] {

--- a/crates/pcb-ir/src/geom/accuracy.rs
+++ b/crates/pcb-ir/src/geom/accuracy.rs
@@ -123,7 +123,7 @@ pub struct GeometryAccuracy(f64);
 
 impl Default for GeometryAccuracy {
     fn default() -> Self {
-        Self(0.01)
+        Self::micrometres(10)
     }
 }
 
@@ -133,6 +133,12 @@ impl GeometryAccuracy {
             return Err(AccuracyError::InvalidBudget(max_error_mm));
         }
         Ok(Self(max_error_mm))
+    }
+
+    /// A whole-micrometre budget, usable in constants.
+    pub const fn micrometres(max_error_um: u32) -> Self {
+        assert!(max_error_um > 0, "an accuracy budget must be positive");
+        Self(max_error_um as f64 / 1000.0)
     }
 
     pub fn max_error_mm(self) -> f64 {

--- a/crates/pcb-ir/src/geom/accuracy.rs
+++ b/crates/pcb-ir/src/geom/accuracy.rs
@@ -1,0 +1,220 @@
+//! How geometry is prepared: the feature size worth keeping and the total
+//! boundary approximation allowed.
+//!
+//! Three thresholds govern prepared geometry and they are independent:
+//!
+//! - [`tol::EPSILON_MM`](crate::geom::tol::EPSILON_MM) is numerical
+//!   coincidence.
+//! - [`Resolution::tolerance_mm`] is feature significance and containment
+//!   slack.
+//! - [`GeometryAccuracy`] bounds accumulated approximation. Contours and
+//!   regions carry `uncertainty_mm`, the approximation already present;
+//!   every operation that approximates spends from the region's budget and
+//!   fails when the total would exceed it.
+//!
+//! A budget is chosen once, where source curves are prepared into polygons,
+//! and inherited by everything derived from that preparation. Polygon round
+//! trips cannot recover lost precision, so a coarse preparation is rejected
+//! by a finer request instead of being silently reused.
+
+use std::fmt;
+
+/// The preparation resolution of a region: significance and accuracy
+/// together, chosen once at a preparation entry point and carried by every
+/// region derived from it.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Resolution {
+    /// Minimum significant feature size and containment slack, in
+    /// millimetres. Zero keeps every ring and tests containment exactly.
+    pub tolerance_mm: f64,
+    /// Total accumulated approximation budget.
+    pub accuracy: GeometryAccuracy,
+}
+
+impl Default for Resolution {
+    /// Sub-micrometre significance with the ten micrometre default budget.
+    fn default() -> Self {
+        Self {
+            tolerance_mm: super::tol::REGION_MM,
+            accuracy: GeometryAccuracy::default(),
+        }
+    }
+}
+
+impl Resolution {
+    pub fn new(tolerance_mm: f64, accuracy: GeometryAccuracy) -> Self {
+        Self {
+            tolerance_mm,
+            accuracy,
+        }
+    }
+
+    /// The same budget with a different significance tolerance.
+    pub fn with_tolerance(self, tolerance_mm: f64) -> Self {
+        Self {
+            tolerance_mm,
+            ..self
+        }
+    }
+
+    /// The same significance with a different budget.
+    pub fn with_accuracy(self, accuracy: GeometryAccuracy) -> Self {
+        Self { accuracy, ..self }
+    }
+
+    /// Zero significance: every ring survives and containment is exact.
+    /// Intermediate compositions use this so significance is applied once,
+    /// to the final image.
+    pub fn strict(self) -> Self {
+        self.with_tolerance(0.0)
+    }
+
+    /// The resolution two regions share: this tolerance, the tighter budget.
+    pub(crate) fn meet(self, other: Self) -> Self {
+        Self {
+            tolerance_mm: self.tolerance_mm,
+            accuracy: self.accuracy.min(other.accuracy),
+        }
+    }
+
+    pub(crate) fn is_valid(self) -> bool {
+        self.tolerance_mm.is_finite() && self.tolerance_mm >= 0.0
+    }
+}
+
+/// Budget for accumulated numerical approximation error, in millimetres.
+///
+/// This accounting does not certify topology or final Hausdorff distance.
+/// Independent of feature significance and coincidence. Unmet budgets return
+/// an error, including when earlier approximation cannot be refined.
+///
+/// ```
+/// use pcb_ir::geom::{ContourSet, FillRule, GeometryAccuracy, Resolution, shapes};
+/// let source = shapes::circle(0.2).unwrap();
+/// let resolution = Resolution::new(0.000001, GeometryAccuracy::new(0.0001)?);
+/// let region = ContourSet::from_contours(&[source], FillRule::NonZero, resolution)?;
+/// let inset = region.disk_erode(0.025)?;
+/// assert!(inset.uncertainty_mm <= 0.0005);
+/// # Ok::<(), pcb_ir::geom::AccuracyError>(())
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeometryAccuracy(f64);
+
+impl Default for GeometryAccuracy {
+    fn default() -> Self {
+        Self(0.01)
+    }
+}
+
+impl GeometryAccuracy {
+    pub fn new(max_error_mm: f64) -> Result<Self, AccuracyError> {
+        if !max_error_mm.is_finite() || max_error_mm <= 0.0 {
+            return Err(AccuracyError::InvalidBudget(max_error_mm));
+        }
+        Ok(Self(max_error_mm))
+    }
+
+    pub fn max_error_mm(self) -> f64 {
+        self.0
+    }
+
+    /// The tighter of two budgets.
+    pub fn min(self, other: Self) -> Self {
+        Self(self.0.min(other.0))
+    }
+
+    pub(crate) fn remaining(self, uncertainty_mm: f64) -> Result<f64, AccuracyError> {
+        let remaining = self.0 - uncertainty_mm;
+        if remaining > 0.0 && uncertainty_mm >= 0.0 {
+            Ok(remaining)
+        } else {
+            Err(AccuracyError::BudgetExceeded {
+                requested_mm: self.0,
+                uncertainty_mm,
+            })
+        }
+    }
+
+    pub(crate) fn allowance(self, uncertainty_mm: f64) -> Result<f64, AccuracyError> {
+        Ok(self.remaining(uncertainty_mm)? / 4.0)
+    }
+
+    pub(crate) fn before_transform(
+        self,
+        bbox: super::BBox,
+        transform: super::Affine2,
+    ) -> Result<Self, AccuracyError> {
+        let scale = transform.max_scale();
+        if !scale.is_finite()
+            || scale <= 0.0
+            || transform.determinant() == 0.0
+            || !transform.m02.is_finite()
+            || !transform.m12.is_finite()
+        {
+            return Err(AccuracyError::InvalidGeometry(
+                "singular or non-finite transform",
+            ));
+        }
+        Self::new(self.remaining(numerical_error(bbox.transformed(transform)))? / scale)
+    }
+
+    pub fn check(self, uncertainty_mm: f64) -> Result<(), AccuracyError> {
+        if uncertainty_mm >= 0.0 && uncertainty_mm <= self.0 {
+            Ok(())
+        } else {
+            Err(AccuracyError::BudgetExceeded {
+                requested_mm: self.0,
+                uncertainty_mm,
+            })
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum AccuracyError {
+    InvalidBudget(f64),
+    BudgetExceeded {
+        requested_mm: f64,
+        uncertainty_mm: f64,
+    },
+    InvalidGeometry(&'static str),
+    SubdivisionLimit,
+}
+
+impl fmt::Display for AccuracyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidBudget(mm) => write!(
+                f,
+                "geometry accuracy must be finite and positive, got {mm} mm"
+            ),
+            Self::BudgetExceeded {
+                requested_mm,
+                uncertainty_mm,
+            } => write!(
+                f,
+                "accuracy budget {requested_mm} mm cannot be met (uncertainty: {uncertainty_mm} mm)"
+            ),
+            Self::InvalidGeometry(reason) => write!(f, "cannot prepare geometry: {reason}"),
+            Self::SubdivisionLimit => {
+                f.write_str("requested geometry accuracy exceeds the subdivision limit")
+            }
+        }
+    }
+}
+
+impl std::error::Error for AccuracyError {}
+
+/// Floating arithmetic allowance. Overlay uses an automatic integer grid;
+/// the i64 adapter retains the floating point coordinate precision.
+pub(crate) fn numerical_error(bbox: super::BBox) -> f64 {
+    if bbox.is_empty() {
+        return 0.0;
+    }
+    let extent = (bbox.max.x - bbox.min.x).max(bbox.max.y - bbox.min.y);
+    let magnitude = [bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y]
+        .into_iter()
+        .map(f64::abs)
+        .fold(1.0, f64::max);
+    16.0 * extent / (1_u64 << 52) as f64 + 64.0 * f64::EPSILON * magnitude
+}

--- a/crates/pcb-ir/src/geom/accuracy.rs
+++ b/crates/pcb-ir/src/geom/accuracy.rs
@@ -16,6 +16,27 @@
 //! and inherited by everything derived from that preparation. Polygon round
 //! trips cannot recover lost precision, so a coarse preparation is rejected
 //! by a finer request instead of being silently reused.
+//!
+//! # What `uncertainty_mm` certifies
+//!
+//! Every point of a prepared region's boundary lies within `uncertainty_mm`
+//! of the boundary of the source geometry that produced it. Flattening and
+//! offsets record the chord or join error they introduce; a boolean's
+//! boundary consists of pieces of its operands' boundaries and their
+//! crossings, so it inherits the larger operand uncertainty plus coordinate
+//! rounding. Every operation checks the accumulated total against the
+//! region's budget and fails rather than return a region it cannot certify;
+//! combining regions prepared at different budgets takes the tighter one.
+//!
+//! The band is about the *source* boundary, not the boundary of the exactly
+//! composed set. Two source features that adjoin or overlap along a curve
+//! within their uncertainty can leave a seam or a sliver in the prepared
+//! result that the exact composition would not have. Such artefacts only add
+//! boundary: distances measured to a prepared region are never larger than
+//! the distance to the exact composition, so clearance and width findings
+//! derived from them remain conservative. Consumers that need the exact
+//! composed topology, rather than distances to source boundaries, must
+//! prepare their inputs exactly (zero uncertainty).
 
 use std::fmt;
 

--- a/crates/pcb-ir/src/geom/accuracy.rs
+++ b/crates/pcb-ir/src/geom/accuracy.rs
@@ -32,7 +32,7 @@ pub struct Resolution {
 }
 
 impl Default for Resolution {
-    /// Sub-micrometre significance with the ten micrometre default budget.
+    /// Sub-micrometre significance with the default budget.
     fn default() -> Self {
         Self {
             tolerance_mm: super::tol::REGION_MM,

--- a/crates/pcb-ir/src/geom/affine.rs
+++ b/crates/pcb-ir/src/geom/affine.rs
@@ -88,6 +88,14 @@ impl Affine2 {
         self.m00 * self.m11 - self.m01 * self.m10
     }
 
+    /// Largest singular value: scales a positional error into this frame.
+    pub fn max_scale(&self) -> f64 {
+        let a = self.m00.hypot(self.m10);
+        let b = self.m01.hypot(self.m11);
+        let cross = self.m00 * self.m01 + self.m10 * self.m11;
+        ((a * a + b * b + (a * a - b * b).hypot(2.0 * cross)) / 2.0).sqrt()
+    }
+
     pub fn inverse(&self) -> Option<Self> {
         let det = self.determinant();
         if det == 0.0 || !det.is_finite() {

--- a/crates/pcb-ir/src/geom/arc.rs
+++ b/crates/pcb-ir/src/geom/arc.rs
@@ -1,6 +1,7 @@
 use crate::geom::affine::Affine2;
 use crate::geom::bbox::BBox;
 use crate::geom::point::Point;
+use crate::geom::tol;
 
 /// A circular arc from `start` to `end` around `center`.
 ///
@@ -141,21 +142,22 @@ impl EllipticalArc {
         (self.basis_orientation() >= 0.0) != self.clockwise
     }
 
+    /// Whether the axes span no area at coincidence scale.
     pub fn is_degenerate(&self) -> bool {
-        self.basis_orientation().abs() <= 1e-18
+        self.basis_orientation().abs() <= tol::EPSILON_MM * tol::EPSILON_MM
     }
 
     pub fn is_full_ellipse(&self) -> bool {
-        self.start.distance_to(self.end) <= 1e-9 && !self.is_degenerate()
+        self.start.distance_to(self.end) <= tol::EPSILON_MM && !self.is_degenerate()
     }
 
     /// The parameter of a point on the ellipse.
     pub fn angle_of(&self, point: Point) -> f64 {
         let delta = point - self.center;
-        let det = self.basis_orientation();
-        if det.abs() <= 1e-18 {
+        if self.is_degenerate() {
             return 0.0;
         }
+        let det = self.basis_orientation();
         // Solve [x_axis y_axis]·(cos θ, sin θ) = delta.
         let cos = (delta.x * self.y_axis.y - delta.y * self.y_axis.x) / det;
         let sin = (self.x_axis.x * delta.y - self.x_axis.y * delta.x) / det;

--- a/crates/pcb-ir/src/geom/arc.rs
+++ b/crates/pcb-ir/src/geom/arc.rs
@@ -1,3 +1,4 @@
+use crate::geom::affine::Affine2;
 use crate::geom::bbox::BBox;
 use crate::geom::point::Point;
 
@@ -94,6 +95,182 @@ impl Arc {
             self.center.y + radius * angle.sin(),
         )
     }
+
+    /// The same arc as an elliptical arc with circular axes, the form every
+    /// affine transform preserves.
+    pub fn to_elliptical(&self) -> EllipticalArc {
+        let radius = self.radius();
+        EllipticalArc {
+            start: self.start,
+            end: self.end,
+            center: self.center,
+            x_axis: Point::new(radius, 0.0),
+            y_axis: Point::new(0.0, radius),
+            clockwise: self.clockwise,
+        }
+    }
+}
+
+/// An arc of the affine image of the unit circle: the points
+/// `center + x_axis·cos θ + y_axis·sin θ` between `start` and `end`.
+///
+/// The axes are the images of the unit x and y vectors and need not be
+/// orthogonal; every affine transform of an arc is again an arc of this
+/// form, which keeps the IR closed under placement. `clockwise` is the
+/// geometric winding of travel, as for [`Arc`]. A zero-length chord denotes
+/// the full ellipse.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EllipticalArc {
+    pub start: Point,
+    pub end: Point,
+    pub center: Point,
+    pub x_axis: Point,
+    pub y_axis: Point,
+    pub clockwise: bool,
+}
+
+impl EllipticalArc {
+    /// Signed area of the parallelogram the axes span; its sign says whether
+    /// increasing the parameter travels counter-clockwise.
+    fn basis_orientation(&self) -> f64 {
+        self.x_axis.x * self.y_axis.y - self.x_axis.y * self.y_axis.x
+    }
+
+    /// Whether increasing the parameter travels in this arc's direction.
+    fn parameter_increases(&self) -> bool {
+        (self.basis_orientation() >= 0.0) != self.clockwise
+    }
+
+    pub fn is_degenerate(&self) -> bool {
+        self.basis_orientation().abs() <= 1e-18
+    }
+
+    pub fn is_full_ellipse(&self) -> bool {
+        self.start.distance_to(self.end) <= 1e-9 && !self.is_degenerate()
+    }
+
+    /// The parameter of a point on the ellipse.
+    pub fn angle_of(&self, point: Point) -> f64 {
+        let delta = point - self.center;
+        let det = self.basis_orientation();
+        if det.abs() <= 1e-18 {
+            return 0.0;
+        }
+        // Solve [x_axis y_axis]·(cos θ, sin θ) = delta.
+        let cos = (delta.x * self.y_axis.y - delta.y * self.y_axis.x) / det;
+        let sin = (self.x_axis.x * delta.y - self.x_axis.y * delta.x) / det;
+        sin.atan2(cos)
+    }
+
+    pub fn start_angle(&self) -> f64 {
+        self.angle_of(self.start)
+    }
+
+    /// Parametric sweep in `[0, 2π]`, measured along the arc direction.
+    pub fn sweep_radians(&self) -> f64 {
+        if self.is_full_ellipse() {
+            return std::f64::consts::TAU;
+        }
+        let start = self.start_angle();
+        let end = self.angle_of(self.end);
+        if self.parameter_increases() {
+            normalize_angle(end - start)
+        } else {
+            normalize_angle(start - end)
+        }
+    }
+
+    /// Parametric sweep with the sign of parameter travel.
+    pub fn signed_sweep_radians(&self) -> f64 {
+        if self.parameter_increases() {
+            self.sweep_radians()
+        } else {
+            -self.sweep_radians()
+        }
+    }
+
+    pub fn point_at(&self, angle: f64) -> Point {
+        self.center + self.x_axis * angle.cos() + self.y_axis * angle.sin()
+    }
+
+    /// Largest singular value of the axis basis: the factor that scales a
+    /// unit-circle approximation error onto this ellipse.
+    pub fn max_scale(&self) -> f64 {
+        Affine2 {
+            m00: self.x_axis.x,
+            m01: self.y_axis.x,
+            m02: 0.0,
+            m10: self.x_axis.y,
+            m11: self.y_axis.y,
+            m12: 0.0,
+        }
+        .max_scale()
+    }
+
+    /// Tight bounding box: the endpoints plus every axis extreme the arc
+    /// passes through.
+    pub fn bbox(&self) -> BBox {
+        let mut bbox = BBox::from_point(self.start);
+        bbox.include_point(self.end);
+        if self.is_degenerate() {
+            return bbox;
+        }
+        let start = self.start_angle();
+        let sweep = self.signed_sweep_radians();
+        // x(θ) is extreme where −x_axis.x·sin θ + y_axis.x·cos θ = 0, and
+        // likewise for y; each gives two antipodal parameters.
+        for (a, b) in [
+            (self.x_axis.x, self.y_axis.x),
+            (self.x_axis.y, self.y_axis.y),
+        ] {
+            let base = b.atan2(a);
+            for angle in [base, base + std::f64::consts::PI] {
+                let offset = if sweep >= 0.0 {
+                    normalize_angle(angle - start)
+                } else {
+                    normalize_angle(start - angle)
+                };
+                if offset <= sweep.abs() + 1e-12 {
+                    bbox.include_point(self.point_at(angle));
+                }
+            }
+        }
+        bbox
+    }
+
+    /// Principal semi-axes and the rotation of the major axis, for formats
+    /// that describe ellipses by radii and rotation.
+    pub fn principal_axes(&self) -> (f64, f64, f64) {
+        let (a, b, c, d) = (self.x_axis.x, self.y_axis.x, self.x_axis.y, self.y_axis.y);
+        let e = (a + d) / 2.0;
+        let f = (a - d) / 2.0;
+        let g = (c + b) / 2.0;
+        let h = (c - b) / 2.0;
+        let q = e.hypot(h);
+        let r = f.hypot(g);
+        let major = q + r;
+        let minor = (q - r).abs();
+        let rotation = (g.atan2(f) + h.atan2(e)) / 2.0;
+        (major, minor, rotation)
+    }
+
+    /// Exact image under an affine transform.
+    pub fn transformed(&self, transform: Affine2) -> Self {
+        let linear = |p: Point| {
+            Point::new(
+                transform.m00 * p.x + transform.m01 * p.y,
+                transform.m10 * p.x + transform.m11 * p.y,
+            )
+        };
+        Self {
+            start: transform.transform_point(self.start),
+            end: transform.transform_point(self.end),
+            center: transform.transform_point(self.center),
+            x_axis: linear(self.x_axis),
+            y_axis: linear(self.y_axis),
+            clockwise: self.clockwise != (transform.determinant() < 0.0),
+        }
+    }
 }
 
 fn angle_is_on_arc(start: f64, end: f64, angle: f64, clockwise: bool) -> bool {
@@ -110,4 +287,52 @@ fn angle_is_on_arc(start: f64, end: f64, angle: f64, clockwise: bool) -> bool {
 
 pub(crate) fn normalize_angle(angle: f64) -> f64 {
     angle.rem_euclid(std::f64::consts::TAU)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn elliptical_arc_matches_its_circular_source_under_scaling() {
+        let arc = Arc::new(
+            Point::new(1.0, 0.0),
+            Point::new(0.0, 1.0),
+            Point::ZERO,
+            false,
+        );
+        let scaled = arc.to_elliptical().transformed(Affine2 {
+            m00: 2.0,
+            m11: 0.5,
+            ..Affine2::IDENTITY
+        });
+        assert!((scaled.sweep_radians() - std::f64::consts::FRAC_PI_2).abs() < 1e-12);
+        let mid = scaled.point_at(scaled.start_angle() + scaled.signed_sweep_radians() / 2.0);
+        assert!((mid.x - 2.0 * 0.5_f64.sqrt()).abs() < 1e-12);
+        assert!((mid.y - 0.5 * 0.5_f64.sqrt()).abs() < 1e-12);
+        let bbox = scaled.bbox();
+        assert!((bbox.max.x - 2.0).abs() < 1e-12 && (bbox.max.y - 0.5).abs() < 1e-12);
+        let (major, minor, _) = scaled.principal_axes();
+        assert!((major - 2.0).abs() < 1e-12 && (minor - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn mirroring_flips_geometric_winding_but_keeps_the_arc() {
+        let arc = Arc::new(
+            Point::new(1.0, 0.0),
+            Point::new(0.0, 1.0),
+            Point::ZERO,
+            false,
+        )
+        .to_elliptical();
+        let mirrored = arc.transformed(Affine2 {
+            m00: -1.0,
+            ..Affine2::IDENTITY
+        });
+        assert!(mirrored.clockwise);
+        assert!((mirrored.sweep_radians() - std::f64::consts::FRAC_PI_2).abs() < 1e-12);
+        let mid = mirrored.point_at(mirrored.start_angle() + mirrored.signed_sweep_radians() / 2.0);
+        assert!((mid.x + 0.5_f64.sqrt()).abs() < 1e-12);
+        assert!((mid.y - 0.5_f64.sqrt()).abs() < 1e-12);
+    }
 }

--- a/crates/pcb-ir/src/geom/copper_balance/lattice.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/lattice.rs
@@ -224,7 +224,7 @@ fn fully_contained_hexagons(
     profile: DenseCopperBalanceProfile,
 ) -> Result<Vec<bool>, AccuracyError> {
     let candidates = uniform_candidates(centers, profile.max_void_radius_mm);
-    let outside = hexagon_set_with_radii(&candidates, voidable.resolution)?.difference(voidable);
+    let outside = hexagon_set_with_radii(&candidates, voidable.resolution)?.difference(voidable)?;
     let outside_points = representative_points(&outside);
     Ok(candidate_point_mask(
         &candidates,
@@ -246,7 +246,7 @@ fn accepted_candidate_mask(
     candidates: &[(Point, f64)],
     profile: DenseCopperBalanceProfile,
 ) -> Result<Vec<bool>, AccuracyError> {
-    let raw = hexagon_set_with_radii(candidates, voidable.resolution)?.intersection(voidable);
+    let raw = hexagon_set_with_radii(candidates, voidable.resolution)?.intersection(voidable)?;
     let (core_points, slack_mm) = minimum_disk_core_points(&raw, voidable, candidates, profile)?;
     Ok(candidate_point_mask(
         candidates,
@@ -263,7 +263,7 @@ pub(super) fn clipped_partial_voids(
     candidates: &[(Point, f64)],
     profile: DenseCopperBalanceProfile,
 ) -> Result<ContourSet, AccuracyError> {
-    let raw = hexagon_set_with_radii(candidates, voidable.resolution)?.intersection(voidable);
+    let raw = hexagon_set_with_radii(candidates, voidable.resolution)?.intersection(voidable)?;
     let (mut core_points, _) = minimum_disk_core_points(&raw, voidable, candidates, profile)?;
     core_points.sort_by(|left, right| left.x.total_cmp(&right.x));
     let rings = raw

--- a/crates/pcb-ir/src/geom/copper_balance/lattice.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/lattice.rs
@@ -1,14 +1,14 @@
 //! Hexagonal void lattice: site enumeration and addressing, containment
 //! classification, per-site activation radii, and the rounded-hex template.
 
+use crate::geom::{AccuracyError, Resolution};
 use std::f64::consts::PI;
 
 use super::{
     DenseCopperBalanceProfile, DenseCopperLattice, DenseCopperLatticeSite, DenseCopperVoid, SQRT_3,
 };
-use crate::geom::path::transform_cmds;
 use crate::geom::shapes;
-use crate::geom::{Affine2, BBox, ContourBuf, ContourSet, FillRule, Point, tol};
+use crate::geom::{Affine2, BBox, ContourBuf, ContourSet, Point};
 
 pub const ROUNDED_HEXAGON_CORNER_RADIUS_RATIO: f64 = 0.15;
 // A sharp regular hexagon has area 3√3 R² / 2. Rounding each 120° corner
@@ -26,29 +26,29 @@ pub(super) struct LatticeCandidates {
 }
 
 impl LatticeCandidates {
-    pub(super) fn new(
+    pub(super) fn build_lattice(
         voidable: &ContourSet,
         origin: Point,
         profile: DenseCopperBalanceProfile,
-    ) -> Self {
+    ) -> Result<Self, AccuracyError> {
         let lattice = DenseCopperLattice {
             origin,
             pitch_mm: profile.pitch_mm,
         };
         if voidable.is_empty() {
-            return Self {
+            return Ok(Self {
                 lattice,
                 full_sites: Vec::new(),
                 edge_candidates: Vec::new(),
-            };
+            });
         }
 
-        let candidate_region = voidable.disk_dilate(profile.max_void_radius_mm);
+        let candidate_region = voidable.disk_dilate(profile.max_void_radius_mm)?;
         let centers = hex_aligned_lattice_centers(candidate_region.bbox, origin, profile)
             .into_iter()
             .filter(|center| candidate_region.contains_point(*center))
             .collect::<Vec<_>>();
-        let fully_contained = fully_contained_hexagons(voidable, &centers, profile);
+        let fully_contained = fully_contained_hexagons(voidable, &centers, profile)?;
         let mut full_sites = Vec::new();
         let mut edge_centers = Vec::new();
         for (center, full) in centers.into_iter().zip(fully_contained) {
@@ -59,18 +59,18 @@ impl LatticeCandidates {
                 edge_centers.push(center);
             }
         }
-        let edge_candidates = minimum_partial_candidates(voidable, &edge_centers, profile)
+        let edge_candidates = minimum_partial_candidates(voidable, &edge_centers, profile)?
             .into_iter()
             .map(|(center, radius)| {
                 let (column, row) = lattice_index(center, origin, profile);
                 (DenseCopperLatticeSite { column, row }, radius)
             })
             .collect();
-        Self {
+        Ok(Self {
             lattice,
             full_sites,
             edge_candidates,
-        }
+        })
     }
 
     pub(super) fn is_empty(&self) -> bool {
@@ -100,7 +100,7 @@ impl LatticeCandidates {
         voidable: &ContourSet,
         radius: f64,
         profile: DenseCopperBalanceProfile,
-    ) -> ContourSet {
+    ) -> Result<ContourSet, AccuracyError> {
         let candidates = self
             .lattice
             .void_candidates(&self.edge_voids(radius, profile));
@@ -112,8 +112,8 @@ impl LatticeCandidates {
         voidable: &ContourSet,
         radius: f64,
         profile: DenseCopperBalanceProfile,
-    ) -> f64 {
-        self.full_void_area(radius) + self.partial_voids(voidable, radius, profile).area()
+    ) -> Result<f64, AccuracyError> {
+        Ok(self.full_void_area(radius) + self.partial_voids(voidable, radius, profile)?.area())
     }
 }
 
@@ -155,17 +155,18 @@ fn minimum_partial_candidates(
     voidable: &ContourSet,
     centers: &[Point],
     profile: DenseCopperBalanceProfile,
-) -> Vec<(Point, f64)> {
+) -> Result<Vec<(Point, f64)>, AccuracyError> {
+    let accuracy = voidable.budget();
     if centers.is_empty() {
-        return Vec::new();
+        return Ok(Vec::new());
     }
 
     let min_radius = profile.min_void_radius_mm;
     let max_radius = profile.max_void_radius_mm;
     let min_trials = uniform_candidates(centers, min_radius);
     let max_trials = uniform_candidates(centers, max_radius);
-    let accepted_at_min = accepted_candidate_mask(voidable, &min_trials, profile);
-    let accepted_at_max = accepted_candidate_mask(voidable, &max_trials, profile);
+    let accepted_at_min = accepted_candidate_mask(voidable, &min_trials, profile)?;
+    let accepted_at_max = accepted_candidate_mask(voidable, &max_trials, profile)?;
     let mut bounds = accepted_at_min
         .into_iter()
         .zip(accepted_at_max)
@@ -184,7 +185,11 @@ fn minimum_partial_candidates(
             .enumerate()
             .filter_map(|(index, (center, bounds))| {
                 let &(low, high) = bounds.as_ref()?;
-                (high - low > tol::FLATTEN_MM).then_some((index, center, (low + high) / 2.0))
+                (high - low > accuracy.max_error_mm()).then_some((
+                    index,
+                    center,
+                    (low + high) / 2.0,
+                ))
             })
             .collect::<Vec<_>>();
         if trials.is_empty() {
@@ -194,7 +199,7 @@ fn minimum_partial_candidates(
             .iter()
             .map(|(_, center, radius)| (*center, *radius))
             .collect::<Vec<_>>();
-        let accepted = accepted_candidate_mask(voidable, &trial_geometry, profile);
+        let accepted = accepted_candidate_mask(voidable, &trial_geometry, profile)?;
         for ((index, _, radius), accepted) in trials.into_iter().zip(accepted) {
             let (low, high) = bounds[index].as_mut().expect("trial has radius bounds");
             if accepted {
@@ -205,26 +210,31 @@ fn minimum_partial_candidates(
         }
     }
 
-    centers
+    Ok(centers
         .iter()
         .copied()
         .zip(bounds)
         .filter_map(|(center, bounds)| bounds.map(|(_, high)| (center, high)))
-        .collect()
+        .collect())
 }
 
 fn fully_contained_hexagons(
     voidable: &ContourSet,
     centers: &[Point],
     profile: DenseCopperBalanceProfile,
-) -> Vec<bool> {
+) -> Result<Vec<bool>, AccuracyError> {
     let candidates = uniform_candidates(centers, profile.max_void_radius_mm);
-    let outside = hexagon_set_with_radii(&candidates, voidable.tolerance).difference(voidable);
+    let outside = hexagon_set_with_radii(&candidates, voidable.resolution)?.difference(voidable);
     let outside_points = representative_points(&outside);
-    candidate_point_mask(&candidates, &outside_points, profile)
-        .into_iter()
-        .map(|has_outside_point| !has_outside_point)
-        .collect()
+    Ok(candidate_point_mask(
+        &candidates,
+        &outside_points,
+        profile,
+        outside.uncertainty_mm,
+    )
+    .into_iter()
+    .map(|has_outside_point| !has_outside_point)
+    .collect())
 }
 
 fn uniform_candidates(centers: &[Point], radius: f64) -> Vec<(Point, f64)> {
@@ -235,10 +245,15 @@ fn accepted_candidate_mask(
     voidable: &ContourSet,
     candidates: &[(Point, f64)],
     profile: DenseCopperBalanceProfile,
-) -> Vec<bool> {
-    let raw = hexagon_set_with_radii(candidates, voidable.tolerance).intersection(voidable);
-    let core_points = minimum_disk_core_points(&raw, voidable, candidates, profile);
-    candidate_point_mask(candidates, &core_points, profile)
+) -> Result<Vec<bool>, AccuracyError> {
+    let raw = hexagon_set_with_radii(candidates, voidable.resolution)?.intersection(voidable);
+    let (core_points, slack_mm) = minimum_disk_core_points(&raw, voidable, candidates, profile)?;
+    Ok(candidate_point_mask(
+        candidates,
+        &core_points,
+        profile,
+        slack_mm,
+    ))
 }
 
 /// The clipped partial-void geometry the solver accounts with: components of
@@ -247,9 +262,9 @@ pub(super) fn clipped_partial_voids(
     voidable: &ContourSet,
     candidates: &[(Point, f64)],
     profile: DenseCopperBalanceProfile,
-) -> ContourSet {
-    let raw = hexagon_set_with_radii(candidates, voidable.tolerance).intersection(voidable);
-    let mut core_points = minimum_disk_core_points(&raw, voidable, candidates, profile);
+) -> Result<ContourSet, AccuracyError> {
+    let raw = hexagon_set_with_radii(candidates, voidable.resolution)?.intersection(voidable);
+    let (mut core_points, _) = minimum_disk_core_points(&raw, voidable, candidates, profile)?;
     core_points.sort_by(|left, right| left.x.total_cmp(&right.x));
     let rings = raw
         .connected_components()
@@ -257,7 +272,11 @@ pub(super) fn clipped_partial_voids(
         .filter(|component| component_contains_any_point(component, &core_points))
         .flat_map(|component| component.rings)
         .collect();
-    ContourSet::new(rings, FillRule::NonZero, voidable.tolerance)
+    Ok(ContourSet::from_regularized(
+        rings,
+        raw.resolution,
+        raw.uncertainty_mm,
+    ))
 }
 
 /// The emitted form of the clipped partial voids: opened at the profile's
@@ -267,20 +286,23 @@ pub(super) fn emission_partial_voids(
     voidable: &ContourSet,
     candidates: &[(Point, f64)],
     profile: DenseCopperBalanceProfile,
-) -> ContourSet {
-    clipped_partial_voids(voidable, candidates, profile)
-        .disk_open(profile.void_regularization_radius_mm())
-        .decimate_inward(tol::FLATTEN_MM)
+) -> Result<ContourSet, AccuracyError> {
+    let clipped = clipped_partial_voids(voidable, candidates, profile)?
+        .disk_open(profile.void_regularization_radius_mm())?;
+    clipped.decimate_inward(clipped.budget().max_error_mm())
 }
 
+/// Points proving where the minimum partial-void disk fits, with the
+/// positional uncertainty of the eroded region they were read from.
 fn minimum_disk_core_points(
     raw: &ContourSet,
     voidable: &ContourSet,
     candidates: &[(Point, f64)],
     profile: DenseCopperBalanceProfile,
-) -> Vec<Point> {
+) -> Result<(Vec<Point>, f64), AccuracyError> {
     let minimum_radius = profile.minimum_partial_void_inradius_mm();
-    let mut points = representative_points(&raw.disk_erode(minimum_radius));
+    let core = raw.disk_erode(minimum_radius)?;
+    let mut points = representative_points(&core);
     // Preserve the exact equality case: a clipped void exactly one minimum
     // disk in diameter erodes to a degenerate point or segment that falls
     // below the ring-area floor, even though the disk itself fits.
@@ -289,7 +311,7 @@ fn minimum_disk_core_points(
             .contains_disk(*center, minimum_radius)
             .then_some(*center)
     }));
-    points
+    Ok((points, core.uncertainty_mm))
 }
 
 fn representative_points(region: &ContourSet) -> Vec<Point> {
@@ -306,11 +328,14 @@ fn representative_points(region: &ContourSet) -> Vec<Point> {
 /// The candidate hexagons are pairwise disjoint, so hexagon membership
 /// identifies the unique owner of every point produced by boolean operations
 /// over their union — corner rounding only removes area strictly inside the
-/// sharp hexagon.
+/// sharp hexagon. `slack_mm` is the positional uncertainty of the region the
+/// points were read from, so a point that the boolean pipeline moved off a
+/// hexagon edge still finds its owner.
 fn candidate_point_mask(
     candidates: &[(Point, f64)],
     points: &[Point],
     profile: DenseCopperBalanceProfile,
+    slack_mm: f64,
 ) -> Vec<bool> {
     let mut matched = vec![false; candidates.len()];
     let mut by_x = candidates
@@ -319,15 +344,13 @@ fn candidate_point_mask(
         .map(|(index, (center, radius))| (index, *center, *radius))
         .collect::<Vec<_>>();
     by_x.sort_by(|left, right| left.1.x.total_cmp(&right.1.x));
-    let search_radius = profile.max_void_radius_mm + tol::FLATTEN_MM;
+    let search_radius = profile.max_void_radius_mm + slack_mm;
     for point in points {
         let first = by_x.partition_point(|(_, center, _)| center.x < point.x - search_radius);
         let owner = by_x[first..]
             .iter()
             .take_while(|(_, center, _)| center.x <= point.x + search_radius)
-            .find(|&&(_, center, radius)| {
-                hexagon_contains(center, radius, *point, tol::FLATTEN_MM)
-            });
+            .find(|&&(_, center, radius)| hexagon_contains(center, radius, *point, slack_mm));
         if let Some((index, _, _)) = owner {
             matched[*index] = true;
         }
@@ -360,15 +383,18 @@ fn component_contains_any_point(component: &ContourSet, points: &[Point]) -> boo
         })
 }
 
-pub(super) fn hexagon_set_with_radii(candidates: &[(Point, f64)], tolerance: f64) -> ContourSet {
+pub(super) fn hexagon_set_with_radii(
+    candidates: &[(Point, f64)],
+    resolution: Resolution,
+) -> Result<ContourSet, AccuracyError> {
     let contours = candidates
         .iter()
         .map(|(center, radius)| {
             let hexagon = rounded_hexagonal_void(*radius).expect("candidate radius is validated");
-            transform_cmds(hexagon.cmds.iter().copied(), Affine2::translation(*center))
+            hexagon.transformed(Affine2::translation(*center))
         })
         .collect::<Vec<_>>();
-    ContourSet::from_filled_contours(&contours, tolerance)
+    ContourSet::from_filled_contours(&contours, resolution)
 }
 
 /// One slightly rounded, flat-top regular hexagonal void centered at zero.
@@ -379,13 +405,13 @@ pub fn rounded_hexagonal_void(radius: f64) -> Option<ContourBuf> {
 pub(super) fn void_set(
     voids: &[DenseCopperVoid],
     lattice: DenseCopperLattice,
-    tolerance: f64,
-) -> ContourSet {
+    resolution: Resolution,
+) -> Result<ContourSet, AccuracyError> {
     let candidates = voids
         .iter()
         .map(|void| (lattice.center(void.site), void.radius_mm))
         .collect::<Vec<_>>();
-    hexagon_set_with_radii(&candidates, tolerance)
+    hexagon_set_with_radii(&candidates, resolution)
 }
 
 pub(super) fn lattice_index(
@@ -402,16 +428,22 @@ pub(super) fn lattice_index(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::geom::{BBox, ContourSet, PathOp, Point, tol};
+    fn res(tolerance_mm: f64) -> Resolution {
+        Resolution::default().with_tolerance(tolerance_mm)
+    }
+
+    use crate::geom::tol;
+    use crate::geom::{BBox, ContourSet, PathOp, Point};
 
     #[test]
     fn rejects_partial_voids_that_cannot_hold_the_minimum_disk() {
         let profile = DenseCopperBalanceProfile::V1;
         let voidable = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(0.15, 10.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let lattice = LatticeCandidates::new(&voidable, Point::new(0.0, 0.0), profile);
+        let lattice =
+            LatticeCandidates::build_lattice(&voidable, Point::new(0.0, 0.0), profile).unwrap();
 
         assert!(lattice.edge_candidates.is_empty());
     }
@@ -421,13 +453,13 @@ mod tests {
         let profile = DenseCopperBalanceProfile::V1;
         let voidable = ContourSet::rectangle(
             BBox::new(Point::new(-0.66, -0.57), Point::new(0.66, 0.57)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let center = Point::new(0.0, 0.0);
 
         assert!(!voidable.contains_disk(center, profile.max_void_radius_mm));
         assert_eq!(
-            fully_contained_hexagons(&voidable, &[center], profile),
+            fully_contained_hexagons(&voidable, &[center], profile).unwrap(),
             vec![true]
         );
     }
@@ -437,17 +469,20 @@ mod tests {
         let profile = DenseCopperBalanceProfile::V1;
         let voidable = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(4.0, 4.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let centers = hex_aligned_lattice_centers(
-            voidable.disk_dilate(profile.max_void_radius_mm).bbox,
+            voidable
+                .disk_dilate(profile.max_void_radius_mm)
+                .unwrap()
+                .bbox,
             Point::new(0.0, 0.0),
             profile,
         );
         let mut previously_accepted = vec![false; centers.len()];
         for radius in [0.20, 0.30, 0.40, 0.50, 0.60, 0.65] {
             let candidates = uniform_candidates(&centers, radius);
-            let accepted = accepted_candidate_mask(&voidable, &candidates, profile);
+            let accepted = accepted_candidate_mask(&voidable, &candidates, profile).unwrap();
             assert!(
                 previously_accepted
                     .iter()
@@ -475,7 +510,7 @@ mod tests {
             );
         }
 
-        let region = ContourSet::from_filled_contours(&[hexagon], tol::REGION_MM);
+        let region = ContourSet::from_filled_contours(&[hexagon], res(tol::REGION_MM)).unwrap();
         let expected_area = ROUNDED_HEXAGON_AREA_FACTOR * radius.powi(2);
         assert!(
             (region.area() - expected_area).abs() <= expected_area * 2e-3,

--- a/crates/pcb-ir/src/geom/copper_balance/lattice.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/lattice.rs
@@ -289,7 +289,7 @@ pub(super) fn emission_partial_voids(
 ) -> Result<ContourSet, AccuracyError> {
     let clipped = clipped_partial_voids(voidable, candidates, profile)?
         .disk_open(profile.void_regularization_radius_mm())?;
-    clipped.decimate_inward(clipped.budget().max_error_mm())
+    clipped.decimate_inward()
 }
 
 /// Points proving where the minimum partial-void disk fits, with the

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -439,7 +439,8 @@ impl EdgeVoidEmission {
             &lattice.void_candidates(&crossing),
             profile,
         )?;
-        let region = lattice::void_set(&instanced, lattice, voidable.resolution)?.union(&clipped);
+        let region =
+            lattice::void_set(&instanced, lattice, voidable.resolution)?.union(&clipped)?;
         Ok(Self {
             instanced,
             clipped,
@@ -471,7 +472,7 @@ impl DenseCopperBalanceResult {
         Some((min, max))
     }
 
-    pub fn boundary_web(&self) -> ContourSet {
+    pub fn boundary_web(&self) -> Result<ContourSet, AccuracyError> {
         self.usable.difference(&self.voidable)
     }
 }
@@ -995,9 +996,9 @@ pub fn generate_spatial_dense_copper_balance(
 /// test here. A genuine containment error — a domain that omits real copper or
 /// real fillable material — is orders of magnitude above this bound, which is
 /// itself far below the smallest void the profile can place.
-fn contains(outer: &ContourSet, inner: &ContourSet) -> bool {
-    let leftover = inner.difference(outer);
-    leftover.is_empty() || leftover.area() <= CONTAINMENT_AREA_TOLERANCE_MM2
+fn contains(outer: &ContourSet, inner: &ContourSet) -> Result<bool, AccuracyError> {
+    let leftover = inner.difference(outer)?;
+    Ok(leftover.is_empty() || leftover.area() <= CONTAINMENT_AREA_TOLERANCE_MM2)
 }
 
 fn validate_spatial_request(
@@ -1028,19 +1029,19 @@ fn validate_spatial_request(
             domain.rings == layer.density_domain.rings
                 && safe_region.rings == layer.safe_region.rings
         }) {
-            if !contains(request.panel_region, layer.density_domain) {
+            if !contains(request.panel_region, layer.density_domain)? {
                 return Err(DenseCopperBalanceError::InvalidInput(
                     "density domain must be contained by the panel region".to_string(),
                 ));
             }
-            if !contains(layer.density_domain, layer.safe_region) {
+            if !contains(layer.density_domain, layer.safe_region)? {
                 return Err(DenseCopperBalanceError::InvalidInput(
                     "safe region must be contained by the density domain".to_string(),
                 ));
             }
             certified.push((layer.density_domain, layer.safe_region));
         }
-        if !contains(layer.density_domain, layer.existing_copper) {
+        if !contains(layer.density_domain, layer.existing_copper)? {
             return Err(DenseCopperBalanceError::InvalidInput(
                 "existing copper must be contained by the density domain".to_string(),
             ));
@@ -1049,7 +1050,7 @@ fn validate_spatial_request(
         // rather than by a shared edge, so their overlap needs no tolerance.
         if !layer
             .safe_region
-            .intersection(layer.existing_copper)
+            .intersection(layer.existing_copper)?
             .is_empty()
         {
             return Err(DenseCopperBalanceError::InvalidInput(
@@ -1269,9 +1270,10 @@ mod tests {
             lattice::void_set(&result.edge_voids, result.lattice, resolution)
                 .unwrap()
                 .intersection(&result.voidable)
+                .unwrap()
                 .rings,
         );
-        ContourSet::from_rings(rings, FillRule::NonZero, resolution)
+        ContourSet::from_rings(rings, FillRule::NonZero, resolution).unwrap()
     }
 
     #[test]
@@ -1303,7 +1305,7 @@ mod tests {
         let voidable = safe_region
             .disk_erode(DenseCopperBalanceProfile::V1.boundary_web_mm)
             .unwrap();
-        assert!(voids.difference(&voidable).is_empty());
+        assert!(voids.difference(&voidable).unwrap().is_empty());
         assert!(
             voids
                 .disk_inter_component_gap_violations(
@@ -1358,7 +1360,7 @@ mod tests {
         assert!(void_radius_mm > 0.6, "expected near-maximum voids");
         let voids = result_voids(&result);
         let voidable = safe_region.disk_erode(profile.boundary_web_mm).unwrap();
-        assert!(voids.difference(&voidable).is_empty());
+        assert!(voids.difference(&voidable).unwrap().is_empty());
     }
 
     #[test]
@@ -1615,7 +1617,7 @@ mod tests {
             res(tol::REGION_MM),
         );
         let target_density = existing.area() / footprint.area();
-        let density_domain = footprint.union(&safe);
+        let density_domain = footprint.union(&safe).unwrap();
         let layers = [SpatialCopperBalanceLayerRequest {
             safe_region: &safe,
             existing_copper: &existing,
@@ -1704,10 +1706,10 @@ mod tests {
         .layers;
 
         assert_eq!(results.len(), 2);
-        assert!(results[0].usable.difference(&left).is_empty());
-        assert!(left.difference(&results[0].usable).is_empty());
-        assert!(results[1].usable.difference(&right).is_empty());
-        assert!(right.difference(&results[1].usable).is_empty());
+        assert!(results[0].usable.difference(&left).unwrap().is_empty());
+        assert!(left.difference(&results[0].usable).unwrap().is_empty());
+        assert!(results[1].usable.difference(&right).unwrap().is_empty());
+        assert!(right.difference(&results[1].usable).unwrap().is_empty());
         assert!(
             results[0]
                 .full_voids

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -8,7 +8,7 @@
 use crate::geom::AccuracyError;
 use std::collections::HashMap;
 
-use crate::geom::{ContourSet, Point};
+use crate::geom::{ContourSet, GeometryAccuracy, Point};
 
 mod lattice;
 mod spatial;
@@ -96,6 +96,10 @@ pub struct DenseCopperBalanceProfile {
     ///
     /// Zero pins every layer to its own board density.
     pub stack_flex_density: f64,
+    /// Boundary accuracy the balance geometry is prepared to. Fill geometry
+    /// is bounded by the process rather than measured, so it takes a coarser
+    /// budget than checks do; the construction clearance guard grows with it.
+    pub accuracy: GeometryAccuracy,
 }
 
 impl DenseCopperBalanceProfile {
@@ -109,6 +113,7 @@ impl DenseCopperBalanceProfile {
         density_sigma_mm: 5.0,
         void_area_levels: 20,
         stack_flex_density: 0.05,
+        accuracy: GeometryAccuracy::micrometres(50),
     };
 
     pub fn lattice_column_pitch_mm(self) -> f64 {
@@ -1336,6 +1341,7 @@ mod tests {
             density_sigma_mm: 5.0,
             void_area_levels: 20,
             stack_flex_density: 0.0,
+            accuracy: GeometryAccuracy::micrometres(50),
         };
         profile.validate().unwrap();
         let safe_region = ContourSet::rectangle(

--- a/crates/pcb-ir/src/geom/copper_balance/mod.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/mod.rs
@@ -5,6 +5,7 @@
 //! per-layer areas; the solver chooses the closest manufacturable copper area
 //! and generates a deterministic perforated plane.
 
+use crate::geom::AccuracyError;
 use std::collections::HashMap;
 
 use crate::geom::{ContourSet, Point};
@@ -41,7 +42,7 @@ const SQRT_3: f64 = 1.732_050_807_568_877_2;
 /// Independent per-layer work, in source order. Browsers cannot spawn native
 /// threads; use the identical solve serially there, without requiring workers
 /// or shared WebAssembly memory. Native builds retain per-layer concurrency.
-fn map_layers<T: Send, R: Send>(
+pub fn map_layers<T: Send, R: Send>(
     items: impl IntoIterator<Item = T>,
     solve: impl Fn(T) -> R + Sync,
 ) -> Vec<R> {
@@ -424,23 +425,26 @@ pub struct EdgeVoidEmission {
 }
 
 impl EdgeVoidEmission {
-    fn new(
+    fn build_emission(
         lattice: DenseCopperLattice,
         voidable: &ContourSet,
         edge_voids: &[DenseCopperVoid],
         profile: DenseCopperBalanceProfile,
-    ) -> Self {
+    ) -> Result<Self, AccuracyError> {
         let (instanced, crossing): (Vec<DenseCopperVoid>, Vec<DenseCopperVoid>) = edge_voids
             .iter()
             .partition(|void| voidable.contains_disk(lattice.center(void.site), void.radius_mm));
-        let clipped =
-            lattice::emission_partial_voids(voidable, &lattice.void_candidates(&crossing), profile);
-        let region = lattice::void_set(&instanced, lattice, voidable.tolerance).union(&clipped);
-        Self {
+        let clipped = lattice::emission_partial_voids(
+            voidable,
+            &lattice.void_candidates(&crossing),
+            profile,
+        )?;
+        let region = lattice::void_set(&instanced, lattice, voidable.resolution)?.union(&clipped);
+        Ok(Self {
             instanced,
             clipped,
             region,
-        }
+        })
     }
 
     pub fn area_mm2(&self) -> f64 {
@@ -472,8 +476,9 @@ impl DenseCopperBalanceResult {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum DenseCopperBalanceError {
+    Accuracy(AccuracyError),
     InvalidProfile(String),
     InvalidInput(String),
 }
@@ -481,6 +486,7 @@ pub enum DenseCopperBalanceError {
 impl std::fmt::Display for DenseCopperBalanceError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Accuracy(error) => error.fmt(f),
             Self::InvalidProfile(message) => write!(f, "invalid copper balance profile: {message}"),
             Self::InvalidInput(message) => write!(f, "invalid copper balance input: {message}"),
         }
@@ -504,11 +510,11 @@ pub(crate) fn generate_dense_copper_balance(
     validate_request(request)?;
 
     let usable = request.safe_region.clone();
-    let voidable = usable.disk_erode(profile.boundary_web_mm);
-    let lattice = LatticeCandidates::new(&voidable, request.lattice_origin, profile);
+    let voidable = usable.disk_erode(profile.boundary_web_mm)?;
+    let lattice = LatticeCandidates::build_lattice(&voidable, request.lattice_origin, profile)?;
     Ok(generate_dense_copper_balance_with_lattice(
         profile, request, usable, &voidable, &lattice,
-    ))
+    )?)
 }
 
 fn generate_dense_copper_balance_with_lattice(
@@ -517,7 +523,7 @@ fn generate_dense_copper_balance_with_lattice(
     usable: ContourSet,
     voidable: &ContourSet,
     lattice: &LatticeCandidates,
-) -> DenseCopperBalanceResult {
+) -> Result<DenseCopperBalanceResult, AccuracyError> {
     let usable_area_mm2 = usable.area();
     let desired_added_area_mm2 =
         request.target_density * request.density_domain_area_mm2 - request.existing_copper_area_mm2;
@@ -536,7 +542,7 @@ fn generate_dense_copper_balance_with_lattice(
             voidable,
             usable_area_mm2,
             desired_added_area_mm2,
-        ));
+        )?);
     }
 
     let (full_voids, edge_voids) = match best.mode {
@@ -555,7 +561,8 @@ fn generate_dense_copper_balance_with_lattice(
     };
     // Account generated copper from the emitted geometry, not the solve's
     // projection, so achieved density is truthful to the output.
-    let edge_void_emission = EdgeVoidEmission::new(lattice.lattice, voidable, &edge_voids, profile);
+    let edge_void_emission =
+        EdgeVoidEmission::build_emission(lattice.lattice, voidable, &edge_voids, profile)?;
     let generated_area_mm2 = match best.mode {
         DenseCopperBalanceMode::None => 0.0,
         DenseCopperBalanceMode::Solid => usable_area_mm2,
@@ -579,7 +586,7 @@ fn generate_dense_copper_balance_with_lattice(
         target_density: request.target_density,
         residual_error: (achieved_density - request.target_density).abs(),
     };
-    DenseCopperBalanceResult {
+    Ok(DenseCopperBalanceResult {
         solution,
         lattice: lattice.lattice,
         usable,
@@ -587,7 +594,7 @@ fn generate_dense_copper_balance_with_lattice(
         full_voids,
         edge_voids,
         edge_void_emission,
-    }
+    })
 }
 
 /// Jointly distribute each layer's already-selected copper area in space.
@@ -628,19 +635,19 @@ pub fn generate_spatial_dense_copper_balance(
                 .iter()
                 .position(|region| region.rings == layer.safe_region.rings)
             {
-                return index;
+                return Ok(index);
             }
-            let voidable = layer.safe_region.disk_erode(profile.boundary_web_mm);
-            region_lattices.push(LatticeCandidates::new(
+            let voidable = layer.safe_region.disk_erode(profile.boundary_web_mm)?;
+            region_lattices.push(LatticeCandidates::build_lattice(
                 &voidable,
                 request.lattice_origin,
                 profile,
-            ));
+            )?);
             region_voidable.push(voidable);
             region_sources.push(layer.safe_region);
-            region_sources.len() - 1
+            Ok::<_, AccuracyError>(region_sources.len() - 1)
         })
-        .collect::<Vec<_>>();
+        .collect::<Result<Vec<_>, _>>()?;
     let uniform = map_layers(
         request
             .layers
@@ -662,7 +669,9 @@ pub fn generate_spatial_dense_copper_balance(
                 &region_lattices[*region_index],
             )
         },
-    );
+    )
+    .into_iter()
+    .collect::<Result<Vec<_>, _>>()?;
 
     let mut panel_samples =
         hex_aligned_lattice_centers(request.panel_region.bbox, request.lattice_origin, profile)
@@ -1090,15 +1099,15 @@ fn project_perforated_geometry(
     voidable: &ContourSet,
     usable_area_mm2: f64,
     desired_added_area_mm2: f64,
-) -> ProjectedArea {
+) -> Result<ProjectedArea, AccuracyError> {
     // Each edge site has an activation radius aᵢ. At nominal radius r its
     // clipped hex uses max(r, aᵢ), making total void area monotone in r.
     // Project the requested area onto that one-dimensional feasible set.
     let target_void_area_mm2 = usable_area_mm2 - desired_added_area_mm2;
     let mut low_radius = profile.min_void_radius_mm;
     let mut high_radius = profile.max_void_radius_mm;
-    let low_void_area = lattice.void_area(voidable, low_radius, profile);
-    let high_void_area = lattice.void_area(voidable, high_radius, profile);
+    let low_void_area = lattice.void_area(voidable, low_radius, profile)?;
+    let high_void_area = lattice.void_area(voidable, high_radius, profile)?;
     let mut best = perforated_candidate(
         low_radius,
         low_void_area,
@@ -1113,7 +1122,7 @@ fn project_perforated_geometry(
     ));
 
     if target_void_area_mm2 <= low_void_area || target_void_area_mm2 >= high_void_area {
-        return best;
+        return Ok(best);
     }
 
     // Every candidate evaluation clips the boundary voids against the safe
@@ -1138,7 +1147,7 @@ fn project_perforated_geometry(
             (low_squared + high_squared) / 2.0
         };
         let radius = squared_radius.sqrt();
-        let void_area = lattice.void_area(voidable, radius, profile);
+        let void_area = lattice.void_area(voidable, radius, profile)?;
         best.consider(perforated_candidate(
             radius,
             void_area,
@@ -1153,7 +1162,7 @@ fn project_perforated_geometry(
             high_area = void_area;
         }
     }
-    best
+    Ok(best)
 }
 
 fn perforated_candidate(
@@ -1226,36 +1235,50 @@ fn validate_request(request: DenseCopperBalanceRequest<'_>) -> Result<(), DenseC
     Ok(())
 }
 
+impl From<AccuracyError> for DenseCopperBalanceError {
+    fn from(error: AccuracyError) -> Self {
+        Self::Accuracy(error)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::lattice::hexagon_set_with_radii;
     use super::*;
-    use crate::geom::{BBox, FillRule, Point, tol};
+    use crate::geom::{BBox, FillRule, Point, Resolution, tol};
+
+    fn res(tolerance_mm: f64) -> Resolution {
+        Resolution::default().with_tolerance(tolerance_mm)
+    }
 
     fn result_voids(result: &DenseCopperBalanceResult) -> ContourSet {
+        let resolution = result.usable.resolution;
         match result.solution.mode {
             DenseCopperBalanceMode::Perforated { .. } => {}
-            _ => return ContourSet::empty(result.usable.tolerance),
+            _ => return ContourSet::empty(resolution),
         }
         let candidates = result
             .full_voids
             .iter()
             .map(|void| (result.lattice.center(void.site), void.radius_mm))
             .collect::<Vec<_>>();
-        let mut rings = hexagon_set_with_radii(&candidates, result.usable.tolerance).rings;
+        let mut rings = hexagon_set_with_radii(&candidates, resolution)
+            .unwrap()
+            .rings;
         rings.extend(
-            lattice::void_set(&result.edge_voids, result.lattice, result.usable.tolerance)
+            lattice::void_set(&result.edge_voids, result.lattice, resolution)
+                .unwrap()
                 .intersection(&result.voidable)
                 .rings,
         );
-        ContourSet::new(rings, FillRule::NonZero, result.usable.tolerance)
+        ContourSet::from_rings(rings, FillRule::NonZero, resolution)
     }
 
     #[test]
     fn clipped_lattice_matches_target_and_preserves_both_webs() {
         let safe_region = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 10.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let result = generate_dense_copper_balance(
             DenseCopperBalanceProfile::V1,
@@ -1277,13 +1300,16 @@ mod tests {
         assert!((result.solution.achieved_density - 0.75).abs() <= 5e-3);
         assert!(result.solution.residual_error < (result.solution.initial_density - 0.75).abs());
         let voids = result_voids(&result);
-        let voidable = safe_region.disk_erode(DenseCopperBalanceProfile::V1.boundary_web_mm);
+        let voidable = safe_region
+            .disk_erode(DenseCopperBalanceProfile::V1.boundary_web_mm)
+            .unwrap();
         assert!(voids.difference(&voidable).is_empty());
         assert!(
             voids
                 .disk_inter_component_gap_violations(
                     DenseCopperBalanceProfile::V1.min_copper_web_mm / 2.0
                 )
+                .unwrap()
                 .is_empty()
         );
         let minimum_core_radius = DenseCopperBalanceProfile::V1.minimum_partial_void_inradius_mm();
@@ -1291,7 +1317,7 @@ mod tests {
             voids
                 .connected_components()
                 .into_iter()
-                .all(|void| !void.disk_erode(minimum_core_radius).is_empty())
+                .all(|void| { !void.disk_erode(minimum_core_radius).unwrap().is_empty() })
         );
     }
 
@@ -1312,7 +1338,7 @@ mod tests {
         profile.validate().unwrap();
         let safe_region = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(12.0, 8.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let result = generate_dense_copper_balance(
             profile,
@@ -1331,7 +1357,7 @@ mod tests {
         };
         assert!(void_radius_mm > 0.6, "expected near-maximum voids");
         let voids = result_voids(&result);
-        let voidable = safe_region.disk_erode(profile.boundary_web_mm);
+        let voidable = safe_region.disk_erode(profile.boundary_web_mm).unwrap();
         assert!(voids.difference(&voidable).is_empty());
     }
 
@@ -1339,7 +1365,7 @@ mod tests {
     fn retains_useful_partial_voids_at_the_boundary() {
         let safe_region = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(4.0, 4.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let result = generate_dense_copper_balance(
             DenseCopperBalanceProfile::V1,
@@ -1357,21 +1383,23 @@ mod tests {
             result.solution.mode,
             DenseCopperBalanceMode::Perforated { .. }
         ));
-        let voidable = safe_region.disk_erode(DenseCopperBalanceProfile::V1.boundary_web_mm);
+        let voidable = safe_region
+            .disk_erode(DenseCopperBalanceProfile::V1.boundary_web_mm)
+            .unwrap();
         let voids = result_voids(&result).connected_components();
         let touches_each_boundary = [
-            voids
-                .iter()
-                .any(|void| (void.bbox.min.x - voidable.bbox.min.x).abs() <= 2.0 * tol::FLATTEN_MM),
-            voids
-                .iter()
-                .any(|void| (void.bbox.min.y - voidable.bbox.min.y).abs() <= 2.0 * tol::FLATTEN_MM),
-            voids
-                .iter()
-                .any(|void| (void.bbox.max.x - voidable.bbox.max.x).abs() <= 2.0 * tol::FLATTEN_MM),
-            voids
-                .iter()
-                .any(|void| (void.bbox.max.y - voidable.bbox.max.y).abs() <= 2.0 * tol::FLATTEN_MM),
+            voids.iter().any(|void| {
+                (void.bbox.min.x - voidable.bbox.min.x).abs() <= voidable.budget().max_error_mm()
+            }),
+            voids.iter().any(|void| {
+                (void.bbox.min.y - voidable.bbox.min.y).abs() <= voidable.budget().max_error_mm()
+            }),
+            voids.iter().any(|void| {
+                (void.bbox.max.x - voidable.bbox.max.x).abs() <= voidable.budget().max_error_mm()
+            }),
+            voids.iter().any(|void| {
+                (void.bbox.max.y - voidable.bbox.max.y).abs() <= voidable.budget().max_error_mm()
+            }),
         ];
         assert!(touches_each_boundary.into_iter().all(|touches| touches));
     }
@@ -1380,15 +1408,15 @@ mod tests {
     fn spatial_solver_rejects_existing_copper_in_the_safe_region() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 12.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let safe = ContourSet::rectangle(
             BBox::new(Point::new(10.0, 0.0), Point::new(20.0, 12.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let existing = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(11.0, 12.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let layers = [SpatialCopperBalanceLayerRequest {
             safe_region: &safe,
@@ -1420,17 +1448,17 @@ mod tests {
     fn spatial_solver_rejects_geometry_outside_its_containing_region() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 12.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let inside = ContourSet::rectangle(
             BBox::new(Point::new(10.0, 0.0), Point::new(20.0, 12.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let outside = ContourSet::rectangle(
             BBox::new(Point::new(-1.0, 0.0), Point::new(5.0, 12.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let empty = ContourSet::empty(tol::REGION_MM);
+        let empty = ContourSet::empty(res(tol::REGION_MM));
         let solve = |safe_region, existing_copper, density_domain| {
             let layers = [SpatialCopperBalanceLayerRequest {
                 safe_region,
@@ -1474,14 +1502,16 @@ mod tests {
         let profile = DenseCopperBalanceProfile::V1;
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(24.0, 16.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let voidable = panel.disk_erode(profile.boundary_web_mm);
-        let lattice = LatticeCandidates::new(&voidable, Point::ZERO, profile);
+        let voidable = panel.disk_erode(profile.boundary_web_mm).unwrap();
+        let lattice = LatticeCandidates::build_lattice(&voidable, Point::ZERO, profile).unwrap();
         let target_density = (panel.area()
-            - lattice.void_area(&voidable, profile.min_void_radius_mm, profile))
+            - lattice
+                .void_area(&voidable, profile.min_void_radius_mm, profile)
+                .unwrap())
             / panel.area();
-        let existing = ContourSet::empty(tol::REGION_MM);
+        let existing = ContourSet::empty(res(tol::REGION_MM));
         let layer = SpatialCopperBalanceLayerRequest {
             safe_region: &panel,
             existing_copper: &existing,
@@ -1529,9 +1559,9 @@ mod tests {
     fn spatial_solver_preserves_area_and_radius_bounds_for_constant_inputs() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(24.0, 16.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let existing = ContourSet::empty(tol::REGION_MM);
+        let existing = ContourSet::empty(res(tol::REGION_MM));
         let layers = [SpatialCopperBalanceLayerRequest {
             safe_region: &panel,
             existing_copper: &existing,
@@ -1568,21 +1598,21 @@ mod tests {
     fn unfillable_clearance_stays_out_of_the_density_denominator() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         // An immutable footprint poured to 80%, a gutter beside it, and a wide
         // clearance ring in between that no generated copper may enter.
         let footprint = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let existing = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 16.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let safe = ContourSet::rectangle(
             BBox::new(Point::new(25.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let target_density = existing.area() / footprint.area();
         let density_domain = footprint.union(&safe);
@@ -1632,17 +1662,17 @@ mod tests {
     fn spatial_solver_preserves_each_layers_safe_region() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let left = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let right = ContourSet::rectangle(
             BBox::new(Point::new(20.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let existing = ContourSet::empty(tol::REGION_MM);
+        let existing = ContourSet::empty(res(tol::REGION_MM));
         // Nothing outside each layer's own half can hold copper, so each
         // layer's density domain is exactly its safe region.
         let layers = [
@@ -1696,15 +1726,15 @@ mod tests {
     fn spatial_solver_opposes_a_fixed_copper_gradient_without_changing_total_area() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let existing = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let safe = ContourSet::rectangle(
             BBox::new(Point::new(20.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         // Fixed copper fills the left half and the right half is fillable, so
         // the density domain is the whole panel.
@@ -1769,9 +1799,9 @@ mod tests {
     fn a_solid_layer_leaves_the_counterweight_to_its_mirror() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(30.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let empty = ContourSet::empty(tol::REGION_MM);
+        let empty = ContourSet::empty(res(tol::REGION_MM));
         // A target its whole safe region cannot reach saturates this layer to
         // a solid pour, leaving it no radii while its sites still exist.
         let results = generate_spatial_dense_copper_balance(
@@ -1824,19 +1854,19 @@ mod tests {
     fn layers_hold_their_targets_when_the_stackup_weighs_nothing() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         // Fixed copper on one layer only, so the two layers see different
         // local fields and would trade if anything let them.
         let left_copper = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let safe = ContourSet::rectangle(
             BBox::new(Point::new(20.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let empty = ContourSet::empty(tol::REGION_MM);
+        let empty = ContourSet::empty(res(tol::REGION_MM));
         let results = generate_spatial_dense_copper_balance(
             DenseCopperBalanceProfile::V1,
             SpatialCopperBalanceRequest {
@@ -1879,9 +1909,9 @@ mod tests {
     fn moment_field_records_the_flattening_it_achieved() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let empty = ContourSet::empty(tol::REGION_MM);
+        let empty = ContourSet::empty(res(tol::REGION_MM));
         let solve = |stack_weight_mm2: f64| {
             generate_spatial_dense_copper_balance(
                 DenseCopperBalanceProfile::V1,
@@ -1936,9 +1966,9 @@ mod tests {
     fn stack_moment_shrinks_when_the_boards_themselves_are_asymmetric() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let empty = ContourSet::empty(tol::REGION_MM);
+        let empty = ContourSet::empty(res(tol::REGION_MM));
         // Mirrored layers, no fixed copper, but one is asked for markedly more
         // copper than the other: the imbalance is in the targets themselves.
         let (heavy, light) = (0.70, 0.40);
@@ -2022,17 +2052,17 @@ mod tests {
     fn stack_flex_trades_density_between_mirrored_layers() {
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let left_copper = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let safe = ContourSet::rectangle(
             BBox::new(Point::new(20.0, 0.0), Point::new(40.0, 20.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
-        let empty = ContourSet::empty(tol::REGION_MM);
+        let empty = ContourSet::empty(res(tol::REGION_MM));
         let solve = |stack_flex_density: f64| {
             generate_spatial_dense_copper_balance(
                 DenseCopperBalanceProfile {
@@ -2105,7 +2135,7 @@ mod tests {
     fn area_bounds_tolerate_the_same_slivers_as_containment() {
         let safe_region = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 10.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let existing_copper_area_mm2 = 100.0;
         let exact_domain_area_mm2 = existing_copper_area_mm2 + safe_region.area();
@@ -2128,7 +2158,7 @@ mod tests {
     fn geometric_projection_never_worsens_target_sweep() {
         let safe_region = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(8.0, 5.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         for target_step in 0..=10 {
             let target_density = target_step as f64 / 10.0;

--- a/crates/pcb-ir/src/geom/copper_balance/spatial.rs
+++ b/crates/pcb-ir/src/geom/copper_balance/spatial.rs
@@ -299,7 +299,11 @@ pub(super) fn spatial_result_from_squared_radii(
 mod tests {
     use super::super::lattice::hex_aligned_lattice_centers;
     use super::*;
-    use crate::geom::{BBox, ContourSet, Point, tol};
+    use crate::geom::{BBox, ContourSet, Point, Resolution, tol};
+
+    fn res(tolerance_mm: f64) -> Resolution {
+        Resolution::default().with_tolerance(tolerance_mm)
+    }
 
     /// The projection lands the sum on the target when the box can reach it,
     /// and saturates at the nearer bound when it cannot.
@@ -329,7 +333,7 @@ mod tests {
         let profile = DenseCopperBalanceProfile::V1;
         let panel = ContourSet::rectangle(
             BBox::new(Point::new(0.0, 0.0), Point::new(20.0, 12.0)),
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         let samples = hex_aligned_lattice_centers(panel.bbox, Point::ZERO, profile)
             .into_iter()

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -363,7 +363,7 @@ pub fn region_clearance_sites(
     first: &ContourSet,
     second: &ContourSet,
     minimum_mm: f64,
-) -> Vec<ClearanceSite> {
+) -> Result<Vec<ClearanceSite>, AccuracyError> {
     let index = second.prepare_query();
     region_clearance_sites_with_index(first, second, &index, minimum_mm)
 }
@@ -374,7 +374,7 @@ pub fn region_clearance_sites_with_index(
     second: &ContourSet,
     second_boundary: &PreparedRegion,
     minimum_mm: f64,
-) -> Vec<ClearanceSite> {
+) -> Result<Vec<ClearanceSite>, AccuracyError> {
     let lines = first.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
     let mut sites = linework_clearance_sites(
         &lines,
@@ -383,7 +383,7 @@ pub fn region_clearance_sites_with_index(
         minimum_mm,
         first.uncertainty_mm,
     );
-    for overlap in first.intersection(second).connected_components() {
+    for overlap in first.intersection(second)?.connected_components() {
         let Some(point) = overlap
             .rings
             .first()
@@ -430,11 +430,11 @@ pub fn region_clearance_sites_with_index(
             joined.bbox = joined.bbox.union(site.bbox);
             joined.first_paths.extend(site.first_paths);
             joined.second_paths.extend(site.second_paths);
-            joined.overlap = joined.overlap.union(&site.overlap);
+            joined.overlap = joined.overlap.union(&site.overlap)?;
         }
         sites.push(joined);
     }
-    sites
+    Ok(sites)
 }
 
 /// A local required-clearance band around the supplied reference paths.
@@ -933,7 +933,9 @@ mod tests {
 
     #[test]
     fn clearance_sites_locate_every_disconnected_span_with_threshold_endpoints() {
-        let material = rect_region(2.0, 0.1, 3.0, 1.0).union(&rect_region(7.0, 0.1, 8.0, 1.0));
+        let material = rect_region(2.0, 0.1, 3.0, 1.0)
+            .union(&rect_region(7.0, 0.1, 8.0, 1.0))
+            .unwrap();
         let sites = linework_clearance_sites(
             &[(Point::new(0.0, 0.0), Point::new(10.0, 0.0))],
             &material,
@@ -1018,9 +1020,11 @@ mod tests {
         let first = rect_region(0.0, 0.0, 10.0, 1.0);
         let second = rect_region(2.0, 1.1, 3.0, 4.0)
             .union(&rect_region(7.0, 1.1, 8.0, 4.0))
-            .union(&rect_region(2.0, 3.0, 8.0, 4.0));
+            .unwrap()
+            .union(&rect_region(2.0, 3.0, 8.0, 4.0))
+            .unwrap();
         assert_eq!(second.connected_components().len(), 1);
-        let sites = region_clearance_sites(&first, &second, 0.2);
+        let sites = region_clearance_sites(&first, &second, 0.2).unwrap();
         assert_eq!(sites.len(), 2);
         let authoritative = region_clearance(&first, &second).unwrap().mm;
         assert!(
@@ -1039,7 +1043,7 @@ mod tests {
     fn region_sites_keep_contained_overlap_without_a_near_outer_boundary() {
         let first = rect_region(-5.0, -5.0, 5.0, 5.0);
         let second = rect_region(-0.5, -0.5, 0.5, 0.5);
-        let sites = region_clearance_sites(&first, &second, 0.2);
+        let sites = region_clearance_sites(&first, &second, 0.2).unwrap();
         assert_eq!(sites.len(), 1);
         assert_eq!(sites[0].distance.mm, 0.0);
         assert!((sites[0].overlap.area() - 1.0).abs() < 1e-9);
@@ -1050,7 +1054,7 @@ mod tests {
     fn region_sites_merge_boundary_spans_with_their_shared_overlap() {
         let first = rect_region(0.0, 0.0, 2.0, 2.0);
         let second = rect_region(1.0, 0.5, 3.0, 1.5);
-        let sites = region_clearance_sites(&first, &second, 0.2);
+        let sites = region_clearance_sites(&first, &second, 0.2).unwrap();
         assert_eq!(sites.len(), 1);
         assert_eq!(sites[0].distance.mm, 0.0);
         assert!((sites[0].overlap.area() - 1.0).abs() < 1e-9);
@@ -1211,7 +1215,7 @@ mod tests {
             res(tol::REGION_MM),
         )
         .unwrap();
-        let raw_residue = bulge.difference(&bulge.disk_open(0.5).unwrap());
+        let raw_residue = bulge.difference(&bulge.disk_open(0.5).unwrap()).unwrap();
         assert!(
             !raw_residue.is_empty(),
             "the opening must shed residue here"
@@ -1274,6 +1278,7 @@ mod tests {
         assert!(
             !region
                 .difference(&region.disk_open(candidate_radius).unwrap())
+                .unwrap()
                 .is_empty(),
             "the opening must still localize the one-sided nib"
         );
@@ -1334,7 +1339,11 @@ mod tests {
             res(tol::REGION_MM),
         )
         .unwrap();
-        let raw_residue = chevron.disk_close(0.5).unwrap().difference(&chevron);
+        let raw_residue = chevron
+            .disk_close(0.5)
+            .unwrap()
+            .difference(&chevron)
+            .unwrap();
         assert!(
             !raw_residue.is_empty(),
             "the closing must shed residue here"
@@ -1405,7 +1414,11 @@ mod tests {
         let disk_findings = thin_features(&disk, 0.1).unwrap();
         assert!(disk_findings.is_empty(), "findings: {disk_findings:?}");
         assert_eq!(thin_features(&undersized_disk, 0.1).unwrap().len(), 1);
-        assert!(thin_gaps(&left.union(&right), 0.1).unwrap().is_empty());
+        assert!(
+            thin_gaps(&left.union(&right).unwrap(), 0.1)
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[test]
@@ -1483,7 +1496,7 @@ mod tests {
     fn widths_are_invariant_under_quarter_turns() {
         let left = rect_region(0.0, 0.0, 4.0, 2.0);
         let right = rect_region(4.06, 0.0, 8.0, 2.0);
-        let region = left.union(&right);
+        let region = left.union(&right).unwrap();
         let rotated = ContourSet::from_rings(
             region
                 .rings
@@ -1492,7 +1505,8 @@ mod tests {
                 .collect(),
             FillRule::NonZero,
             res(tol::REGION_MM),
-        );
+        )
+        .unwrap();
 
         let original = thin_gaps(&region, 0.1).unwrap();
         let turned = thin_gaps(&rotated, 0.1).unwrap();

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -5,6 +5,7 @@
 //! it was measured against. Deciding whether a distance violates a limit is
 //! the caller's policy, via [`Distance::certainly_below`].
 
+use crate::geom::{AccuracyError, Resolution};
 use std::collections::BTreeMap;
 
 use crate::geom::bbox::BBox;
@@ -95,11 +96,11 @@ impl PreparedRegion {
         } else {
             direction / direction.length()
         };
-        Some(Distance::flattened(
+        Some(Distance::with_uncertainty(
             nearest.mm - cutout_radius_mm,
             center + direction * cutout_radius_mm,
             nearest.second,
-            1,
+            self.uncertainty_mm,
         ))
     }
 }
@@ -178,7 +179,12 @@ pub fn region_clearance_within(
             )
         })
     {
-        return Some(Distance::flattened(0.0, point, point, 2));
+        return Some(Distance::with_uncertainty(
+            0.0,
+            point,
+            point,
+            first.uncertainty_mm + second.uncertainty_mm,
+        ));
     }
 
     // Only the first boundary's edges within reach of the second region's
@@ -188,7 +194,7 @@ pub fn region_clearance_within(
         .filter_map(|(first_start, first_end)| {
             second_boundary
                 .segment_nearest_within(first_start, first_end, maximum_mm)
-                .map(|distance| distance.also_flattened(1))
+                .map(|distance| distance.also_uncertain(first.uncertainty_mm))
         })
         .min_by(|left, right| left.mm.total_cmp(&right.mm))
 }
@@ -231,10 +237,10 @@ pub fn linework_clearance_sites(
     material: &ContourSet,
     index: &PreparedRegion,
     minimum_mm: f64,
-    flattened_linework: u32,
+    linework_uncertainty_mm: f64,
 ) -> Vec<ClearanceSite> {
-    let flattened = flattened_linework + 1;
-    let reach = minimum_mm - f64::from(flattened) * tol::FLATTEN_MM - 1e-6;
+    let uncertainty_mm = linework_uncertainty_mm + material.uncertainty_mm;
+    let reach = minimum_mm - uncertainty_mm - 1e-6;
     if reach <= 0.0 || material.is_empty() {
         return Vec::new();
     }
@@ -295,13 +301,18 @@ pub fn linework_clearance_sites(
                 bbox.include_point(start);
                 bbox.include_point(end);
                 let distance = if endpoint_inside[2 * span_index] {
-                    Some(Distance::flattened(0.0, start, start, flattened))
+                    Some(Distance::with_uncertainty(
+                        0.0,
+                        start,
+                        start,
+                        uncertainty_mm,
+                    ))
                 } else if endpoint_inside[2 * span_index + 1] {
-                    Some(Distance::flattened(0.0, end, end, flattened))
+                    Some(Distance::with_uncertainty(0.0, end, end, uncertainty_mm))
                 } else {
                     index
                         .segment_nearest_within(start, end, minimum_mm)
-                        .map(|distance| distance.also_flattened(flattened_linework))
+                        .map(|distance| distance.also_uncertain(linework_uncertainty_mm))
                 };
                 if let Some(distance) = distance
                     && nearest.is_none_or(|best| distance.mm < best.mm)
@@ -340,7 +351,7 @@ pub fn linework_clearance_sites(
                 bbox,
                 first_paths,
                 second_paths,
-                overlap: ContourSet::empty(material.tolerance),
+                overlap: ContourSet::empty(material.resolution),
             })
         })
         .collect()
@@ -365,7 +376,13 @@ pub fn region_clearance_sites_with_index(
     minimum_mm: f64,
 ) -> Vec<ClearanceSite> {
     let lines = first.rings.iter().flat_map(ring_edges).collect::<Vec<_>>();
-    let mut sites = linework_clearance_sites(&lines, second, second_boundary, minimum_mm, 1);
+    let mut sites = linework_clearance_sites(
+        &lines,
+        second,
+        second_boundary,
+        minimum_mm,
+        first.uncertainty_mm,
+    );
     for overlap in first.intersection(second).connected_components() {
         let Some(point) = overlap
             .rings
@@ -376,7 +393,12 @@ pub fn region_clearance_sites_with_index(
             continue;
         };
         let mut joined = ClearanceSite {
-            distance: Distance::flattened(0.0, point, point, 2),
+            distance: Distance::with_uncertainty(
+                0.0,
+                point,
+                point,
+                first.uncertainty_mm + second.uncertainty_mm,
+            ),
             bbox: overlap.bbox,
             first_paths: Vec::new(),
             second_paths: Vec::new(),
@@ -416,7 +438,11 @@ pub fn region_clearance_sites_with_index(
 }
 
 /// A local required-clearance band around the supplied reference paths.
-pub fn linework_envelope(paths: &[Vec<Point>], radius_mm: f64) -> ContourSet {
+pub fn linework_envelope(
+    paths: &[Vec<Point>],
+    radius_mm: f64,
+    resolution: Resolution,
+) -> Result<ContourSet, AccuracyError> {
     use crate::geom::path::{ContourBuf, PathCmd, stroke_to_fill};
     use crate::geom::{FillRule, StrokeStyle};
     let contours = paths
@@ -430,21 +456,28 @@ pub fn linework_envelope(paths: &[Vec<Point>], radius_mm: f64) -> ContourSet {
             )
         })
         .collect::<Vec<_>>();
-    let band =
-        stroke_to_fill(&contours, StrokeStyle::round(2.0 * radius_mm).into()).unwrap_or_default();
-    ContourSet::from_contours(&band, FillRule::NonZero, tol::REGION_MM)
+    let band = stroke_to_fill(
+        &contours,
+        StrokeStyle::round(2.0 * radius_mm).into(),
+        resolution.accuracy,
+    )?
+    .unwrap_or_default();
+    ContourSet::from_contours(&band, FillRule::NonZero, resolution)
 }
 
 /// Circular material in the same flattened representation as check images.
 /// Analytic diameter/radial measurements should continue to use the circle
 /// parameters; this region is for boolean evidence such as missing copper.
-pub fn circular_region(center: Point, radius_mm: f64) -> ContourSet {
+pub fn circular_region(
+    center: Point,
+    radius_mm: f64,
+    resolution: Resolution,
+) -> Result<ContourSet, AccuracyError> {
     let Some(circle) = crate::geom::shapes::circle(2.0 * radius_mm) else {
-        return ContourSet::empty(tol::REGION_MM);
+        return Ok(ContourSet::empty(resolution));
     };
-    let circle =
-        crate::geom::path::transform_cmds(circle.cmds, crate::geom::Affine2::translation(center));
-    ContourSet::from_filled_contours(&[circle], tol::REGION_MM)
+    let circle = circle.transformed(crate::geom::Affine2::translation(center));
+    ContourSet::from_filled_contours(&[circle], resolution)
 }
 
 fn linear_interval(value: f64, slope: f64, minimum: f64, maximum: f64) -> Option<(f64, f64)> {
@@ -645,59 +678,50 @@ pub struct ThinSite {
     pub walls: Vec<(Point, Point)>,
 }
 
-/// Opening and closing use tessellated round offsets. Widening the candidate
-/// threshold by the full two-offset plus source-flattening error makes the
-/// morphological stage conservative; exact source-boundary distance below
-/// then decides the verdict and discards the extra candidates.
-const MORPHOLOGY_CANDIDATE_GUARD_MM: f64 = 2.0 * tol::STROKE_OUTLINE_MM + tol::FLATTEN_MM;
-
 /// Filled material certainly narrower than `min_width_mm`. Only two-sided
 /// residue is reported, so the bite an isolated convex arc sheds under the
 /// opening is not a thin feature. Largest piece first.
-pub fn thin_features(region: &ContourSet, min_width_mm: f64) -> Vec<ThinPiece> {
-    pieces(
+pub fn thin_features(
+    region: &ContourSet,
+    min_width_mm: f64,
+) -> Result<Vec<ThinPiece>, AccuracyError> {
+    Ok(pieces(
         region.disk_feature_violation_components(
-            (min_width_mm + MORPHOLOGY_CANDIDATE_GUARD_MM) / 2.0,
-            reportable_width(min_width_mm),
-        ),
+            (min_width_mm + (2.0 * region.budget().max_error_mm() + region.uncertainty_mm)) / 2.0,
+            min_width_mm - 2.0 * region.uncertainty_mm,
+        )?,
         min_width_mm,
-    )
-}
-
-/// The widest measurement certainly below `min_mm` once both flattened
-/// walls' uncertainty is counted, as [`pieces`] requires.
-fn reportable_width(min_mm: f64) -> f64 {
-    min_mm - 2.0 * tol::FLATTEN_MM
+    ))
 }
 
 /// Gaps in the material certainly narrower than `min_gap_mm`, including
 /// boundary notches. Only two-sided residue is reported, so the bite an
 /// isolated concave corner sheds under the closing is not clearance.
 /// Largest piece first.
-pub fn thin_gaps(region: &ContourSet, min_gap_mm: f64) -> Vec<ThinPiece> {
-    pieces(
+pub fn thin_gaps(region: &ContourSet, min_gap_mm: f64) -> Result<Vec<ThinPiece>, AccuracyError> {
+    Ok(pieces(
         region.disk_gap_violation_components(
-            (min_gap_mm + MORPHOLOGY_CANDIDATE_GUARD_MM) / 2.0,
-            reportable_width(min_gap_mm),
-        ),
+            (min_gap_mm + (2.0 * region.budget().max_error_mm() + region.uncertainty_mm)) / 2.0,
+            min_gap_mm - 2.0 * region.uncertainty_mm,
+        )?,
         min_gap_mm,
-    )
+    ))
 }
 
 /// The narrowest local width of a filled region: the least separation of
 /// any two facing boundary branches. An opening wide enough to erase the
 /// whole region makes every piece of it a candidate. `None` when no two
 /// branches face each other (an empty region, or a single point).
-pub fn min_width(region: &ContourSet) -> Option<Distance> {
-    min_width_disk(region).map(|disk| disk.width)
+pub fn min_width(region: &ContourSet) -> Result<Option<Distance>, AccuracyError> {
+    Ok(min_width_disk(region)?.map(|disk| disk.width))
 }
 
-pub fn min_width_disk(region: &ContourSet) -> Option<WidthDisk> {
+pub fn min_width_disk(region: &ContourSet) -> Result<Option<WidthDisk>, AccuracyError> {
     let erase_all = 2.0 * region.bbox.width().max(region.bbox.height());
-    thin_features(region, erase_all)
+    Ok(thin_features(region, erase_all)?
         .into_iter()
         .map(|piece| piece.disk)
-        .min_by(|left, right| left.width.mm.total_cmp(&right.width.mm))
+        .min_by(|left, right| left.width.mm.total_cmp(&right.width.mm)))
 }
 
 /// Convert the conservative opening/closing candidates into authoritative
@@ -714,9 +738,11 @@ fn pieces(components: Vec<TwoSidedResidualComponent>, minimum_mm: f64) -> Vec<Th
                 .axis
                 .iter()
                 .flat_map(|axis| {
-                    let reach =
-                        (minimum_mm - 2.0 * tol::FLATTEN_MM - 2.0 * axis.uncertainty_mm - 1e-6)
-                            / 2.0;
+                    let reach = (minimum_mm
+                        - component.width.uncertainty_mm
+                        - 2.0 * axis.uncertainty_mm
+                        - 1e-6)
+                        / 2.0;
                     if reach <= 0.0 {
                         return Vec::new();
                     }
@@ -785,7 +811,12 @@ fn pieces(components: Vec<TwoSidedResidualComponent>, minimum_mm: f64) -> Vec<Th
                                     dist::point_segment(end, a, b).1,
                                 )
                             });
-                            let mut width = Distance::flattened(2.0 * radius_mm, first, second, 2);
+                            let mut width = Distance::with_uncertainty(
+                                2.0 * radius_mm,
+                                first,
+                                second,
+                                component.width.uncertainty_mm,
+                            );
                             width.uncertainty_mm += 2.0 * axis.uncertainty_mm;
                             (
                                 (start, end),
@@ -874,6 +905,10 @@ fn region_perimeter(region: &ContourSet) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn res(tolerance_mm: f64) -> Resolution {
+        Resolution::default().with_tolerance(tolerance_mm)
+    }
+
     use crate::geom::path::{ContourBuf, PathCmd};
     use crate::geom::{FillRule, shapes};
 
@@ -891,8 +926,9 @@ mod tests {
         ContourSet::from_contours(
             &[rect_at(min_x, min_y, max_x, max_y)],
             FillRule::NonZero,
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         )
+        .unwrap()
     }
 
     #[test]
@@ -903,10 +939,10 @@ mod tests {
             &material,
             &material.prepare_query(),
             0.3,
-            0,
+            0.0,
         );
         assert_eq!(sites.len(), 2);
-        let reach = 0.3 - tol::FLATTEN_MM - 1e-6;
+        let reach = 0.3 - material.uncertainty_mm - 1e-6;
         let extension = (reach * reach - 0.1_f64.powi(2)).sqrt();
         for (site, left) in sites.iter().zip([2.0, 7.0]) {
             assert!((site.distance.mm - 0.1).abs() < 1e-9);
@@ -921,7 +957,8 @@ mod tests {
     fn clearance_sites_include_segments_deep_inside_material() {
         let material = rect_region(0.0, 0.0, 10.0, 10.0);
         let line = (Point::new(2.0, 5.0), Point::new(8.0, 5.0));
-        let sites = linework_clearance_sites(&[line], &material, &material.prepare_query(), 0.2, 0);
+        let sites =
+            linework_clearance_sites(&[line], &material, &material.prepare_query(), 0.2, 0.0);
         assert_eq!(sites.len(), 1);
         assert_eq!(sites[0].distance.mm, 0.0);
         assert_eq!(sites[0].first_paths, vec![vec![line.0, line.1]]);
@@ -930,7 +967,8 @@ mod tests {
     #[test]
     fn clearance_sites_merge_repeated_contacts_on_the_same_source_edge() {
         let material =
-            ContourSet::from_filled_contours(&[rect_at(0.0, 0.0, 1.0, 1.0)], tol::REGION_MM);
+            ContourSet::from_filled_contours(&[rect_at(0.0, 0.0, 1.0, 1.0)], res(tol::REGION_MM))
+                .unwrap();
         let index = material.prepare_query();
         let sites = linework_clearance_sites(
             &[
@@ -940,7 +978,7 @@ mod tests {
             &material,
             &index,
             0.2,
-            1,
+            0.005,
         );
         assert_eq!(sites.len(), 1);
         assert_eq!(sites[0].first_paths.len(), 2);
@@ -967,7 +1005,7 @@ mod tests {
             &material,
             &material.prepare_query(),
             0.2,
-            0,
+            0.0,
         );
         assert_eq!(sites.len(), 1);
         assert_eq!(sites[0].distance.mm, 0.0);
@@ -1105,8 +1143,9 @@ mod tests {
                 PathCmd::close(),
             ])],
             FillRule::NonZero,
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
         let index = diagonal.prepare_query();
         let near_middle = index
             .nearest_within(Point::new(40.3, 40.0), 0.5)
@@ -1119,12 +1158,17 @@ mod tests {
         let copper = ContourSet::from_contours(
             &[shapes::circle(5.0).unwrap()],
             FillRule::NonZero,
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
         let index = copper.prepare_query();
 
         assert_eq!(
-            index.circular_enclosure(Point::default(), 1.35, 0.125 - tol::FLATTEN_MM),
+            index.circular_enclosure(
+                Point::default(),
+                1.35,
+                0.125 - copper.budget().max_error_mm() / 2.0
+            ),
             None,
             "a satisfied enclosure exceeds the search bound"
         );
@@ -1132,10 +1176,10 @@ mod tests {
         let measurement = index
             .circular_enclosure(Point::new(1.3, 0.0), 1.35, 0.125)
             .expect("hole extending beyond copper must measure");
-        assert!((measurement.mm + 0.15).abs() < tol::FLATTEN_MM);
-        assert_eq!(measurement.uncertainty_mm, tol::FLATTEN_MM);
-        assert!((measurement.first.x - 2.65).abs() < tol::FLATTEN_MM);
-        assert!((measurement.second.x - 2.5).abs() < tol::FLATTEN_MM);
+        assert!((measurement.mm + 0.15).abs() < copper.budget().max_error_mm() / 2.0);
+        assert_eq!(measurement.uncertainty_mm, copper.uncertainty_mm);
+        assert!((measurement.first.x - 2.65).abs() < copper.budget().max_error_mm() / 2.0);
+        assert!((measurement.second.x - 2.5).abs() < copper.budget().max_error_mm() / 2.0);
     }
 
     #[test]
@@ -1164,14 +1208,15 @@ mod tests {
                 PathCmd::close(),
             ])],
             FillRule::NonZero,
-            tol::REGION_MM,
-        );
-        let raw_residue = bulge.difference(&bulge.disk_open(0.5));
+            res(tol::REGION_MM),
+        )
+        .unwrap();
+        let raw_residue = bulge.difference(&bulge.disk_open(0.5).unwrap());
         assert!(
             !raw_residue.is_empty(),
             "the opening must shed residue here"
         );
-        assert!(thin_features(&bulge, 1.0).is_empty());
+        assert!(thin_features(&bulge, 1.0).unwrap().is_empty());
     }
 
     #[test]
@@ -1220,17 +1265,19 @@ mod tests {
         let region = ContourSet::from_contours(
             &[rect_at(139.0, -101.0, 141.0, -98.0), hole],
             FillRule::NonZero,
-            tol::REGION_MM,
-        );
-        let candidate_radius = (0.127 + MORPHOLOGY_CANDIDATE_GUARD_MM) / 2.0;
+            res(tol::REGION_MM),
+        )
+        .unwrap();
+        let candidate_radius =
+            (0.127 + (2.0 * region.budget().max_error_mm() + region.uncertainty_mm)) / 2.0;
 
         assert!(
             !region
-                .difference(&region.disk_open(candidate_radius))
+                .difference(&region.disk_open(candidate_radius).unwrap())
                 .is_empty(),
             "the opening must still localize the one-sided nib"
         );
-        assert!(thin_features(&region, 0.127).is_empty());
+        assert!(thin_features(&region, 0.127).unwrap().is_empty());
     }
 
     #[test]
@@ -1241,10 +1288,11 @@ mod tests {
                 rect_at(0.0, 0.0, 10.0, 10.0),
                 rect_at(10.0, 5.0, 12.0, 5.05),
             ],
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
 
-        let findings = thin_features(&region, 0.1);
+        let findings = thin_features(&region, 0.1).unwrap();
 
         assert_eq!(findings.len(), 1);
         let piece = &findings[0];
@@ -1283,14 +1331,15 @@ mod tests {
                 PathCmd::close(),
             ])],
             FillRule::NonZero,
-            tol::REGION_MM,
-        );
-        let raw_residue = chevron.disk_close(0.5).difference(&chevron);
+            res(tol::REGION_MM),
+        )
+        .unwrap();
+        let raw_residue = chevron.disk_close(0.5).unwrap().difference(&chevron);
         assert!(
             !raw_residue.is_empty(),
             "the closing must shed residue here"
         );
-        assert!(thin_gaps(&chevron, 1.0).is_empty());
+        assert!(thin_gaps(&chevron, 1.0).unwrap().is_empty());
     }
 
     #[test]
@@ -1300,10 +1349,11 @@ mod tests {
                 rect_at(0.0, 0.0, 10.0, 10.0),
                 rect_at(10.06, 0.0, 20.0, 10.0),
             ],
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
 
-        let gaps = thin_gaps(&region, 0.1);
+        let gaps = thin_gaps(&region, 0.1).unwrap();
 
         assert_eq!(gaps.len(), 1);
         assert!(
@@ -1311,14 +1361,14 @@ mod tests {
             "width {}",
             gaps[0].width.mm
         );
-        assert!(thin_features(&region, 0.1).is_empty());
+        assert!(thin_features(&region, 0.1).unwrap().is_empty());
     }
 
     #[test]
     fn small_islands_are_not_filtered_out_of_feature_width() {
         let island = rect_region(0.0, 0.0, 0.05, 0.05);
 
-        let findings = thin_features(&island, 0.1);
+        let findings = thin_features(&island, 0.1).unwrap();
 
         assert_eq!(findings.len(), 1);
         assert!(!findings[0].sites.is_empty());
@@ -1340,42 +1390,48 @@ mod tests {
         let feature = rect_region(0.0, 0.0, 1.0, 0.1);
         let disk = ContourSet::from_filled_contours(
             &[shapes::circle(0.1).expect("valid circle")],
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
         let undersized_disk = ContourSet::from_filled_contours(
             &[shapes::circle(0.08).expect("valid circle")],
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
         let left = rect_region(2.0, 0.0, 3.0, 1.0);
         let right = rect_region(3.1, 0.0, 4.1, 1.0);
 
-        assert!(thin_features(&feature, 0.1).is_empty());
-        let disk_findings = thin_features(&disk, 0.1);
+        assert!(thin_features(&feature, 0.1).unwrap().is_empty());
+        let disk_findings = thin_features(&disk, 0.1).unwrap();
         assert!(disk_findings.is_empty(), "findings: {disk_findings:?}");
-        assert_eq!(thin_features(&undersized_disk, 0.1).len(), 1);
-        assert!(thin_gaps(&left.union(&right), 0.1).is_empty());
+        assert_eq!(thin_features(&undersized_disk, 0.1).unwrap().len(), 1);
+        assert!(thin_gaps(&left.union(&right), 0.1).unwrap().is_empty());
     }
 
     #[test]
     fn min_width_is_limit_free() {
         let stadium = ContourSet::from_contours(
-            &[shapes::obround(1.8, 0.6, true).expect("valid obround")],
+            &[shapes::obround(1.8, 0.6).expect("valid obround")],
             FillRule::NonZero,
-            tol::REGION_MM,
-        );
-        let width = min_width(&stadium).expect("a stadium has facing walls");
-        // The flattened arc's inscribed disk is its apothem, short of the
-        // true radius by at most one flattening tolerance per side.
+            res(tol::REGION_MM),
+        )
+        .unwrap();
+        let width = min_width(&stadium)
+            .unwrap()
+            .expect("a stadium has facing walls");
         assert!(
             (0.0..=width.uncertainty_mm).contains(&(0.6 - width.mm)),
             "width {}",
             width.mm
         );
-        assert_eq!(width.uncertainty_mm, 2.0 * tol::FLATTEN_MM);
 
         let plate = rect_region(0.0, 0.0, 10.0, 3.0);
-        assert!((min_width(&plate).unwrap().mm - 3.0).abs() < 1e-9);
-        assert!(min_width(&ContourSet::empty(tol::REGION_MM)).is_none());
+        assert!((min_width(&plate).unwrap().unwrap().mm - 3.0).abs() < 1e-9);
+        assert!(
+            min_width(&ContourSet::empty(res(tol::REGION_MM)))
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -1395,10 +1451,11 @@ mod tests {
                 PathCmd::close(),
             ])],
             FillRule::NonZero,
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
 
-        let findings = thin_features(&region, 0.1);
+        let findings = thin_features(&region, 0.1).unwrap();
 
         assert_eq!(findings.len(), 1);
         let width = findings[0].width;
@@ -1427,18 +1484,18 @@ mod tests {
         let left = rect_region(0.0, 0.0, 4.0, 2.0);
         let right = rect_region(4.06, 0.0, 8.0, 2.0);
         let region = left.union(&right);
-        let rotated = ContourSet::new(
+        let rotated = ContourSet::from_rings(
             region
                 .rings
                 .iter()
                 .map(|ring| ring.iter().map(|[x, y]| [-y, *x]).collect())
                 .collect(),
             FillRule::NonZero,
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
 
-        let original = thin_gaps(&region, 0.1);
-        let turned = thin_gaps(&rotated, 0.1);
+        let original = thin_gaps(&region, 0.1).unwrap();
+        let turned = thin_gaps(&rotated, 0.1).unwrap();
 
         assert_eq!(original.len(), 1);
         assert_eq!(turned.len(), 1);

--- a/crates/pcb-ir/src/geom/dist.rs
+++ b/crates/pcb-ir/src/geom/dist.rs
@@ -1,17 +1,12 @@
 //! Euclidean distance primitives with closest-point witnesses.
 
 use crate::geom::point::Point;
-use crate::geom::tol;
 
 /// A measured length between two witness points, in the IR's canonical
 /// millimeters, with the uncertainty its inputs carry.
 ///
-/// Flattening places each curved boundary up to [`tol::FLATTEN_MM`] from
-/// its source, so a length measured against `n` flattened boundaries is
-/// known only to within `n · FLATTEN_MM`. A consumer comparing against a
-/// minimum uses [`Distance::certainly_below`], so tessellation alone can
-/// never manufacture a violation. `mm` is signed where the quantity is: a
-/// negative enclosure is the depth of a breach.
+/// `uncertainty_mm` carries the preparation history of the measured inputs.
+/// `mm` is signed where the quantity is: a negative enclosure is a breach.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Distance {
     pub mm: f64,
@@ -32,21 +27,19 @@ impl Distance {
         }
     }
 
-    /// A length measured against `flattened_boundaries` tessellated curves.
-    pub fn flattened(mm: f64, first: Point, second: Point, flattened_boundaries: u32) -> Self {
+    /// A measurement using the accumulated positional errors of its inputs.
+    pub fn with_uncertainty(mm: f64, first: Point, second: Point, uncertainty_mm: f64) -> Self {
         Self {
             mm,
-            uncertainty_mm: f64::from(flattened_boundaries) * tol::FLATTEN_MM,
             first,
             second,
+            uncertainty_mm,
         }
     }
 
-    /// The same length, with `flattened_boundaries` more tessellated inputs
-    /// counted toward its uncertainty.
-    pub fn also_flattened(self, flattened_boundaries: u32) -> Self {
+    pub fn also_uncertain(self, uncertainty_mm: f64) -> Self {
         Self {
-            uncertainty_mm: self.uncertainty_mm + f64::from(flattened_boundaries) * tol::FLATTEN_MM,
+            uncertainty_mm: self.uncertainty_mm + uncertainty_mm,
             ..self
         }
     }

--- a/crates/pcb-ir/src/geom/mod.rs
+++ b/crates/pcb-ir/src/geom/mod.rs
@@ -3,6 +3,7 @@
 //! All geometry is in millimeters. Unit conversion belongs at format
 //! boundaries (parsers and writers); see [`Unit`].
 
+pub(crate) mod accuracy;
 mod affine;
 mod arc;
 mod bbox;
@@ -21,8 +22,9 @@ mod style;
 pub mod tol;
 pub mod warp;
 
+pub use accuracy::{AccuracyError, GeometryAccuracy, Resolution};
 pub use affine::Affine2;
-pub use arc::Arc;
+pub use arc::{Arc, EllipticalArc};
 pub use bbox::BBox;
 pub use path::{ContourBuf, PathCmd, PathOp, Segment, StrokeToFillStyle};
 pub use pattern::{StrokePatternMark, stroke_pattern_marks};

--- a/crates/pcb-ir/src/geom/path.rs
+++ b/crates/pcb-ir/src/geom/path.rs
@@ -108,6 +108,10 @@ impl PathCmd {
         }
     }
 
+    pub fn is_finite(self) -> bool {
+        self.p0.is_finite() && self.p1.is_finite() && self.p2.is_finite() && self.p3.is_finite()
+    }
+
     /// Whether this command is a curve rather than a line or a move.
     pub fn is_curve(self) -> bool {
         matches!(self.op, PathOp::ArcTo | PathOp::EllipseTo | PathOp::CubicTo)
@@ -612,16 +616,7 @@ pub fn stroke_to_fill(
         };
         let mut out = Vec::new();
         for contour in contours {
-            accuracy.check(contour.uncertainty_mm)?;
-            if contour
-                .cmds
-                .iter()
-                .any(|cmd| matches!(cmd.op, PathOp::CubicTo | PathOp::EllipseTo))
-            {
-                return Err(AccuracyError::InvalidGeometry(
-                    "pattern placement requires lines or circular arcs",
-                ));
-            }
+            let contour = contour.flattened_curves(accuracy)?;
             let segments = contour.segments().collect::<Vec<_>>();
             for mark in stroke_pattern_marks(&segments, style.pattern, style.width) {
                 match mark {
@@ -1038,6 +1033,33 @@ mod tests {
             .unwrap()
             .unwrap();
         assert!(fill.iter().all(|contour| contour.uncertainty_mm >= 0.001));
+    }
+
+    #[test]
+    fn patterned_strokes_flatten_curves_within_budget() {
+        let ellipse = crate::geom::shapes::circle(4.0)
+            .unwrap()
+            .transformed(Affine2 {
+                m00: 2.0,
+                m01: 0.0,
+                m02: 0.0,
+                m10: 0.0,
+                m11: 1.0,
+                m12: 0.0,
+            });
+        assert!(ellipse.cmds.iter().any(|cmd| cmd.op == PathOp::EllipseTo));
+        let mut style = StrokeToFillStyle::new(0.2, LineCap::Round, LineJoin::Round);
+        style.pattern = LinePattern::Dashed;
+        let accuracy = GeometryAccuracy::default();
+        let dashes = stroke_to_fill(&[ellipse], style, accuracy)
+            .unwrap()
+            .unwrap();
+        assert!(dashes.len() > 1);
+        assert!(
+            dashes
+                .iter()
+                .all(|dash| dash.uncertainty_mm <= accuracy.max_error_mm())
+        );
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/path.rs
+++ b/crates/pcb-ir/src/geom/path.rs
@@ -1,11 +1,12 @@
+use crate::geom::pattern::{StrokePatternMark, stroke_pattern_marks};
+use crate::geom::{AccuracyError, GeometryAccuracy};
 use kurbo::{BezPath, Cap, Join, PathEl, Stroke, StrokeOpts};
 
-use crate::geom::arc::Arc;
+use crate::geom::affine::Affine2;
+use crate::geom::arc::{Arc, EllipticalArc};
 use crate::geom::bbox::BBox;
-use crate::geom::pattern::{StrokePatternMark, stroke_pattern_marks};
 use crate::geom::point::Point;
 use crate::geom::style::{LineCap, LineJoin, LinePattern};
-use crate::geom::tol;
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum PathOp {
@@ -13,6 +14,7 @@ pub enum PathOp {
     MoveTo,
     LineTo,
     ArcTo,
+    EllipseTo,
     CubicTo,
     Close,
 }
@@ -21,6 +23,9 @@ pub enum PathOp {
 ///
 /// - `MoveTo`/`LineTo`: `p0` is the target point.
 /// - `ArcTo`: `p0` is the arc end, `p1` the center, `clockwise` the direction.
+/// - `EllipseTo`: `p0` is the arc end, `p1` the center, `p2` and `p3` the
+///   images of the unit x and y axes, `clockwise` the direction. This is the
+///   affine image of a circular arc; see [`EllipticalArc`].
 /// - `CubicTo`: `p0`/`p1` are control points, `p2` the end point.
 /// - `Close`: no points.
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
@@ -29,6 +34,7 @@ pub struct PathCmd {
     pub p0: Point,
     pub p1: Point,
     pub p2: Point,
+    pub p3: Point,
     pub clockwise: bool,
 }
 
@@ -59,6 +65,24 @@ impl PathCmd {
         }
     }
 
+    /// An arc of the ellipse `center + x_axis·cos θ + y_axis·sin θ`.
+    pub fn ellipse_to(
+        end: Point,
+        center: Point,
+        x_axis: Point,
+        y_axis: Point,
+        clockwise: bool,
+    ) -> Self {
+        Self {
+            op: PathOp::EllipseTo,
+            p0: end,
+            p1: center,
+            p2: x_axis,
+            p3: y_axis,
+            clockwise,
+        }
+    }
+
     pub fn cubic_to(p1: Point, p2: Point, p3: Point) -> Self {
         Self {
             op: PathOp::CubicTo,
@@ -78,9 +102,66 @@ impl PathCmd {
 
     pub fn end_point(self) -> Option<Point> {
         match self.op {
-            PathOp::MoveTo | PathOp::LineTo | PathOp::ArcTo => Some(self.p0),
+            PathOp::MoveTo | PathOp::LineTo | PathOp::ArcTo | PathOp::EllipseTo => Some(self.p0),
             PathOp::CubicTo => Some(self.p2),
             PathOp::Close => None,
+        }
+    }
+
+    /// Whether this command is a curve rather than a line or a move.
+    pub fn is_curve(self) -> bool {
+        matches!(self.op, PathOp::ArcTo | PathOp::EllipseTo | PathOp::CubicTo)
+    }
+
+    /// The elliptical arc of an `EllipseTo` command starting at `start`.
+    fn elliptical_arc(self, start: Point) -> EllipticalArc {
+        EllipticalArc {
+            start,
+            end: self.p0,
+            center: self.p1,
+            x_axis: self.p2,
+            y_axis: self.p3,
+            clockwise: self.clockwise,
+        }
+    }
+
+    fn from_elliptical_arc(arc: EllipticalArc) -> Self {
+        Self::ellipse_to(arc.end, arc.center, arc.x_axis, arc.y_axis, arc.clockwise)
+    }
+
+    /// Exact image under an affine transform, given the current point.
+    fn transformed(self, transform: Affine2, start: Point) -> Self {
+        match self.op {
+            PathOp::MoveTo | PathOp::LineTo => Self {
+                p0: transform.transform_point(self.p0),
+                ..self
+            },
+            PathOp::CubicTo => Self {
+                p0: transform.transform_point(self.p0),
+                p1: transform.transform_point(self.p1),
+                p2: transform.transform_point(self.p2),
+                ..self
+            },
+            PathOp::ArcTo => {
+                if transform.preserves_circles(1e-12 * transform.max_scale().powi(2)) {
+                    Self {
+                        p0: transform.transform_point(self.p0),
+                        p1: transform.transform_point(self.p1),
+                        clockwise: self.clockwise != (transform.determinant() < 0.0),
+                        ..self
+                    }
+                } else {
+                    Self::from_elliptical_arc(
+                        Arc::new(start, self.p0, self.p1, self.clockwise)
+                            .to_elliptical()
+                            .transformed(transform),
+                    )
+                }
+            }
+            PathOp::EllipseTo => {
+                Self::from_elliptical_arc(self.elliptical_arc(start).transformed(transform))
+            }
+            PathOp::Close => self,
         }
     }
 }
@@ -93,6 +174,9 @@ impl PathCmd {
 pub struct ContourBuf {
     pub bbox: BBox,
     pub cmds: Vec<PathCmd>,
+    /// Approximation already present in these commands. Zero means the
+    /// commands themselves are the source geometry, not that they are lines.
+    pub uncertainty_mm: f64,
 }
 
 impl ContourBuf {
@@ -101,12 +185,45 @@ impl ContourBuf {
         Self {
             bbox: contour_bbox(&cmds),
             cmds,
+            uncertainty_mm: 0.0,
         }
     }
 
     /// Build from commands with a precomputed bounding box.
     pub fn from_parts(bbox: BBox, cmds: Vec<PathCmd>) -> Self {
-        Self { bbox, cmds }
+        Self {
+            bbox,
+            cmds,
+            uncertainty_mm: 0.0,
+        }
+    }
+
+    /// Record the approximation already present in these commands.
+    pub fn with_uncertainty(mut self, uncertainty_mm: f64) -> Self {
+        self.uncertainty_mm = uncertainty_mm;
+        self
+    }
+
+    /// Exact image under an affine transform. Circular arcs stay circular
+    /// under similarities and become elliptical arcs otherwise; nothing is
+    /// approximated. Prior uncertainty scales with the transform.
+    pub fn transformed(self, transform: Affine2) -> Self {
+        let scale = transform.max_scale();
+        let mut current = Point::default();
+        let cmds = self
+            .cmds
+            .into_iter()
+            .map(|cmd| {
+                let transformed = cmd.transformed(transform, current);
+                current = cmd.end_point().unwrap_or(current);
+                transformed
+            })
+            .collect::<Vec<_>>();
+        Self {
+            bbox: contour_bbox(&cmds),
+            cmds,
+            uncertainty_mm: self.uncertainty_mm * scale,
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -117,11 +234,43 @@ impl ContourBuf {
         segments(&self.cmds)
     }
 
-    /// Signed area enclosed by this contour, preserving line, circular-arc,
-    /// and cubic Bézier segments without flattening. Counter-clockwise
-    /// contours are positive and clockwise contours are negative.
+    /// Signed area enclosed by this contour, preserving arc and cubic
+    /// segments without flattening. Counter-clockwise contours are positive
+    /// and clockwise contours are negative.
     pub fn signed_area(&self) -> f64 {
         self.segments().map(segment_signed_double_area).sum::<f64>() / 2.0
+    }
+
+    /// The same contour with elliptical arcs and cubics replaced by chords
+    /// within `accuracy`, for writers that only carry lines and circular arcs.
+    pub fn flattened_curves(&self, accuracy: GeometryAccuracy) -> Result<Self, AccuracyError> {
+        let allowance = accuracy.allowance(self.uncertainty_mm)?;
+        let mut cmds = Vec::with_capacity(self.cmds.len());
+        let mut current = Point::default();
+        let mut added: f64 = 0.0;
+        for cmd in &self.cmds {
+            match cmd.op {
+                PathOp::EllipseTo | PathOp::CubicTo => {
+                    let start = current;
+                    let segment = if cmd.op == PathOp::EllipseTo {
+                        Segment::Ellipse(cmd.elliptical_arc(start))
+                    } else {
+                        Segment::Cubic {
+                            start,
+                            c1: cmd.p0,
+                            c2: cmd.p1,
+                            end: cmd.p2,
+                        }
+                    };
+                    let (points, error) = segment.chords(allowance)?;
+                    added = added.max(error);
+                    cmds.extend(points.into_iter().map(PathCmd::line_to));
+                }
+                _ => cmds.push(*cmd),
+            }
+            current = cmd.end_point().unwrap_or(current);
+        }
+        Ok(Self::new(cmds).with_uncertainty(self.uncertainty_mm + added))
     }
 }
 
@@ -133,6 +282,7 @@ pub enum Segment {
         end: Point,
     },
     Arc(Arc),
+    Ellipse(EllipticalArc),
     Cubic {
         start: Point,
         c1: Point,
@@ -146,6 +296,7 @@ impl Segment {
         match *self {
             Self::Line { start, .. } | Self::Cubic { start, .. } => start,
             Self::Arc(arc) => arc.start,
+            Self::Ellipse(arc) => arc.start,
         }
     }
 
@@ -153,6 +304,7 @@ impl Segment {
         match *self {
             Self::Line { end, .. } | Self::Cubic { end, .. } => end,
             Self::Arc(arc) => arc.end,
+            Self::Ellipse(arc) => arc.end,
         }
     }
 
@@ -164,6 +316,7 @@ impl Segment {
                 bbox
             }
             Self::Arc(arc) => arc.bbox(),
+            Self::Ellipse(arc) => arc.bbox(),
             Self::Cubic { start, c1, c2, end } => {
                 let mut bbox = BBox::from_point(start);
                 bbox.include_point(c1);
@@ -174,39 +327,84 @@ impl Segment {
         }
     }
 
+    /// The point at parameter `t` in `[0, 1]` along the segment.
+    pub fn point_at(&self, t: f64) -> Point {
+        match *self {
+            Self::Line { start, end } => start + (end - start) * t,
+            Self::Arc(arc) => {
+                let start_angle = arc.start.angle_from(arc.center);
+                let signed_sweep = if arc.clockwise {
+                    -arc.sweep_radians()
+                } else {
+                    arc.sweep_radians()
+                };
+                arc.point_at(start_angle + signed_sweep * t)
+            }
+            Self::Ellipse(arc) => arc.point_at(arc.start_angle() + arc.signed_sweep_radians() * t),
+            Self::Cubic { start, c1, c2, end } => {
+                let u = 1.0 - t;
+                start * (u * u * u)
+                    + c1 * (3.0 * u * u * t)
+                    + c2 * (3.0 * u * t * t)
+                    + end * (t * t * t)
+            }
+        }
+    }
+
     /// Sample the segment at `count` evenly spaced parameters, excluding the
-    /// start point and including the end point. Lines and arcs are exact;
-    /// cubics are evaluated on the Bezier polynomial.
+    /// start point and including the end point.
     pub fn sample_points(&self, count: usize, out: &mut Vec<Point>) {
         match *self {
             Self::Line { end, .. } => out.push(end),
-            Self::Arc(arc) => {
-                let sweep = arc.sweep_radians();
-                let signed = if arc.clockwise { -sweep } else { sweep };
-                let start_angle = arc.start.angle_from(arc.center);
+            _ => {
                 for step in 1..=count {
-                    let t = step as f64 / count as f64;
                     if step == count {
-                        out.push(arc.end);
+                        out.push(self.end());
                     } else {
-                        out.push(arc.point_at(start_angle + signed * t));
+                        out.push(self.point_at(step as f64 / count as f64));
                     }
                 }
             }
-            Self::Cubic { start, c1, c2, end } => {
-                for step in 1..=count {
-                    let t = step as f64 / count as f64;
-                    if step == count {
-                        out.push(end);
-                    } else {
-                        let u = 1.0 - t;
-                        let point = start * (u * u * u)
-                            + c1 * (3.0 * u * u * t)
-                            + c2 * (3.0 * u * t * t)
-                            + end * (t * t * t);
-                        out.push(point);
-                    }
+        }
+    }
+
+    /// Chord endpoints (excluding the start) approximating a curved segment
+    /// within `max_error_mm`, and the error actually incurred. Lines and
+    /// circular arcs are returned as their own end point with no error.
+    pub fn chords(&self, max_error_mm: f64) -> Result<(Vec<Point>, f64), AccuracyError> {
+        match *self {
+            Self::Line { end, .. } | Self::Arc(Arc { end, .. }) => Ok((vec![end], 0.0)),
+            Self::Ellipse(arc) => {
+                let scale = arc.max_scale();
+                let sweep = arc.sweep_radians();
+                // A chord of parametric angle δ on the unit circle has
+                // sagitta 2·sin²(δ/4); the basis scales it by at most `scale`.
+                let ratio = (max_error_mm / (2.0 * scale)).min(1.0);
+                let step = 4.0 * ratio.sqrt().asin();
+                let count = (sweep / step).ceil().max(1.0);
+                if !count.is_finite() || count > 1_000_000.0 {
+                    return Err(AccuracyError::SubdivisionLimit);
                 }
+                let count = count as usize;
+                let mut points = Vec::with_capacity(count);
+                self.sample_points(count, &mut points);
+                let error = 2.0 * scale * (sweep / count as f64 / 4.0).sin().powi(2);
+                Ok((points, error))
+            }
+            Self::Cubic { start, c1, c2, end } => {
+                let mut path = BezPath::new();
+                path.move_to(kurbo_point(start));
+                path.curve_to(kurbo_point(c1), kurbo_point(c2), kurbo_point(end));
+                let mut points = Vec::new();
+                kurbo::flatten(path, max_error_mm.max(f64::MIN_POSITIVE), |el| {
+                    if let PathEl::LineTo(point) = el {
+                        points.push(ir_point(point));
+                    }
+                });
+                if points.len() > 1_000_000 {
+                    return Err(AccuracyError::SubdivisionLimit);
+                }
+                Ok((points, max_error_mm))
             }
         }
     }
@@ -222,6 +420,10 @@ fn segment_signed_double_area(segment: Segment) -> f64 {
                 arc.sweep_radians()
             };
             cross(arc.center, arc.end - arc.start) + arc.radius().powi(2) * sweep
+        }
+        Segment::Ellipse(arc) => {
+            cross(arc.center, arc.end - arc.start)
+                + cross(arc.x_axis, arc.y_axis) * arc.signed_sweep_radians()
         }
         Segment::Cubic { start, c1, c2, end } => {
             // Integrate x·dy - y·dx over the cubic in power-basis form.
@@ -276,6 +478,11 @@ impl Iterator for Segments<'_> {
                     self.current = Some(cmd.p0);
                     return Some(Segment::Arc(Arc::new(start, cmd.p0, cmd.p1, cmd.clockwise)));
                 }
+                PathOp::EllipseTo => {
+                    let start = self.current.unwrap_or(cmd.p0);
+                    self.current = Some(cmd.p0);
+                    return Some(Segment::Ellipse(cmd.elliptical_arc(start)));
+                }
                 PathOp::CubicTo => {
                     let start = self.current.unwrap_or(cmd.p2);
                     self.current = Some(cmd.p2);
@@ -313,6 +520,10 @@ pub fn contour_bbox(cmds: &[PathCmd]) -> BBox {
                 bbox = bbox.union(Arc::new(current, cmd.p0, cmd.p1, cmd.clockwise).bbox());
                 current = cmd.p0;
             }
+            PathOp::EllipseTo => {
+                bbox = bbox.union(cmd.elliptical_arc(current).bbox());
+                current = cmd.p0;
+            }
             PathOp::CubicTo => {
                 bbox.include_point(cmd.p0);
                 bbox.include_point(cmd.p1);
@@ -325,60 +536,10 @@ pub fn contour_bbox(cmds: &[PathCmd]) -> BBox {
     bbox
 }
 
-pub fn transform_cmds(
-    cmds: impl IntoIterator<Item = PathCmd>,
-    transform: crate::geom::affine::Affine2,
-) -> ContourBuf {
-    let mut bbox = BBox::empty();
-    let mut current = Point::default();
-    let mut transformed_cmds = Vec::new();
-
-    for cmd in cmds {
-        let start = current;
-        let mut transformed = cmd;
-        transformed.p0 = transform.transform_point(cmd.p0);
-        transformed.p1 = transform.transform_point(cmd.p1);
-        if cmd.op != PathOp::ArcTo {
-            transformed.p2 = transform.transform_point(cmd.p2);
-        } else if transform.determinant() < 0.0 {
-            transformed.clockwise = !cmd.clockwise;
-        }
-
-        match cmd.op {
-            PathOp::MoveTo | PathOp::LineTo => {
-                current = cmd.p0;
-                bbox.include_point(transformed.p0);
-            }
-            PathOp::ArcTo => {
-                bbox = bbox.union(
-                    Arc::new(
-                        transform.transform_point(start),
-                        transformed.p0,
-                        transformed.p1,
-                        transformed.clockwise,
-                    )
-                    .bbox(),
-                );
-                current = cmd.p0;
-            }
-            PathOp::CubicTo => {
-                bbox.include_point(transformed.p0);
-                bbox.include_point(transformed.p1);
-                bbox.include_point(transformed.p2);
-                current = cmd.p2;
-            }
-            PathOp::Close => {}
-        }
-
-        transformed_cmds.push(transformed);
-    }
-
-    ContourBuf::from_parts(bbox, transformed_cmds)
-}
-
 pub(crate) fn validate_cmd_points(name: &str, cmds: &[PathCmd]) -> Result<(), String> {
     for (index, cmd) in cmds.iter().enumerate() {
-        if !cmd.p0.is_finite() || !cmd.p1.is_finite() || !cmd.p2.is_finite() {
+        if !cmd.p0.is_finite() || !cmd.p1.is_finite() || !cmd.p2.is_finite() || !cmd.p3.is_finite()
+        {
             return Err(format!(
                 "{name} path command {index} contains non-finite point"
             ));
@@ -423,74 +584,129 @@ impl From<crate::geom::style::StrokeStyle> for StrokeToFillStyle {
     }
 }
 
-/// Convert stroked centerlines/arcs into filled contours.
+/// Convert stroked centerlines/arcs into filled contours within `accuracy`.
 ///
-/// Use this for rendering, boolean composition, comparison, and fallback
-/// targets that cannot represent native strokes. Gerber export should prefer
-/// native draw/arc objects where possible.
+/// This is a preparation step: the outline is approximated once, here, and
+/// the returned contours record what it cost. Use it for boolean
+/// composition, comparison, and targets that cannot represent native
+/// strokes. Gerber export should prefer native draw/arc objects.
 pub fn stroke_to_fill(
     contours: &[ContourBuf],
     style: StrokeToFillStyle,
-) -> Option<Vec<ContourBuf>> {
+    accuracy: GeometryAccuracy,
+) -> Result<Option<Vec<ContourBuf>>, AccuracyError> {
+    if !style.width.is_finite()
+        || contours
+            .iter()
+            .any(|c| !c.bbox.is_valid() || !c.uncertainty_mm.is_finite() || c.uncertainty_mm < 0.0)
+    {
+        return Err(AccuracyError::InvalidGeometry("invalid stroke geometry"));
+    }
     if style.width <= 0.0 {
-        return None;
+        return Ok(None);
     }
-
-    if matches!(style.pattern, LinePattern::Solid | LinePattern::Erase) {
-        return solid_stroke_to_fill(contours, style);
-    }
-
-    let solid_style = StrokeToFillStyle {
-        pattern: LinePattern::Solid,
-        ..style
-    };
-    let mut out = Vec::new();
-    for contour in contours {
-        let segments = contour.segments().collect::<Vec<_>>();
-        for mark in stroke_pattern_marks(&segments, style.pattern, style.width) {
-            match mark {
-                StrokePatternMark::Dash(segments) => {
-                    let Some(contour) = contour_from_segments(&segments) else {
-                        continue;
-                    };
-                    if let Some(mut contours) = solid_stroke_to_fill(&[contour], solid_style) {
-                        out.append(&mut contours);
+    if !matches!(style.pattern, LinePattern::Solid | LinePattern::Erase) {
+        let solid_style = StrokeToFillStyle {
+            pattern: LinePattern::Solid,
+            ..style
+        };
+        let mut out = Vec::new();
+        for contour in contours {
+            accuracy.check(contour.uncertainty_mm)?;
+            if contour
+                .cmds
+                .iter()
+                .any(|cmd| matches!(cmd.op, PathOp::CubicTo | PathOp::EllipseTo))
+            {
+                return Err(AccuracyError::InvalidGeometry(
+                    "pattern placement requires lines or circular arcs",
+                ));
+            }
+            let segments = contour.segments().collect::<Vec<_>>();
+            for mark in stroke_pattern_marks(&segments, style.pattern, style.width) {
+                match mark {
+                    StrokePatternMark::Dash(segments) => {
+                        if let Some(dash) = contour_from_segments(&segments) {
+                            out.extend(
+                                stroke_to_fill(
+                                    &[dash.with_uncertainty(contour.uncertainty_mm)],
+                                    solid_style,
+                                    accuracy,
+                                )?
+                                .unwrap_or_default(),
+                            );
+                        }
                     }
-                }
-                StrokePatternMark::Dot(at) => {
-                    let Some(dot) = crate::geom::shapes::circle(style.width) else {
-                        continue;
-                    };
-                    out.push(transform_cmds(
-                        dot.cmds,
-                        crate::geom::Affine2::translation(at),
-                    ));
+                    StrokePatternMark::Dot(at) => {
+                        let dot = crate::geom::shapes::circle(style.width)
+                            .expect("positive finite stroke width");
+                        out.push(
+                            dot.with_uncertainty(contour.uncertainty_mm)
+                                .transformed(Affine2::translation(at)),
+                        );
+                    }
                 }
             }
         }
+        return Ok((!out.is_empty()).then_some(out));
     }
-    (!out.is_empty()).then_some(out)
+    let prior = contours
+        .iter()
+        .map(|c| c.uncertainty_mm)
+        .fold(0.0, f64::max);
+    let bbox = contours
+        .iter()
+        .fold(BBox::empty(), |bbox, c| bbox.union(c.bbox))
+        .expand(style.width.max(0.0));
+    let numeric = crate::geom::accuracy::numerical_error(bbox);
+    let remaining = accuracy.allowance(prior + stroke_rounding_error(style) + numeric)?;
+    if remaining < f64::EPSILON
+        || (bbox.width().max(bbox.height()) / remaining).sqrt() > 1_000_000.0
+    {
+        return Err(AccuracyError::SubdivisionLimit);
+    }
+    let mut out = solid_stroke_to_fill(contours, style, remaining / 2.0);
+    if let Some(out) = &mut out {
+        for contour in out {
+            contour.uncertainty_mm += numeric;
+            accuracy.check(contour.uncertainty_mm)?;
+        }
+    }
+    Ok(out)
+}
+
+// Kurbo's round caps/joins use a fixed unit-circle tolerance, independently
+// of the tolerance passed to stroke().
+fn stroke_rounding_error(style: StrokeToFillStyle) -> f64 {
+    if matches!(style.line_cap, LineCap::Round) || matches!(style.line_join, LineJoin::Round) {
+        0.0004 * style.width.max(0.0) / 2.0
+    } else {
+        0.0
+    }
 }
 
 fn solid_stroke_to_fill(
     contours: &[ContourBuf],
     style: StrokeToFillStyle,
+    accuracy: f64,
 ) -> Option<Vec<ContourBuf>> {
-    let source = contours_to_kurbo(contours);
+    let (source, conversion_error) = contours_to_kurbo(contours, accuracy);
     if source.elements().is_empty() {
         return None;
     }
     let stroke = Stroke::new(style.width)
         .with_join(kurbo_join(style.line_join))
         .with_caps(kurbo_cap(style.line_cap));
-    let outline = kurbo::stroke(
-        source,
-        &stroke,
-        &StrokeOpts::default(),
-        tol::STROKE_OUTLINE_MM,
-    );
+    let outline = kurbo::stroke(source, &stroke, &StrokeOpts::default(), accuracy);
     let mut out = kurbo_path_to_contours(&outline);
     for contour in &mut out {
+        contour.uncertainty_mm = contours
+            .iter()
+            .map(|c| c.uncertainty_mm)
+            .fold(0.0, f64::max)
+            + conversion_error
+            + stroke_rounding_error(style)
+            + accuracy;
         if contour
             .cmds
             .last()
@@ -517,6 +733,7 @@ fn contour_from_segments(segments: &[Segment]) -> Option<ContourBuf> {
             Segment::Arc(arc) => {
                 cmds.push(PathCmd::arc_to(arc.end, arc.center, arc.clockwise));
             }
+            Segment::Ellipse(arc) => cmds.push(PathCmd::from_elliptical_arc(arc)),
             Segment::Cubic { c1, c2, end, .. } => {
                 cmds.push(PathCmd::cubic_to(c1, c2, end));
             }
@@ -526,9 +743,13 @@ fn contour_from_segments(segments: &[Segment]) -> Option<ContourBuf> {
     Some(ContourBuf::new(cmds))
 }
 
-pub(crate) fn contours_to_kurbo(contours: &[ContourBuf]) -> BezPath {
+/// Convert contours to a kurbo path, approximating circular and elliptical
+/// arcs by cubics whose radial error stays within `accuracy`. Returns the
+/// largest conversion error incurred.
+pub(crate) fn contours_to_kurbo(contours: &[ContourBuf], accuracy: f64) -> (BezPath, f64) {
     let mut out = BezPath::new();
     let mut current = Point::default();
+    let mut conversion_error: f64 = 0.0;
     for contour in contours {
         for cmd in &contour.cmds {
             match cmd.op {
@@ -541,7 +762,20 @@ pub(crate) fn contours_to_kurbo(contours: &[ContourBuf]) -> BezPath {
                     out.line_to(kurbo_point(cmd.p0));
                 }
                 PathOp::ArcTo => {
-                    append_arc_to_kurbo(&mut out, current, cmd.p0, cmd.p1, cmd.clockwise);
+                    let arc = Arc::new(current, cmd.p0, cmd.p1, cmd.clockwise);
+                    let radius_mismatch = (arc.radius() - cmd.p0.distance_to(cmd.p1)).abs();
+                    conversion_error = conversion_error.max(
+                        append_arc_to_kurbo(&mut out, arc.to_elliptical(), accuracy)
+                            + radius_mismatch,
+                    );
+                    current = cmd.p0;
+                }
+                PathOp::EllipseTo => {
+                    conversion_error = conversion_error.max(append_arc_to_kurbo(
+                        &mut out,
+                        cmd.elliptical_arc(current),
+                        accuracy,
+                    ));
                     current = cmd.p0;
                 }
                 PathOp::CubicTo => {
@@ -556,47 +790,40 @@ pub(crate) fn contours_to_kurbo(contours: &[ContourBuf]) -> BezPath {
             }
         }
     }
-    out
+    (out, conversion_error)
 }
 
-fn append_arc_to_kurbo(
-    out: &mut BezPath,
-    start: Point,
-    end: Point,
-    center: Point,
-    clockwise: bool,
-) {
-    let arc = Arc::new(start, end, center, clockwise);
-    let radius = arc.radius();
-    if radius == 0.0 {
-        out.line_to(kurbo_point(end));
-        return;
+/// Append an elliptical arc as tangent-matched cubics and return the radial
+/// error bound. A cubic over a unit-circle angle `δ ≤ π/2` errs by at most
+/// `δ⁶ / 40000`, and the axis basis scales that by its largest singular
+/// value, so the sweep is subdivided until that bound meets `accuracy`.
+fn append_arc_to_kurbo(out: &mut BezPath, arc: EllipticalArc, accuracy: f64) -> f64 {
+    let scale = arc.max_scale();
+    if arc.is_degenerate() || scale == 0.0 {
+        out.line_to(kurbo_point(arc.end));
+        return 0.0;
     }
-
-    let sweep = arc.sweep_radians();
-    let signed_sweep = if clockwise { -sweep } else { sweep };
-    let segment_count = (signed_sweep.abs() / std::f64::consts::FRAC_PI_2)
-        .ceil()
-        .max(1.0) as usize;
+    let signed_sweep = arc.signed_sweep_radians();
+    let max_angle = (accuracy * 40_000.0 / scale)
+        .powf(1.0 / 6.0)
+        .min(std::f64::consts::FRAC_PI_2);
+    let segment_count = (signed_sweep.abs() / max_angle).ceil().max(1.0) as usize;
     let delta = signed_sweep / segment_count as f64;
-    let mut angle = start.angle_from(center);
+    let mut angle = arc.start_angle();
+    // Tangent at parameter θ is −x_axis·sin θ + y_axis·cos θ.
+    let tangent = |angle: f64| arc.y_axis * angle.cos() - arc.x_axis * angle.sin();
 
     for _ in 0..segment_count {
         let next_angle = angle + delta;
         let k = 4.0 / 3.0 * (delta / 4.0).tan();
         let p0 = arc.point_at(angle);
         let p3 = arc.point_at(next_angle);
-        let c1 = Point::new(
-            p0.x - radius * angle.sin() * k,
-            p0.y + radius * angle.cos() * k,
-        );
-        let c2 = Point::new(
-            p3.x + radius * next_angle.sin() * k,
-            p3.y - radius * next_angle.cos() * k,
-        );
+        let c1 = p0 + tangent(angle) * k;
+        let c2 = p3 - tangent(next_angle) * k;
         out.curve_to(kurbo_point(c1), kurbo_point(c2), kurbo_point(p3));
         angle = next_angle;
     }
+    scale * delta.abs().powi(6) / 40_000.0
 }
 
 fn kurbo_path_to_contours(path: &BezPath) -> Vec<ContourBuf> {
@@ -683,13 +910,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn signed_area_preserves_arcs_and_cubics() {
+    fn signed_area_preserves_arcs_ellipses_and_cubics() {
         let circle = ContourBuf::new(vec![
             PathCmd::move_to(Point::new(1.0, 0.0)),
             PathCmd::arc_to(Point::new(1.0, 0.0), Point::ZERO, false),
             PathCmd::close(),
         ]);
         assert!((circle.signed_area() - std::f64::consts::PI).abs() <= 1e-12);
+
+        let ellipse = circle.clone().transformed(Affine2 {
+            m00: 2.0,
+            m11: 0.5,
+            ..Affine2::IDENTITY
+        });
+        assert!(ellipse.cmds[1].op == PathOp::EllipseTo);
+        assert!((ellipse.signed_area() - std::f64::consts::PI).abs() <= 1e-12);
+        let mirrored = circle.transformed(Affine2 {
+            m00: -1.0,
+            m11: 2.0,
+            ..Affine2::IDENTITY
+        });
+        assert!((mirrored.signed_area() + 2.0 * std::f64::consts::PI).abs() <= 1e-12);
 
         let curved = ContourBuf::new(vec![
             PathCmd::move_to(Point::ZERO),
@@ -704,25 +945,73 @@ mod tests {
     }
 
     #[test]
+    fn similarity_transforms_keep_circular_arcs() {
+        let circle = crate::geom::shapes::circle(2.0).unwrap();
+        let placed = circle.transformed(Affine2::placement(
+            Point::new(5.0, 5.0),
+            30.0,
+            crate::geom::point::Mirror::NONE,
+            3.0,
+        ));
+        assert!(placed.cmds.iter().all(|cmd| cmd.op != PathOp::EllipseTo));
+        assert!((placed.bbox.min.x - 2.0).abs() <= 1e-9);
+        assert!((placed.bbox.max.y - 8.0).abs() <= 1e-9);
+    }
+
+    #[test]
+    fn flattening_curves_stays_within_the_requested_error() {
+        let ellipse = crate::geom::shapes::ellipse(4.0, 2.0).unwrap();
+        for budget in [0.01, 0.001, 0.0001] {
+            let flat = ellipse
+                .flattened_curves(GeometryAccuracy::new(budget).unwrap())
+                .unwrap();
+            assert!(flat.cmds.iter().all(|cmd| !cmd.is_curve()));
+            assert!(flat.uncertainty_mm <= budget);
+            let worst = flat
+                .segments()
+                .map(|segment| {
+                    let mid = segment.point_at(0.5);
+                    let radial = ((mid.x / 2.0).powi(2) + mid.y.powi(2)).sqrt();
+                    (1.0 - radial).abs()
+                })
+                .fold(0.0, f64::max);
+            // Radial parameter error bounds the geometric error on this ellipse.
+            assert!(
+                worst <= flat.uncertainty_mm,
+                "{worst} > {}",
+                flat.uncertainty_mm
+            );
+        }
+    }
+
+    #[test]
     fn stroke_to_fill_rejects_non_positive_width() {
+        let accuracy = GeometryAccuracy::default();
+
         let source = vec![line_contour(Point::new(0.0, 0.0), Point::new(1.0, 0.0))];
 
         assert!(
             stroke_to_fill(
                 &source,
-                StrokeToFillStyle::new(0.0, LineCap::Round, LineJoin::Round)
+                StrokeToFillStyle::new(0.0, LineCap::Round, LineJoin::Round),
+                accuracy
             )
+            .unwrap()
             .is_none()
         );
     }
 
     #[test]
     fn stroke_to_fill_expands_centerline_by_half_width() {
+        let accuracy = GeometryAccuracy::default();
+
         let source = vec![line_contour(Point::new(0.0, 0.0), Point::new(10.0, 0.0))];
         let fill = stroke_to_fill(
             &source,
             StrokeToFillStyle::new(2.0, LineCap::Butt, LineJoin::Round),
+            accuracy,
         )
+        .unwrap()
         .expect("stroke should expand to fill geometry");
         let bbox = fill
             .iter()
@@ -741,23 +1030,14 @@ mod tests {
     }
 
     #[test]
-    fn stroke_to_fill_expands_phantom_pattern_with_dot_flashes() {
-        let source = vec![line_contour(Point::new(0.0, 0.0), Point::new(20.0, 0.0))];
+    fn patterned_strokes_preserve_input_error() {
+        let source = line_contour(Point::ZERO, Point::new(20.0, 0.0)).with_uncertainty(0.001);
         let mut style = StrokeToFillStyle::new(1.0, LineCap::Round, LineJoin::Round);
         style.pattern = LinePattern::Phantom;
-
-        let fill = stroke_to_fill(&source, style).expect("pattern should expand to fill geometry");
-        let bboxes = fill.iter().map(|contour| contour.bbox).collect::<Vec<_>>();
-
-        assert_eq!(fill.len(), 4);
-        assert!(
-            bboxes.iter().any(|bbox| {
-                (bbox.min.x - 8.0).abs() <= 1e-9 && (bbox.max.x - 9.0).abs() <= 1e-9
-            })
-        );
-        assert!(bboxes.iter().any(|bbox| {
-            (bbox.min.x - 11.0).abs() <= 1e-9 && (bbox.max.x - 12.0).abs() <= 1e-9
-        }));
+        let fill = stroke_to_fill(&[source], style, GeometryAccuracy::default())
+            .unwrap()
+            .unwrap();
+        assert!(fill.iter().all(|contour| contour.uncertainty_mm >= 0.001));
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/pattern.rs
+++ b/crates/pcb-ir/src/geom/pattern.rs
@@ -5,7 +5,7 @@
 //! dot centers so format writers do not need to guess at source-specific
 //! rendering conventions.
 
-use crate::geom::{Arc, LinePattern, Point, Segment};
+use crate::geom::{Arc, EllipticalArc, LinePattern, Point, Segment};
 
 const EPSILON: f64 = 1e-9;
 
@@ -86,7 +86,9 @@ fn measured_segments(segments: &[Segment]) -> Vec<MeasuredSegment> {
     let mut measured = Vec::with_capacity(segments.len());
     let mut cursor = 0.0;
     for &segment in segments {
-        if let Segment::Cubic { start, .. } = segment {
+        if let Segment::Cubic { start, .. } | Segment::Ellipse(EllipticalArc { start, .. }) =
+            segment
+        {
             const STEPS: usize = 32;
             let mut points = Vec::with_capacity(STEPS);
             segment.sample_points(STEPS, &mut points);
@@ -126,7 +128,9 @@ fn segment_length(segment: Segment) -> f64 {
     match segment {
         Segment::Line { start, end } => start.distance_to(end),
         Segment::Arc(arc) => arc.radius() * arc.sweep_radians(),
-        Segment::Cubic { .. } => unreachable!("cubic segments are flattened before measurement"),
+        Segment::Cubic { .. } | Segment::Ellipse(_) => {
+            unreachable!("curved segments are flattened before measurement")
+        }
     }
 }
 
@@ -173,7 +177,7 @@ fn segment_slice(segment: Segment, start_t: f64, end_t: f64) -> Segment {
             arc.center,
             arc.clockwise,
         )),
-        Segment::Cubic { .. } => Segment::Line {
+        Segment::Cubic { .. } | Segment::Ellipse(_) => Segment::Line {
             start: segment_point(segment, start_t),
             end: segment_point(segment, end_t),
         },
@@ -181,25 +185,7 @@ fn segment_slice(segment: Segment, start_t: f64, end_t: f64) -> Segment {
 }
 
 fn segment_point(segment: Segment, t: f64) -> Point {
-    match segment {
-        Segment::Line { start, end } => start + (end - start) * t,
-        Segment::Arc(arc) => {
-            let start_angle = arc.start.angle_from(arc.center);
-            let signed_sweep = if arc.clockwise {
-                -arc.sweep_radians()
-            } else {
-                arc.sweep_radians()
-            };
-            arc.point_at(start_angle + signed_sweep * t)
-        }
-        Segment::Cubic { start, c1, c2, end } => {
-            let u = 1.0 - t;
-            start * (u * u * u)
-                + c1 * (3.0 * u * u * t)
-                + c2 * (3.0 * u * t * t)
-                + end * (t * t * t)
-        }
-    }
+    segment.point_at(t)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -511,9 +511,7 @@ impl ContourSet {
                 !c.bbox.is_valid()
                     || !c.uncertainty_mm.is_finite()
                     || c.uncertainty_mm < 0.0
-                    || c.cmds.iter().any(|cmd| {
-                        !cmd.p0.is_finite() || !cmd.p1.is_finite() || !cmd.p2.is_finite()
-                    })
+                    || !c.cmds.iter().all(|cmd| cmd.is_finite())
             })
         {
             return Err(AccuracyError::InvalidGeometry(

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -536,7 +536,10 @@ impl ContourSet {
     }
 
     /// Regularized union of many regions.
-    pub fn union_all(resolution: Resolution, regions: impl IntoIterator<Item = Self>) -> Self {
+    pub fn union_all(
+        resolution: Resolution,
+        regions: impl IntoIterator<Item = Self>,
+    ) -> Result<Self, AccuracyError> {
         let mut composer = PaintComposer::new(resolution);
         for region in regions {
             composer.push(Polarity::Dark, region);
@@ -565,7 +568,7 @@ impl ContourSet {
                 )?,
             );
         }
-        composer.finish().checked()
+        composer.finish()
     }
 
     /// Build the union of the geometric images painted by a set of paths.
@@ -625,7 +628,7 @@ impl ContourSet {
                 Self::from_contours(&contours, fill_rule, resolution.strict())?,
             );
         }
-        composer.finish().checked()
+        composer.finish()
     }
 
     pub fn rectangle(bbox: BBox, resolution: Resolution) -> Self {
@@ -1498,9 +1501,10 @@ impl PaintComposer {
         self.run.append(&mut region.rings);
     }
 
-    pub fn finish(mut self) -> ContourSet {
+    /// The composed image, checked against its budget.
+    pub fn finish(mut self) -> Result<ContourSet, AccuracyError> {
         self.flush_run();
-        ContourSet::from_regularized(self.image, self.resolution, self.uncertainty_mm)
+        ContourSet::from_regularized(self.image, self.resolution, self.uncertainty_mm).checked()
     }
 
     fn flush_run(&mut self) {

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -1589,6 +1589,9 @@ fn flatten_shapes(shapes: Vec<Shape>) -> Vec<Ring> {
 }
 
 fn push_ring(out: &mut Vec<Ring>, ring: &mut Ring) {
+    // Flattening emits an explicit corner point at every join; drop the
+    // zero-length edges that would otherwise reach the writers.
+    ring.dedup();
     if ring.first() == ring.last() {
         ring.pop();
     }

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -58,7 +58,7 @@ fn flatten_contours(contours: &[ContourBuf], accuracy: f64) -> (Vec<Ring>, f64) 
         .iter()
         .any(|el| matches!(el, kurbo::PathEl::CurveTo(..) | kurbo::PathEl::QuadTo(..)));
     let flatten_error = if curved {
-        (accuracy - conversion_error).max(accuracy / 2.0)
+        accuracy - conversion_error
     } else {
         0.0
     };
@@ -472,10 +472,8 @@ impl ContourSet {
         } else {
             f64::INFINITY
         };
-        if resolution.tolerance_mm > 0.0 {
-            let min_area = resolution.tolerance_mm.powi(2);
-            rings.retain(|ring| ring_signed_area(ring).abs() > min_area);
-        }
+        let min_area = resolution.tolerance_mm.powi(2);
+        rings.retain(|ring| ring_signed_area(ring).abs() > min_area);
         let ring_bounds = rings
             .iter()
             .map(|ring| rings_bbox(std::slice::from_ref(ring)))
@@ -537,12 +535,11 @@ impl ContourSet {
             let bounds = segment.bbox();
             (bounds.width().max(bounds.height()) / remaining).sqrt() > MAX_CHORDS_PER_SEGMENT
         };
-        if remaining < f64::EPSILON
-            || contours
-                .iter()
-                .flat_map(ContourBuf::segments)
-                .filter(|segment| !matches!(segment, Segment::Line { .. }))
-                .any(absurd)
+        if contours
+            .iter()
+            .flat_map(ContourBuf::segments)
+            .filter(|segment| !matches!(segment, Segment::Line { .. }))
+            .any(absurd)
         {
             return Err(AccuracyError::SubdivisionLimit);
         }
@@ -937,14 +934,9 @@ impl ContourSet {
 
     /// Decimate the region's boundary so it only shrinks; see
     /// [`decimate_rings_inward`].
-    pub fn decimate_inward(&self, deviation_mm: f64) -> Result<Self, AccuracyError> {
-        if !deviation_mm.is_finite() || deviation_mm < 0.0 {
-            return Err(AccuracyError::InvalidGeometry(
-                "invalid decimation deviation",
-            ));
-        }
+    pub fn decimate_inward(&self) -> Result<Self, AccuracyError> {
         let inherited = self.uncertainty_mm + numerical_error(self.bbox);
-        let deviation_mm = deviation_mm.min(self.budget().allowance(inherited)?);
+        let deviation_mm = self.budget().allowance(inherited)?;
         Ok(Self::from_regularized(
             simplify_rings(
                 decimate_rings_inward(&self.rings, deviation_mm),
@@ -3018,8 +3010,9 @@ mod tests {
             res(tol::REGION_MM),
         )
         .unwrap();
-        let deviation = 0.05;
-        let decimated = ring.decimate_inward(deviation).unwrap();
+        let decimated = ring.decimate_inward().unwrap();
+        let deviation = decimated.uncertainty_mm - ring.uncertainty_mm;
+        assert!(deviation > 0.0);
 
         assert!(decimated.difference(&ring).area() <= ring.tolerance().powi(2));
 

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -456,10 +456,14 @@ impl ContourSet {
     }
 
     /// Regularize source polygons. Their vertices are taken as exact; only
-    /// coordinate rounding is charged.
-    pub fn from_rings(rings: Vec<Ring>, fill_rule: FillRule, resolution: Resolution) -> Self {
+    /// coordinate rounding is charged, and checked like any other cost.
+    pub fn from_rings(
+        rings: Vec<Ring>,
+        fill_rule: FillRule,
+        resolution: Resolution,
+    ) -> Result<Self, AccuracyError> {
         let uncertainty = numerical_error(rings_bbox(&rings));
-        Self::from_regularized(simplify_rings(rings, fill_rule), resolution, uncertainty)
+        Self::from_regularized(simplify_rings(rings, fill_rule), resolution, uncertainty).checked()
     }
 
     /// Construct from known regularized polygons, preserving their history.
@@ -677,31 +681,38 @@ impl ContourSet {
     }
 
     /// Regularized union: `self ∪ other`.
-    pub fn union(&self, other: &Self) -> Self {
+    pub fn union(&self, other: &Self) -> Result<Self, AccuracyError> {
+        let budget = self.resolution.meet(other.resolution).accuracy;
         if self.is_empty() && self.uncertainty_mm == 0.0 {
-            return other.clone();
+            return other.clone().rebudget(budget);
         }
         if other.is_empty() && other.uncertainty_mm == 0.0 {
-            return self.clone();
+            return self.clone().rebudget(budget);
         }
         self.boolean(other, OverlayRule::Union)
     }
 
-    pub fn union_assign(&mut self, other: &Self) {
-        *self = self.union(other);
+    pub fn union_assign(&mut self, other: &Self) -> Result<(), AccuracyError> {
+        *self = self.union(other)?;
+        Ok(())
     }
 
     /// Regularized difference: `self \ cutters`.
-    pub fn difference(&self, cutters: &Self) -> Self {
+    pub fn difference(&self, cutters: &Self) -> Result<Self, AccuracyError> {
         self.boolean(cutters, OverlayRule::Difference)
     }
 
     /// Regularized intersection: `self ∩ clip`.
-    pub fn intersection(&self, clip: &Self) -> Self {
+    pub fn intersection(&self, clip: &Self) -> Result<Self, AccuracyError> {
         self.boolean(clip, OverlayRule::Intersect)
     }
 
-    fn boolean(&self, other: &Self, rule: OverlayRule) -> Self {
+    /// Every point of the result's boundary is a point of an operand's
+    /// boundary or a crossing of two, so it stays within the larger operand
+    /// uncertainty of the source geometry; the overlay adds coordinate
+    /// rounding. The result takes the tighter budget and fails when the
+    /// operands' history does not fit it.
+    fn boolean(&self, other: &Self, rule: OverlayRule) -> Result<Self, AccuracyError> {
         let rings = flatten_shapes(self.rings.overlay_as::<i64>(
             &other.rings,
             rule,
@@ -709,7 +720,7 @@ impl ContourSet {
         ));
         let uncertainty = self.uncertainty_mm.max(other.uncertainty_mm)
             + numerical_error(self.bbox.union(other.bbox));
-        Self::from_regularized(rings, self.resolution.meet(other.resolution), uncertainty)
+        Self::from_regularized(rings, self.resolution.meet(other.resolution), uncertainty).checked()
     }
     /// Connected components, each retaining its own hole rings.
     pub fn connected_components(&self) -> Vec<Self> {
@@ -770,7 +781,12 @@ impl ContourSet {
     /// nearest point along a wall's own line, as at the corners of a notch
     /// or of aligned holes, leaves the side open and both reaches apply.
     /// Distinct components always face across void.
-    fn facing_components(&self, material_mm: f64, void_mm: f64, reach_mm: f64) -> Self {
+    fn facing_components(
+        &self,
+        material_mm: f64,
+        void_mm: f64,
+        reach_mm: f64,
+    ) -> Result<Self, AccuracyError> {
         let (components, outers) = self.ring_components();
         let segments = source_boundary_segments(self);
         let boundary = PreparedRegion::from_segments(
@@ -1173,7 +1189,6 @@ impl ContourSet {
         self.disk_erode(radius)?
             .disk_dilate(radius)?
             .intersection(self)
-            .checked()
     }
 
     /// Morphological closing by a disk: `(self ⊕ D_radius) ⊖ D_radius`.
@@ -1183,10 +1198,7 @@ impl ContourSet {
     /// fills void tips and gaps too small to accommodate the disk while
     /// rounding the surviving inward corners.
     pub fn disk_close(&self, radius: f64) -> Result<Self, AccuracyError> {
-        self.disk_dilate(radius)?
-            .disk_erode(radius)?
-            .union(self)
-            .checked()
+        self.disk_dilate(radius)?.disk_erode(radius)?.union(self)
     }
 
     /// Diagnose distinct components whose Euclidean separation is less than
@@ -1219,9 +1231,9 @@ impl ContourSet {
                 }
                 let overlap = left
                     .disk_dilate(radius)?
-                    .intersection(&right.disk_dilate(radius)?)
-                    .difference(self);
-                violations = violations.union(&overlap);
+                    .intersection(&right.disk_dilate(radius)?)?
+                    .difference(self)?;
+                violations = violations.union(&overlap)?;
             }
         }
         Ok(violations)
@@ -1270,7 +1282,7 @@ impl ContourSet {
 
         let mut kept = self.clone();
         while let Some(next) = kept.narrow_gap_trim(gap_radius, filled_radius, guard)? {
-            if kept.difference(&next).area() <= self.tolerance().powi(2) {
+            if kept.difference(&next)?.area() <= self.tolerance().powi(2) {
                 return Err(GapRegularizationError(format!(
                     "gap regularization stalled with {:.9} mm² of void-gap violations",
                     kept.disk_gap_violations(gap_radius)?.area()
@@ -1279,7 +1291,7 @@ impl ContourSet {
             kept = next;
         }
         Ok(DiskGapRegularization {
-            removed: self.difference(&kept).checked()?,
+            removed: self.difference(&kept)?,
             kept: kept.checked()?,
         })
     }
@@ -1299,10 +1311,9 @@ impl ContourSet {
         }
         let keep_out = narrow_void_keep_out(self, &narrow_voids, gap_radius + guard)?;
         Ok(Some(
-            self.difference(&keep_out)
+            self.difference(&keep_out)?
                 .disk_open(filled_radius)?
-                .intersection(self)
-                .checked()?,
+                .intersection(self)?,
         ))
     }
 
@@ -1343,8 +1354,8 @@ impl ContourSet {
             let facing = width_mm + 4.0 * region.tolerance();
             let touching = 3.0 * region.tolerance() + region.uncertainty_mm;
             let reach = 3.0 * (radius + 2.0 * region.tolerance());
-            let candidates = region.facing_components(facing, touching, reach);
-            Ok(candidates.difference(&candidates.disk_erode(radius)?.disk_dilate(radius)?))
+            let candidates = region.facing_components(facing, touching, reach)?;
+            candidates.difference(&candidates.disk_erode(radius)?.disk_dilate(radius)?)
         })
     }
 
@@ -1363,7 +1374,7 @@ impl ContourSet {
         self.two_sided_residual(radius, |region, radius| {
             let facing = width_mm + 4.0 * region.tolerance();
             let reach = 4.0 * (radius + 2.0 * region.tolerance());
-            let candidates = region.facing_components(0.0, facing, reach);
+            let candidates = region.facing_components(0.0, facing, reach)?;
             closing_residual(&candidates, radius)
         })
     }
@@ -1635,7 +1646,7 @@ struct OrientedBoundarySegment {
 }
 
 fn closing_residual(region: &ContourSet, radius: f64) -> Result<ContourSet, AccuracyError> {
-    region.disk_close(radius)?.difference(region).checked()
+    region.disk_close(radius)?.difference(region)
 }
 
 /// Every source boundary edge longer than the region tolerance, in ring
@@ -2403,16 +2414,13 @@ fn narrow_void_keep_out(
     radius: f64,
 ) -> Result<ContourSet, GapRegularizationError> {
     let axis_keep_out = narrow_void_medial_axis_keep_out(source, narrow_voids, radius)?;
-    let axisless = narrow_voids
-        .connected_components()
-        .into_iter()
-        .filter(|component| component.intersection(&axis_keep_out).is_empty())
-        .collect::<Vec<_>>();
-    Ok(axisless
-        .into_iter()
-        .try_fold(axis_keep_out, |keep_out, thin| {
-            Ok::<_, AccuracyError>(keep_out.union(&thin.disk_dilate(radius)?))
-        })?)
+    let mut keep_out = axis_keep_out.clone();
+    for component in narrow_voids.connected_components() {
+        if component.intersection(&axis_keep_out)?.is_empty() {
+            keep_out = keep_out.union(&component.disk_dilate(radius)?)?;
+        }
+    }
+    Ok(keep_out)
 }
 
 fn narrow_void_medial_axis_keep_out(
@@ -2568,9 +2576,9 @@ fn narrow_void_medial_axis_keep_out(
         source.resolution,
     )?;
     let interior_axis =
-        medial_axis.intersection(&narrow_voids.disk_erode(2.0 * axis_stroke_radius)?);
+        medial_axis.intersection(&narrow_voids.disk_erode(2.0 * axis_stroke_radius)?)?;
     let keep_out = interior_axis.disk_dilate(radius)?;
-    Ok(keep_out.intersection(&source.disk_dilate(radius)?))
+    Ok(keep_out.intersection(&source.disk_dilate(radius)?)?)
 }
 
 fn boundary_segments_are_incident(left: BoundarySegment, right: BoundarySegment) -> bool {
@@ -2881,18 +2889,22 @@ mod tests {
                 rect(2.0, 2.0, 8.0, 8.0),
                 res(tol::REGION_MM),
             ))
+            .unwrap()
             .union(&ContourSet::rectangle(
                 rect(3.0, 3.0, 7.0, 7.0),
                 res(tol::REGION_MM),
             ))
+            .unwrap()
             .difference(&ContourSet::rectangle(
                 rect(4.0, 4.0, 6.0, 6.0),
                 res(tol::REGION_MM),
             ))
+            .unwrap()
             .union(&ContourSet::rectangle(
                 rect(20.0, 0.0, 30.0, 10.0),
                 res(tol::REGION_MM),
-            ));
+            ))
+            .unwrap();
         assert_eq!(region.rings.len(), 5);
 
         let (components, _) = region.ring_components();
@@ -2916,7 +2928,7 @@ mod tests {
         let trace = ContourSet::rectangle(rect(0.0, 0.0, 5.0, 0.1), res(tol::REGION_MM));
         let pad = ContourSet::rectangle(rect(10.0, 0.0, 12.0, 2.0), res(tol::REGION_MM));
         let neighbour = ContourSet::rectangle(rect(12.15, 0.0, 14.0, 2.0), res(tol::REGION_MM));
-        let region = trace.union(&pad).union(&neighbour);
+        let region = trace.union(&pad).unwrap().union(&neighbour).unwrap();
         assert_eq!(region.rings.len(), 3);
 
         let same_bounds = |left: BBox, right: BBox| {
@@ -2924,46 +2936,63 @@ mod tests {
         };
         // The trace's long walls face across material; a reach past the
         // whole trace keeps all of it and none of the pads.
-        let material = region.facing_components(0.2, 0.01, 1.0);
+        let material = region.facing_components(0.2, 0.01, 1.0).unwrap();
         assert_eq!(material.rings.len(), 1);
         assert!(same_bounds(material.bbox, trace.bbox));
 
         // The pads face each other across their gap, along their whole
         // aligned edges, and the trace is out of reach.
-        let void = region.facing_components(0.0, 0.2, 0.5);
+        let void = region.facing_components(0.0, 0.2, 0.5).unwrap();
         assert_eq!(void.rings.len(), 2);
         assert!(same_bounds(void.bbox, pad.bbox.union(neighbour.bbox)));
 
-        let with_context = region.facing_components(0.0, 0.2, 10.0);
+        let with_context = region.facing_components(0.0, 0.2, 10.0).unwrap();
         assert_eq!(with_context.rings.len(), 3);
 
         // A notch faces across void; a plane web between holes across material.
-        let notched =
-            ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM)).difference(
-                &ContourSet::rectangle(rect(1.9, 2.0, 2.1, 4.5), res(tol::REGION_MM)),
-            );
-        assert_eq!(notched.facing_components(0.0, 0.3, 1.0).rings.len(), 1);
-        assert!(notched.facing_components(0.15, 0.15, 1.0).is_empty());
+        let notched = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM))
+            .difference(&ContourSet::rectangle(
+                rect(1.9, 2.0, 2.1, 4.5),
+                res(tol::REGION_MM),
+            ))
+            .unwrap();
+        assert_eq!(
+            notched
+                .facing_components(0.0, 0.3, 1.0)
+                .unwrap()
+                .rings
+                .len(),
+            1
+        );
+        assert!(
+            notched
+                .facing_components(0.15, 0.15, 1.0)
+                .unwrap()
+                .is_empty()
+        );
         let webbed = ContourSet::rectangle(rect(0.0, 0.0, 8.0, 4.0), res(tol::REGION_MM))
             .difference(&ContourSet::rectangle(
                 rect(1.0, 1.0, 1.9, 3.0),
                 res(tol::REGION_MM),
             ))
+            .unwrap()
             .difference(&ContourSet::rectangle(
                 rect(2.1, 1.0, 3.0, 3.0),
                 res(tol::REGION_MM),
             ))
+            .unwrap()
             .difference(&ContourSet::rectangle(
                 rect(6.0, 1.0, 7.0, 3.0),
                 res(tol::REGION_MM),
-            ));
-        let nearby_web = webbed.facing_components(0.3, 0.0, 1.0);
+            ))
+            .unwrap();
+        let nearby_web = webbed.facing_components(0.3, 0.0, 1.0).unwrap();
         assert_eq!(nearby_web.rings.len(), 3);
         assert!(nearby_web.contains_point(Point::new(2.0, 2.0)));
         assert!(nearby_web.contains_point(Point::new(2.0, 3.5)));
         assert!(!nearby_web.contains_point(Point::new(6.5, 2.0)));
         assert!(!nearby_web.contains_point(Point::new(5.0, 3.5)));
-        assert!(webbed.facing_components(0.0, 0.15, 1.0).is_empty());
+        assert!(webbed.facing_components(0.0, 0.15, 1.0).unwrap().is_empty());
     }
 
     #[test]
@@ -3016,7 +3045,7 @@ mod tests {
         let deviation = decimated.uncertainty_mm - ring.uncertainty_mm;
         assert!(deviation > 0.0);
 
-        assert!(decimated.difference(&ring).area() <= ring.tolerance().powi(2));
+        assert!(decimated.difference(&ring).unwrap().area() <= ring.tolerance().powi(2));
 
         // Area loss is bounded by the deviation times the boundary length.
         let perimeter: f64 = ring
@@ -3117,9 +3146,12 @@ mod tests {
     /// fall in has to see that sign.
     #[test]
     fn grid_coverage_subtracts_holes() {
-        let ring = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM)).difference(
-            &ContourSet::rectangle(rect(1.0, 1.0, 2.0, 3.0), res(tol::REGION_MM)),
-        );
+        let ring = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM))
+            .difference(&ContourSet::rectangle(
+                rect(1.0, 1.0, 2.0, 3.0),
+                res(tol::REGION_MM),
+            ))
+            .unwrap();
 
         let coverage = ring.grid_coverage(rect(0.0, 0.0, 4.0, 4.0), 1, 1);
 
@@ -3132,8 +3164,8 @@ mod tests {
         let inner = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), res(tol::REGION_MM));
         let clip = ContourSet::rectangle(rect(5.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
 
-        let ring = outer.difference(&inner);
-        let clipped = ring.intersection(&clip);
+        let ring = outer.difference(&inner).unwrap();
+        let clipped = ring.intersection(&clip).unwrap();
         let expanded = clipped.disk_dilate(0.5).unwrap();
 
         assert!(!expanded.is_empty());
@@ -3174,7 +3206,7 @@ mod tests {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM));
         let inner = ContourSet::rectangle(rect(1.0, 1.0, 3.0, 3.0), res(tol::REGION_MM));
 
-        let ring = outer.difference(&inner);
+        let ring = outer.difference(&inner).unwrap();
 
         assert!((ring.area() - 12.0).abs() <= 1e-6);
     }
@@ -3183,7 +3215,7 @@ mod tests {
     fn containment_observes_boundaries_and_holes() {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let hole = ContourSet::rectangle(rect(4.0, 4.0, 6.0, 6.0), res(tol::REGION_MM));
-        let region = outer.difference(&hole);
+        let region = outer.difference(&hole).unwrap();
 
         assert!(region.contains_point(Point::new(2.0, 2.0)));
         assert!(region.contains_point(Point::new(0.0, 5.0)));
@@ -3213,7 +3245,7 @@ mod tests {
     fn segment_spans_preserve_holes_and_clip_to_the_query() {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let hole = ContourSet::rectangle(rect(4.0, 2.0, 6.0, 8.0), res(tol::REGION_MM));
-        let ring = outer.difference(&hole);
+        let ring = outer.difference(&hole).unwrap();
 
         assert_spans(
             ring.segment_spans(Point::new(-2.0, 5.0), Point::new(12.0, 5.0)),
@@ -3239,9 +3271,11 @@ mod tests {
             ]],
             FillRule::NonZero,
             res(tol::REGION_MM),
-        );
+        )
+        .unwrap();
         assert_spans(
             left.union(&concave)
+                .unwrap()
                 .segment_spans(Point::new(-1.0, 1.5), Point::new(9.0, 1.5)),
             &[((0.0, 1.5), (2.0, 1.5)), ((4.0, 1.5), (5.0, 1.5))],
         );
@@ -3295,7 +3329,7 @@ mod tests {
         let circle = shapes::circle(2.0).unwrap();
         let circle = circle.transformed(crate::geom::Affine2::translation(Point::new(5.0, 5.0)));
         let hole = ContourSet::from_filled_contours(&[circle], res(tol::REGION_MM)).unwrap();
-        let region = outer.difference(&hole);
+        let region = outer.difference(&hole).unwrap();
 
         let contours = region.to_bridged_contours();
         let round_trip =
@@ -3316,7 +3350,7 @@ mod tests {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let hole = ContourSet::rectangle(rect(4.0, 4.0, 6.0, 6.0), res(tol::REGION_MM));
 
-        let eroded = outer.difference(&hole).disk_erode(0.5).unwrap();
+        let eroded = outer.difference(&hole).unwrap().disk_erode(0.5).unwrap();
 
         assert!((eroded.bbox.min.x - 0.5).abs() <= 1e-9);
         assert!((eroded.bbox.min.y - 0.5).abs() <= 1e-9);
@@ -3344,7 +3378,7 @@ mod tests {
 
         let opened = region.disk_open(0.5).unwrap();
 
-        assert!(opened.difference(&region).is_empty());
+        assert!(opened.difference(&region).unwrap().is_empty());
         assert!((opened.bbox.min.x - 0.0).abs() <= 1e-9);
         assert!((opened.bbox.min.y - 0.0).abs() <= 1e-9);
         assert!((opened.bbox.max.x - 10.0).abs() <= 1e-9);
@@ -3357,25 +3391,29 @@ mod tests {
         let body = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let sliver = ContourSet::rectangle(rect(12.0, 0.0, 20.0, 0.8), res(tol::REGION_MM));
         let island = ContourSet::rectangle(rect(22.0, 0.0, 22.8, 0.8), res(tol::REGION_MM));
-        let region = body.union(&sliver).union(&island);
+        let region = body.union(&sliver).unwrap().union(&island).unwrap();
 
         let opened = region.disk_open(0.5).unwrap();
 
         assert_eq!(opened.connected_components().len(), 1);
-        assert!(opened.intersection(&body).area() > 99.0);
-        assert!(opened.intersection(&sliver).is_empty());
-        assert!(opened.intersection(&island).is_empty());
+        assert!(opened.intersection(&body).unwrap().area() > 99.0);
+        assert!(opened.intersection(&sliver).unwrap().is_empty());
+        assert!(opened.intersection(&island).unwrap().is_empty());
     }
 
     #[test]
     fn disk_opening_is_idempotent_within_offset_tolerance() {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let notch = ContourSet::rectangle(rect(4.0, 8.0, 6.0, 10.0), res(tol::REGION_MM));
-        let region = outer.difference(&notch);
+        let region = outer.difference(&notch).unwrap();
 
         let once = region.disk_open(0.5).unwrap();
         let twice = once.disk_open(0.5).unwrap();
-        let symmetric_difference = once.difference(&twice).union(&twice.difference(&once));
+        let symmetric_difference = once
+            .difference(&twice)
+            .unwrap()
+            .union(&twice.difference(&once).unwrap())
+            .unwrap();
 
         assert!(
             symmetric_difference.area() <= 2e-2,
@@ -3388,25 +3426,25 @@ mod tests {
     fn disk_closing_fills_sub_diameter_gaps_and_stays_outside_source() {
         let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), res(tol::REGION_MM));
         let right = ContourSet::rectangle(rect(4.8, 0.0, 10.0, 10.0), res(tol::REGION_MM));
-        let region = left.union(&right);
+        let region = left.union(&right).unwrap();
 
         let closed = region.disk_close(0.5).unwrap();
         let middle = ContourSet::rectangle(rect(4.0, 1.0, 4.8, 9.0), res(tol::REGION_MM));
 
-        assert!(region.difference(&closed).is_empty());
-        assert!(closed.intersection(&middle).area() > 6.3);
+        assert!(region.difference(&closed).unwrap().is_empty());
+        assert!(closed.intersection(&middle).unwrap().area() > 6.3);
     }
 
     #[test]
     fn disk_closing_preserves_wide_gaps() {
         let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), res(tol::REGION_MM));
         let right = ContourSet::rectangle(rect(5.2, 0.0, 10.0, 10.0), res(tol::REGION_MM));
-        let region = left.union(&right);
+        let region = left.union(&right).unwrap();
 
         let closed = region.disk_close(0.5).unwrap();
         let middle = ContourSet::rectangle(rect(4.0, 1.0, 5.2, 9.0), res(tol::REGION_MM));
 
-        assert!(closed.intersection(&middle).is_empty());
+        assert!(closed.intersection(&middle).unwrap().is_empty());
     }
 
     #[test]
@@ -3415,8 +3453,12 @@ mod tests {
         let close = ContourSet::rectangle(rect(4.8, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let wide = ContourSet::rectangle(rect(5.2, 0.0, 10.0, 10.0), res(tol::REGION_MM));
 
-        let close_violations = left.union(&close).disk_gap_violations(0.5).unwrap();
-        let wide_violations = left.union(&wide).disk_gap_violations(0.5).unwrap();
+        let close_violations = left
+            .union(&close)
+            .unwrap()
+            .disk_gap_violations(0.5)
+            .unwrap();
+        let wide_violations = left.union(&wide).unwrap().disk_gap_violations(0.5).unwrap();
 
         assert!(close_violations.area() > 1.5);
         assert!(wide_violations.is_empty());
@@ -3430,7 +3472,7 @@ mod tests {
         // stalling into an error.
         let left = ContourSet::rectangle(rect(0.0, 0.0, 5.0, 6.0), res(tol::REGION_MM));
         let right = ContourSet::rectangle(rect(5.003, 0.0, 10.0, 6.0), res(tol::REGION_MM));
-        let region = left.union(&right);
+        let region = left.union(&right).unwrap();
         assert!(!region.disk_gap_violations(0.5).unwrap().is_empty());
 
         let regularization = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
@@ -3449,8 +3491,8 @@ mod tests {
     fn disk_gap_violations_exclude_isolated_void_corners() {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let wide_hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), res(tol::REGION_MM));
-        let region = outer.difference(&wide_hole);
-        let raw_closing_residual = region.disk_close(0.5).unwrap().difference(&region);
+        let region = outer.difference(&wide_hole).unwrap();
+        let raw_closing_residual = region.disk_close(0.5).unwrap().difference(&region).unwrap();
 
         assert!(raw_closing_residual.area() > 0.1);
         assert!(region.disk_gap_violations(0.5).unwrap().is_empty());
@@ -3469,7 +3511,7 @@ mod tests {
     fn disk_gap_regularization_widens_a_gap_thinner_than_the_guard() {
         let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), res(tol::REGION_MM));
         let right = ContourSet::rectangle(rect(4.01, 0.0, 10.0, 10.0), res(tol::REGION_MM));
-        let region = left.union(&right);
+        let region = left.union(&right).unwrap();
 
         let before = region.disk_gap_violations(0.5).unwrap();
         let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
@@ -3485,18 +3527,18 @@ mod tests {
         let left = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let right = ContourSet::rectangle(rect(10.8, 0.0, 20.8, 10.0), res(tol::REGION_MM));
         let distant = ContourSet::rectangle(rect(24.0, 0.0, 30.0, 10.0), res(tol::REGION_MM));
-        let region = left.union(&right).union(&distant);
+        let region = left.union(&right).unwrap().union(&distant).unwrap();
 
         let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
 
         assert_eq!(result.kept.connected_components().len(), 3);
-        assert!(result.kept.difference(&region).is_empty());
+        assert!(result.kept.difference(&region).unwrap().is_empty());
         assert!(
             result.removed.area() < 4.0,
             "removed {:.9} mm²",
             result.removed.area()
         );
-        assert!(result.removed.intersection(&distant).area() <= 0.25);
+        assert!(result.removed.intersection(&distant).unwrap().area() <= 0.25);
         assert!(result.kept.disk_gap_violations(0.5).unwrap().is_empty());
     }
 
@@ -3505,13 +3547,17 @@ mod tests {
         let lower_left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM));
         let lower_right = ContourSet::rectangle(rect(4.8, 0.0, 8.8, 4.0), res(tol::REGION_MM));
         let upper = ContourSet::rectangle(rect(2.4, 4.8, 6.4, 8.8), res(tol::REGION_MM));
-        let region = lower_left.union(&lower_right).union(&upper);
+        let region = lower_left
+            .union(&lower_right)
+            .unwrap()
+            .union(&upper)
+            .unwrap();
 
         let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
 
         assert_eq!(result.kept.connected_components().len(), 3);
         for source in [&lower_left, &lower_right, &upper] {
-            assert!(result.kept.intersection(source).area() > 13.0);
+            assert!(result.kept.intersection(source).unwrap().area() > 13.0);
         }
         let violations = result.kept.disk_gap_violations(0.5).unwrap();
         assert!(
@@ -3525,7 +3571,7 @@ mod tests {
     fn disk_gap_regularization_widens_a_same_component_hairpin() {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let narrow_notch = ContourSet::rectangle(rect(4.6, 3.0, 5.4, 10.0), res(tol::REGION_MM));
-        let hairpin = outer.difference(&narrow_notch);
+        let hairpin = outer.difference(&narrow_notch).unwrap();
 
         let before = hairpin.disk_gap_violations(0.5).unwrap();
         let result = hairpin.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
@@ -3545,7 +3591,7 @@ mod tests {
     fn disk_gap_regularization_widens_a_narrow_internal_void() {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let narrow_hole = ContourSet::rectangle(rect(4.6, 3.0, 5.4, 7.0), res(tol::REGION_MM));
-        let region = outer.difference(&narrow_hole);
+        let region = outer.difference(&narrow_hole).unwrap();
 
         let before = region.disk_gap_violations(0.5).unwrap();
         let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
@@ -3566,10 +3612,10 @@ mod tests {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), res(tol::REGION_MM));
 
-        let dilated = outer.difference(&hole).disk_dilate(0.5).unwrap();
+        let dilated = outer.difference(&hole).unwrap().disk_dilate(0.5).unwrap();
         let expected_hole = ContourSet::rectangle(rect(3.5, 3.5, 6.5, 6.5), res(tol::REGION_MM));
 
-        assert!(dilated.intersection(&expected_hole).is_empty());
+        assert!(dilated.intersection(&expected_hole).unwrap().is_empty());
         let area = dilated.area();
         assert!(
             (area - 111.785398163).abs() <= 2e-2,
@@ -3581,13 +3627,13 @@ mod tests {
     fn union_contains_both_regions_when_a_hole_overlaps_filled_material() {
         let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), res(tol::REGION_MM));
-        let frame = outer.difference(&hole);
+        let frame = outer.difference(&hole).unwrap();
         let plug = ContourSet::rectangle(rect(4.0, 4.0, 6.0, 6.0), res(tol::REGION_MM));
 
-        let union = frame.union(&plug);
+        let union = frame.union(&plug).unwrap();
 
-        assert!(frame.difference(&union).is_empty());
-        assert!(plug.difference(&union).is_empty());
+        assert!(frame.difference(&union).unwrap().is_empty());
+        assert!(plug.difference(&union).unwrap().is_empty());
         assert!((union.area() - 88.0).abs() <= 1e-6);
     }
 
@@ -3681,10 +3727,10 @@ mod tests {
             res(tol::REGION_MM),
         )
         .unwrap();
-        let source = outer.difference(&holes);
+        let source = outer.difference(&holes).unwrap();
 
         let dilated = source.disk_dilate(0.525).unwrap();
-        let removed_source = source.difference(&dilated);
+        let removed_source = source.difference(&dilated).unwrap();
 
         assert!(
             removed_source.is_empty(),
@@ -3844,16 +3890,103 @@ mod tests {
     }
 
     #[test]
+    fn cancelled_overlap_edges_leave_one_exact_rectangle() {
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 2.0, 1.0), res(0.0));
+        let right = ContourSet::rectangle(rect(1.0, 0.0, 3.0, 1.0), res(0.0));
+        let whole = ContourSet::rectangle(rect(0.0, 0.0, 3.0, 1.0), res(0.0));
+
+        let union = left.union(&right).unwrap();
+
+        assert_eq!(union.rings.len(), 1);
+        assert!((union.area() - 3.0).abs() < 1e-9);
+        assert!(union.difference(&whole).unwrap().is_empty());
+        assert!(whole.difference(&union).unwrap().is_empty());
+        assert!(union.contains_point(Point::new(1.5, 0.5)));
+        let inside = union
+            .prepare_query()
+            .signed_distance(Point::new(1.5, 0.5))
+            .unwrap();
+        assert!((inside.mm + 0.5).abs() < 1e-9);
+        assert!(union.uncertainty_mm < 1e-9);
+    }
+
+    #[test]
+    fn adjoining_rectangles_equal_one_rectangle() {
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 1.0, 1.0), res(0.0));
+        let right = ContourSet::rectangle(rect(1.0, 0.0, 2.0, 1.0), res(0.0));
+        let whole = ContourSet::rectangle(rect(0.0, 0.0, 2.0, 1.0), res(0.0));
+
+        let union = left.union(&right).unwrap();
+
+        assert_eq!(union.rings.len(), 1);
+        assert!((union.area() - whole.area()).abs() < 1e-9);
+        for x in [0.5, 1.0, 1.5] {
+            let point = Point::new(x, 0.5);
+            assert_eq!(union.contains_point(point), whole.contains_point(point));
+            let seamed = union.prepare_query().signed_distance(point).unwrap().mm;
+            let exact = whole.prepare_query().signed_distance(point).unwrap().mm;
+            assert!((seamed - exact).abs() < 1e-9, "x={x}: {seamed} vs {exact}");
+        }
+    }
+
+    #[test]
+    fn mixed_budget_booleans_fail_when_the_coarser_history_does_not_fit() {
+        let coarse_resolution = Resolution::new(0.0, GeometryAccuracy::new(0.05).unwrap());
+        let fine_resolution = Resolution::new(0.0, GeometryAccuracy::new(0.001).unwrap());
+        let coarse = ContourSet::from_contours(
+            &[shapes::circle(4.0).unwrap()],
+            FillRule::NonZero,
+            coarse_resolution,
+        )
+        .unwrap();
+        let fine = ContourSet::rectangle(rect(0.0, 0.0, 1.0, 1.0), fine_resolution);
+        assert!(coarse.uncertainty_mm > fine_resolution.accuracy.max_error_mm());
+
+        assert!(matches!(
+            coarse.union(&fine),
+            Err(AccuracyError::BudgetExceeded { .. })
+        ));
+        assert!(matches!(
+            fine.difference(&coarse),
+            Err(AccuracyError::BudgetExceeded { .. })
+        ));
+        assert!(matches!(
+            fine.intersection(&coarse),
+            Err(AccuracyError::BudgetExceeded { .. })
+        ));
+
+        // The same operands fit the coarser budget, and the result keeps it
+        // together with the coarse history.
+        let loose = ContourSet::rectangle(rect(3.0, 0.0, 4.0, 1.0), coarse_resolution);
+        let union = coarse.union(&loose).unwrap();
+        assert_eq!(union.budget(), coarse_resolution.accuracy);
+        assert!(union.uncertainty_mm >= coarse.uncertainty_mm);
+        assert!(union.contains_point(Point::new(3.5, 0.5)));
+        assert!((union.area() - coarse.area() - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn polygon_preparation_checks_coordinate_rounding_against_the_budget() {
+        let far = vec![[0.0, 0.0], [1000.0, 0.0], [1000.0, 1000.0], [0.0, 1000.0]];
+        let resolution = Resolution::new(0.0, GeometryAccuracy::new(1e-15).unwrap());
+        assert!(matches!(
+            ContourSet::from_rings(vec![far.clone()], FillRule::NonZero, resolution),
+            Err(AccuracyError::BudgetExceeded { .. })
+        ));
+        assert!(ContourSet::from_rings(vec![far], FillRule::NonZero, res(0.0)).is_ok());
+    }
+
+    #[test]
     fn regularization_drops_rings_below_significance() {
         let square = vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
         let sliver = vec![[2.0, 0.0], [12.0, 0.0], [12.0, 5e-6], [2.0, 5e-6]];
         let rings = || vec![square.clone(), sliver.clone()];
 
-        let significant = ContourSet::from_rings(rings(), FillRule::NonZero, res(0.01));
+        let significant = ContourSet::from_rings(rings(), FillRule::NonZero, res(0.01)).unwrap();
         assert_eq!(significant.rings.len(), 1);
         assert!((significant.area() - 1.0).abs() < 1e-9);
 
-        let exact = ContourSet::from_rings(rings(), FillRule::NonZero, res(0.0));
+        let exact = ContourSet::from_rings(rings(), FillRule::NonZero, res(0.0)).unwrap();
         assert_eq!(exact.rings.len(), 2);
     }
 

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -28,14 +28,16 @@ use i_overlay::i_float::int::point::IntPoint;
 use i_overlay::mesh::outline::offset::OutlineOffset;
 use i_overlay::mesh::style::{LineJoin as OutlineLineJoin, OutlineStyle};
 
+use crate::geom::accuracy::numerical_error;
 use crate::geom::affine::Affine2;
 use crate::geom::bbox::BBox;
 use crate::geom::dist::{self, Distance};
-use crate::geom::path::{ContourBuf, PathCmd, contours_to_kurbo, stroke_to_fill, transform_cmds};
+use crate::geom::path::{ContourBuf, PathCmd, Segment, stroke_to_fill};
 use crate::geom::point::Point;
 use crate::geom::store::{Path, PathArena};
 use crate::geom::style::{FillRule, Paint, Polarity};
 use crate::geom::tol;
+use crate::geom::{AccuracyError, GeometryAccuracy, Resolution};
 
 /// A closed polygon boundary, flattened to line segments.
 pub type Ring = Vec<[f64; 2]>;
@@ -43,24 +45,33 @@ pub type Ring = Vec<[f64; 2]>;
 /// One connected polygon: an outer ring plus hole rings.
 pub type Shape = Vec<Ring>;
 
-/// Flatten contours to polygon rings using the shared chord tolerance.
-pub fn rings_from_contours(contours: &[ContourBuf]) -> Vec<Ring> {
-    let bez_path = contours_to_kurbo(contours);
+fn flatten_contours(contours: &[ContourBuf], accuracy: f64) -> (Vec<Ring>, f64) {
+    let (bez_path, conversion_error) =
+        crate::geom::path::contours_to_kurbo(contours, accuracy / 2.0);
+    let curved = bez_path
+        .elements()
+        .iter()
+        .any(|el| matches!(el, kurbo::PathEl::CurveTo(..) | kurbo::PathEl::QuadTo(..)));
+    let flatten_error = if curved { accuracy / 2.0 } else { 0.0 };
     let mut rings = Vec::new();
     let mut current = Vec::new();
-    kurbo::flatten(bez_path, tol::FLATTEN_MM, |element| match element {
-        kurbo::PathEl::MoveTo(point) => {
-            push_ring(&mut rings, &mut current);
-            current.push([point.x, point.y]);
-        }
-        kurbo::PathEl::LineTo(point) => current.push([point.x, point.y]),
-        kurbo::PathEl::ClosePath => push_ring(&mut rings, &mut current),
-        kurbo::PathEl::QuadTo(..) | kurbo::PathEl::CurveTo(..) => {
-            unreachable!("kurbo::flatten emits lines")
-        }
-    });
+    kurbo::flatten(
+        bez_path,
+        flatten_error.max(f64::MIN_POSITIVE),
+        |element| match element {
+            kurbo::PathEl::MoveTo(point) => {
+                push_ring(&mut rings, &mut current);
+                current.push([point.x, point.y]);
+            }
+            kurbo::PathEl::LineTo(point) => current.push([point.x, point.y]),
+            kurbo::PathEl::ClosePath => push_ring(&mut rings, &mut current),
+            kurbo::PathEl::QuadTo(..) | kurbo::PathEl::CurveTo(..) => {
+                unreachable!("kurbo::flatten emits lines")
+            }
+        },
+    );
     push_ring(&mut rings, &mut current);
-    rings
+    (rings, conversion_error + flatten_error)
 }
 
 /// Convert polygon rings back into closed line contours.
@@ -170,14 +181,14 @@ fn convex_sublevel_interval(value: impl Fn(f64) -> f64, limit: f64) -> Option<(f
 }
 
 /// Regularize rings under the given fill rule into non-overlapping shapes.
-pub fn simplify_rings(rings: Vec<Ring>, fill_rule: FillRule) -> Vec<Ring> {
+pub(crate) fn simplify_rings(rings: Vec<Ring>, fill_rule: FillRule) -> Vec<Ring> {
     flatten_shapes(simplify_shapes(rings, fill_rule))
 }
 
 /// Regularize rings keeping the connected-shape structure: each shape is its
 /// outer ring followed by its holes, wound opposite.
 pub fn simplify_shapes(rings: Vec<Ring>, fill_rule: FillRule) -> Vec<Shape> {
-    rings.simplify_shape(overlay_fill_rule(fill_rule))
+    rings.simplify_shape_as::<i64>(overlay_fill_rule(fill_rule))
 }
 
 /// Regularize filled rings on an exact output grid.
@@ -212,30 +223,15 @@ pub fn simplify_shapes_on_grid(rings: Vec<Ring>, fill_rule: FillRule, grid: f64)
         .collect()
 }
 
-pub fn union_rings(rings: Vec<Ring>, fill_rule: FillRule) -> Vec<Ring> {
-    simplify_rings(rings, fill_rule)
-}
-
-pub fn difference_rings(subject: Vec<Ring>, cutters: Vec<Ring>) -> Vec<Ring> {
-    flatten_shapes(difference_shapes(subject, cutters))
-}
-
-pub fn intersection_rings(subject: Vec<Ring>, clip: Vec<Ring>) -> Vec<Ring> {
-    if subject.is_empty() || clip.is_empty() {
-        return Vec::new();
-    }
-    flatten_shapes(subject.overlay(&clip, OverlayRule::Intersect, OverlayFillRule::NonZero))
-}
-
 /// Difference keeping the connected-shape structure of the result.
-pub fn difference_shapes(subject: Vec<Ring>, cutters: Vec<Ring>) -> Vec<Shape> {
+pub(crate) fn difference_shapes(subject: Vec<Ring>, cutters: Vec<Ring>) -> Vec<Shape> {
     if subject.is_empty() || cutters.is_empty() {
-        return subject.simplify_shape(OverlayFillRule::NonZero);
+        return subject.simplify_shape_as::<i64>(OverlayFillRule::NonZero);
     }
-    subject.overlay(&cutters, OverlayRule::Difference, OverlayFillRule::NonZero)
+    subject.overlay_as::<i64>(&cutters, OverlayRule::Difference, OverlayFillRule::NonZero)
 }
 
-pub fn rings_bbox(rings: &[Ring]) -> BBox {
+pub(crate) fn rings_bbox(rings: &[Ring]) -> BBox {
     rings
         .iter()
         .flat_map(|ring| ring.iter())
@@ -248,7 +244,7 @@ pub fn rings_bbox(rings: &[Ring]) -> BBox {
 /// Decimate rings so the region only shrinks: the result covers no point the
 /// source did not, and no source vertex ends farther than `deviation_mm`
 /// from the decimated boundary.
-pub fn decimate_rings_inward(rings: &[Ring], deviation_mm: f64) -> Vec<Ring> {
+pub(crate) fn decimate_rings_inward(rings: &[Ring], deviation_mm: f64) -> Vec<Ring> {
     rings
         .iter()
         .map(|ring| decimate_ring_inward(ring, deviation_mm))
@@ -269,7 +265,8 @@ fn decimate_ring_inward(ring: &Ring, deviation_mm: f64) -> Ring {
     // Every chord re-checks its whole chain, so error cannot accumulate.
     let chord_absorbs = |anchor: usize, end: usize| {
         let start = point(anchor);
-        let chord = point(end) - start;
+        let endpoint = point(end);
+        let chord = endpoint - start;
         let length = chord.length();
         if length <= f64::EPSILON {
             return false;
@@ -277,8 +274,7 @@ fn decimate_ring_inward(ring: &Ring, deviation_mm: f64) -> Ring {
         (anchor + 1..end).all(|index| {
             let offset = point(index) - start;
             let cross = chord.x * offset.y - chord.y * offset.x;
-            // Bound distance to the segment, including points beyond its endpoints.
-            cross <= 0.0 && dist::point_segment(point(index), start, point(end)).0 <= deviation_mm
+            cross <= 0.0 && dist::point_segment(point(index), start, endpoint).0 <= deviation_mm
         })
     };
 
@@ -362,8 +358,7 @@ pub fn rings_area(rings: &[Ring]) -> f64 {
 /// Regularized filled planar point set.
 ///
 /// A `ContourSet` is always in canonical form: rings are regularized
-/// (non-overlapping, holes wound opposite their outer boundary) and contours
-/// smaller than `tolerance²` in area are discarded. The winding/fill rule of
+/// (non-overlapping, holes wound opposite their outer boundary). The winding/fill rule of
 /// the *source* geometry matters only at construction; every subsequent
 /// operation is a regularized set operation.
 #[derive(Debug, Clone)]
@@ -374,7 +369,13 @@ pub struct ContourSet {
     pub rings: Vec<Ring>,
     /// Bounds of each ring, indexed like `rings` and fixed with them.
     pub(crate) ring_bounds: Vec<BBox>,
-    pub tolerance: f64,
+    /// The significance tolerance and approximation budget this region was
+    /// prepared at. Every operation that approximates spends from the budget
+    /// and every derived region inherits it.
+    pub resolution: Resolution,
+    /// Accumulated boundary approximation in mm; infinity means unbounded.
+    /// Mutating public rings invalidates this history.
+    pub uncertainty_mm: f64,
 }
 
 /// Result of enforcing a minimum width for every two-sided void gap.
@@ -410,16 +411,52 @@ impl fmt::Display for GapRegularizationError {
 }
 
 impl std::error::Error for GapRegularizationError {}
+impl From<AccuracyError> for GapRegularizationError {
+    fn from(error: AccuracyError) -> Self {
+        Self(error.to_string())
+    }
+}
 
 impl ContourSet {
-    pub fn new(rings: Vec<Ring>, fill_rule: FillRule, tolerance: f64) -> Self {
-        Self::from_regularized(simplify_rings(rings, fill_rule), tolerance)
+    /// The region's own budget applied to its accumulated approximation.
+    fn checked(self) -> Result<Self, AccuracyError> {
+        self.resolution.accuracy.check(self.uncertainty_mm)?;
+        Ok(self)
     }
 
-    /// A region from rings a regularized boolean operation produced, kept
-    /// as they are: non-overlapping, holes wound opposite their outer ring.
-    pub fn from_regularized(rings: Vec<Ring>, tolerance: f64) -> Self {
-        let rings = filter_significant_rings(rings, tolerance);
+    /// Significance tolerance and containment slack, in millimetres.
+    pub fn tolerance(&self) -> f64 {
+        self.resolution.tolerance_mm
+    }
+
+    /// The approximation budget every derived region may spend within.
+    pub fn budget(&self) -> GeometryAccuracy {
+        self.resolution.accuracy
+    }
+
+    /// The same region under a different budget. Loosening always succeeds;
+    /// tightening succeeds only when the accumulated approximation fits.
+    pub fn rebudget(mut self, accuracy: GeometryAccuracy) -> Result<Self, AccuracyError> {
+        accuracy.check(self.uncertainty_mm)?;
+        self.resolution.accuracy = accuracy;
+        Ok(self)
+    }
+
+    /// Regularize source polygons. Their vertices are taken as exact; only
+    /// coordinate rounding is charged.
+    pub fn from_rings(rings: Vec<Ring>, fill_rule: FillRule, resolution: Resolution) -> Self {
+        let uncertainty = numerical_error(rings_bbox(&rings));
+        Self::from_regularized(simplify_rings(rings, fill_rule), resolution, uncertainty)
+    }
+
+    /// Construct from known regularized polygons, preserving their history.
+    /// `uncertainty_mm = 0` asserts these polygons are the actual source.
+    pub fn from_regularized(rings: Vec<Ring>, resolution: Resolution, uncertainty_mm: f64) -> Self {
+        let uncertainty_mm = if uncertainty_mm >= 0.0 {
+            uncertainty_mm
+        } else {
+            f64::INFINITY
+        };
         let ring_bounds = rings
             .iter()
             .map(|ring| rings_bbox(std::slice::from_ref(ring)))
@@ -428,21 +465,83 @@ impl ContourSet {
             bbox: ring_bounds.iter().copied().fold(BBox::empty(), BBox::union),
             rings,
             ring_bounds,
-            tolerance,
+            resolution,
+            uncertainty_mm,
         }
     }
 
-    pub fn empty(tolerance: f64) -> Self {
+    pub fn empty(resolution: Resolution) -> Self {
         Self {
             bbox: BBox::empty(),
             rings: Vec::new(),
             ring_bounds: Vec::new(),
-            tolerance,
+            resolution,
+            uncertainty_mm: 0.0,
         }
     }
 
-    pub fn from_contours(contours: &[ContourBuf], fill_rule: FillRule, tolerance: f64) -> Self {
-        Self::new(rings_from_contours(contours), fill_rule, tolerance)
+    /// Prepare source contours under one fill rule. Curves are flattened
+    /// within the resolution's budget; the result records what that cost on
+    /// top of any approximation the contours already carried.
+    pub fn from_contours(
+        contours: &[ContourBuf],
+        fill_rule: FillRule,
+        resolution: Resolution,
+    ) -> Result<Self, AccuracyError> {
+        let accuracy = resolution.accuracy;
+        if !resolution.is_valid()
+            || contours.iter().any(|c| {
+                !c.bbox.is_valid()
+                    || !c.uncertainty_mm.is_finite()
+                    || c.uncertainty_mm < 0.0
+                    || c.cmds.iter().any(|cmd| {
+                        !cmd.p0.is_finite() || !cmd.p1.is_finite() || !cmd.p2.is_finite()
+                    })
+            })
+        {
+            return Err(AccuracyError::InvalidGeometry(
+                "invalid coordinates or significance tolerance",
+            ));
+        }
+        let prior = contours
+            .iter()
+            .map(|c| c.uncertainty_mm)
+            .fold(0.0, f64::max);
+        let bbox = contours.iter().fold(BBox::empty(), |b, c| b.union(c.bbox));
+        let numeric = numerical_error(bbox);
+        let remaining = accuracy.allowance(prior + numeric)?;
+        if remaining < f64::EPSILON
+            || contours
+                .iter()
+                .flat_map(ContourBuf::segments)
+                .map(|segment| match segment {
+                    Segment::Line { .. } => 1.0,
+                    _ => {
+                        let bounds = segment.bbox();
+                        (bounds.width().max(bounds.height()) / remaining).sqrt()
+                    }
+                })
+                .sum::<f64>()
+                > 1_000_000.0
+        {
+            return Err(AccuracyError::SubdivisionLimit);
+        }
+        let (rings, added) = flatten_contours(contours, remaining);
+        Self::from_regularized(
+            simplify_rings(rings, fill_rule),
+            resolution,
+            prior + added + numeric,
+        )
+        .checked()
+    }
+
+    /// Regularized union of many regions.
+    pub fn union_all(resolution: Resolution, regions: impl IntoIterator<Item = Self>) -> Self {
+        let mut composer = PaintComposer::new(resolution);
+        for region in regions {
+            composer.push(Polarity::Dark, region);
+        }
+        composer.finish()
     }
 
     /// Build the union of independently filled contours.
@@ -451,17 +550,22 @@ impl ContourSet {
     /// winding direction is irrelevant), then the contours are unioned. Use
     /// this when sibling contours are separate features; applying even-odd
     /// across the whole list would XOR duplicated geometry away.
-    pub fn from_filled_contours(contours: &[ContourBuf], tolerance: f64) -> Self {
-        let rings = contours
-            .iter()
-            .flat_map(|contour| {
-                simplify_rings(
-                    rings_from_contours(std::slice::from_ref(contour)),
+    pub fn from_filled_contours(
+        contours: &[ContourBuf],
+        resolution: Resolution,
+    ) -> Result<Self, AccuracyError> {
+        let mut composer = PaintComposer::new(resolution);
+        for contour in contours {
+            composer.push(
+                Polarity::Dark,
+                Self::from_contours(
+                    std::slice::from_ref(contour),
                     FillRule::EvenOdd,
-                )
-            })
-            .collect();
-        Self::new(rings, FillRule::NonZero, tolerance)
+                    resolution.strict(),
+                )?,
+            );
+        }
+        composer.finish().checked()
     }
 
     /// Build the union of the geometric images painted by a set of paths.
@@ -474,12 +578,12 @@ impl ContourSet {
     pub fn from_painted_paths<'a>(
         arena: &PathArena,
         paths: impl IntoIterator<Item = &'a Path>,
-        tolerance: f64,
-    ) -> Self {
+        resolution: Resolution,
+    ) -> Result<Self, AccuracyError> {
         Self::from_placed_painted_paths(
             arena,
             paths.into_iter().map(|path| (path, Affine2::IDENTITY)),
-            tolerance,
+            resolution,
         )
     }
 
@@ -491,40 +595,42 @@ impl ContourSet {
     pub fn from_placed_painted_paths<'a>(
         arena: &PathArena,
         paths: impl IntoIterator<Item = (&'a Path, Affine2)>,
-        tolerance: f64,
-    ) -> Self {
-        let mut rings = Vec::new();
+        resolution: Resolution,
+    ) -> Result<Self, AccuracyError> {
+        if !resolution.is_valid() {
+            return Err(AccuracyError::InvalidGeometry(
+                "invalid significance tolerance",
+            ));
+        }
+        let accuracy = resolution.accuracy;
+        let mut composer = PaintComposer::new(resolution);
         for (path, placement) in paths {
             let contours = arena.path_contours(path);
             let contours = match path.paint {
                 Paint::Fill { .. } => contours,
                 Paint::Stroke(stroke) => {
-                    stroke_to_fill(&contours, stroke.into()).unwrap_or_default()
+                    let local =
+                        GeometryAccuracy::new(accuracy.max_error_mm() / placement.max_scale())?;
+                    stroke_to_fill(&contours, stroke.into(), local)?.unwrap_or_default()
                 }
                 Paint::None => continue,
             };
-            let contours = if placement.is_identity() {
-                contours
-            } else {
-                contours
-                    .into_iter()
-                    .map(|contour| transform_cmds(contour.cmds, placement))
-                    .collect()
-            };
-            let fill_rule = match path.paint {
-                Paint::Fill { rule } => rule,
-                Paint::Stroke(_) => FillRule::NonZero,
-                Paint::None => unreachable!("unpainted paths were skipped"),
-            };
-            let path_rings = simplify_rings(rings_from_contours(&contours), fill_rule);
-            rings.extend(path_rings);
+            let contours = contours
+                .into_iter()
+                .map(|contour| contour.transformed(placement))
+                .collect::<Vec<_>>();
+            let fill_rule = path.fill_rule().unwrap_or(FillRule::NonZero);
+            composer.push(
+                Polarity::Dark,
+                Self::from_contours(&contours, fill_rule, resolution.strict())?,
+            );
         }
-        Self::new(rings, FillRule::NonZero, tolerance)
+        composer.finish().checked()
     }
 
-    pub fn rectangle(bbox: BBox, tolerance: f64) -> Self {
+    pub fn rectangle(bbox: BBox, resolution: Resolution) -> Self {
         if bbox.is_empty() {
-            return Self::empty(tolerance);
+            return Self::empty(resolution);
         }
         let ring = vec![
             [bbox.min.x, bbox.min.y],
@@ -532,7 +638,7 @@ impl ContourSet {
             [bbox.max.x, bbox.max.y],
             [bbox.min.x, bbox.max.y],
         ];
-        Self::new(vec![ring], FillRule::NonZero, tolerance)
+        Self::from_regularized(vec![ring], resolution, 0.0)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -550,21 +656,13 @@ impl ContourSet {
 
     /// Regularized union: `self ∪ other`.
     pub fn union(&self, other: &Self) -> Self {
-        if self.is_empty() {
+        if self.is_empty() && self.uncertainty_mm == 0.0 {
             return other.clone();
         }
-        if other.is_empty() {
+        if other.is_empty() && other.uncertainty_mm == 0.0 {
             return self.clone();
         }
-        Self::new(
-            flatten_shapes(self.rings.overlay(
-                &other.rings,
-                OverlayRule::Union,
-                OverlayFillRule::NonZero,
-            )),
-            FillRule::NonZero,
-            self.tolerance,
-        )
+        self.boolean(other, OverlayRule::Union)
     }
 
     pub fn union_assign(&mut self, other: &Self) {
@@ -573,27 +671,29 @@ impl ContourSet {
 
     /// Regularized difference: `self \ cutters`.
     pub fn difference(&self, cutters: &Self) -> Self {
-        Self::new(
-            difference_rings(self.rings.clone(), cutters.rings.clone()),
-            FillRule::NonZero,
-            self.tolerance,
-        )
+        self.boolean(cutters, OverlayRule::Difference)
     }
 
     /// Regularized intersection: `self ∩ clip`.
     pub fn intersection(&self, clip: &Self) -> Self {
-        Self::new(
-            intersection_rings(self.rings.clone(), clip.rings.clone()),
-            FillRule::NonZero,
-            self.tolerance,
-        )
+        self.boolean(clip, OverlayRule::Intersect)
     }
 
+    fn boolean(&self, other: &Self, rule: OverlayRule) -> Self {
+        let rings = flatten_shapes(self.rings.overlay_as::<i64>(
+            &other.rings,
+            rule,
+            OverlayFillRule::NonZero,
+        ));
+        let uncertainty = self.uncertainty_mm.max(other.uncertainty_mm)
+            + numerical_error(self.bbox.union(other.bbox));
+        Self::from_regularized(rings, self.resolution.meet(other.resolution), uncertainty)
+    }
     /// Connected components, each retaining its own hole rings.
     pub fn connected_components(&self) -> Vec<Self> {
         simplify_shapes(self.rings.clone(), FillRule::NonZero)
             .into_iter()
-            .map(|shape| Self::from_regularized(shape, self.tolerance))
+            .map(|shape| Self::from_regularized(shape, self.resolution, self.uncertainty_mm))
             .collect()
     }
 
@@ -656,6 +756,7 @@ impl ContourSet {
                 .iter()
                 .map(|segment| (segment.start, segment.end))
                 .collect(),
+            self.uncertainty_mm,
         );
         let sees_left = |wall: &OrientedBoundarySegment, across: Point| {
             let along = wall.end - wall.start;
@@ -735,9 +836,14 @@ impl ContourSet {
                 .filter(|&(_, &keep)| keep)
                 .map(|(ring, _)| ring.clone())
                 .collect(),
-            self.tolerance,
+            self.resolution,
+            self.uncertainty_mm,
         );
-        material.intersection(&Self::new(windows, FillRule::NonZero, self.tolerance))
+        material.intersection(&Self::from_regularized(
+            simplify_rings(windows, FillRule::NonZero),
+            self.resolution,
+            0.0,
+        ))
     }
 
     /// Whether the region contains each point, as a one-or-zero indicator.
@@ -808,12 +914,22 @@ impl ContourSet {
 
     /// Decimate the region's boundary so it only shrinks; see
     /// [`decimate_rings_inward`].
-    pub fn decimate_inward(&self, deviation_mm: f64) -> Self {
-        Self::new(
-            decimate_rings_inward(&self.rings, deviation_mm),
-            FillRule::NonZero,
-            self.tolerance,
-        )
+    pub fn decimate_inward(&self, deviation_mm: f64) -> Result<Self, AccuracyError> {
+        if !deviation_mm.is_finite() || deviation_mm < 0.0 {
+            return Err(AccuracyError::InvalidGeometry(
+                "invalid decimation deviation",
+            ));
+        }
+        let inherited = self.uncertainty_mm + numerical_error(self.bbox);
+        let deviation_mm = deviation_mm.min(self.budget().allowance(inherited)?);
+        Ok(Self::from_regularized(
+            simplify_rings(
+                decimate_rings_inward(&self.rings, deviation_mm),
+                FillRule::NonZero,
+            ),
+            self.resolution,
+            inherited + deviation_mm,
+        ))
     }
 
     /// Test many points against the same region in one sweep.
@@ -915,7 +1031,7 @@ impl ContourSet {
             return Vec::new();
         }
 
-        let epsilon = self.tolerance.max(tol::EPSILON_MM);
+        let epsilon = self.tolerance().max(tol::EPSILON_MM);
         let parameter_epsilon = (epsilon / length).min(1.0);
         let cross = |left: Point, right: Point| left.x * right.y - left.y * right.x;
         let mut breaks = vec![0.0, 1.0];
@@ -983,7 +1099,7 @@ impl ContourSet {
             return false;
         }
 
-        let epsilon = self.tolerance.max(tol::EPSILON_MM);
+        let epsilon = self.tolerance().max(tol::EPSILON_MM);
         let rings_near = |reach: f64| {
             self.rings
                 .iter()
@@ -1024,36 +1140,10 @@ impl ContourSet {
             return false;
         }
 
-        let epsilon = self.tolerance.max(tol::EPSILON_MM);
+        let epsilon = self.tolerance().max(tol::EPSILON_MM);
         self.rings
             .iter()
             .all(|ring| ring_boundary_distance(ring, center) + epsilon >= radius)
-    }
-
-    /// Minkowski sum with a disk: `self ⊕ D_radius`. This is the standard
-    /// "buffer out" operation used for manufacturability checks. The
-    /// topology-aware offset expands outer contours, contracts holes, and
-    /// regularizes all resulting contours together.
-    pub fn disk_dilate(&self, radius: f64) -> Self {
-        if self.is_empty() || radius <= 0.0 {
-            return self.clone();
-        }
-
-        self.disk_offset(radius)
-    }
-
-    /// Minkowski erosion by a disk: `self ⊖ D_radius`.
-    ///
-    /// This removes the radius-wide interior band swept by every boundary
-    /// ring. It therefore contracts outer boundaries, expands holes, removes
-    /// necks narrower than twice the radius, and may split or erase connected
-    /// components.
-    pub fn disk_erode(&self, radius: f64) -> Self {
-        if self.is_empty() || radius <= 0.0 {
-            return self.clone();
-        }
-
-        self.disk_offset(-radius)
     }
 
     /// Morphological opening by a disk: `(self ⊖ D_radius) ⊕ D_radius`.
@@ -1062,17 +1152,11 @@ impl ContourSet {
     /// the source region. It is therefore a subset of the source that removes
     /// tips and islands too small to accommodate the disk while rounding the
     /// surviving outward corners.
-    pub fn disk_open(&self, radius: f64) -> Self {
-        if self.is_empty() || radius <= 0.0 {
-            return self.clone();
-        }
-
-        // Round-offset tessellation approximates the mathematical disks. Clip
-        // the regrown result to the source so the operation retains its
-        // defining anti-extensive property at polygon tolerance.
-        self.disk_erode(radius)
-            .disk_dilate(radius)
+    pub fn disk_open(&self, radius: f64) -> Result<Self, AccuracyError> {
+        self.disk_erode(radius)?
+            .disk_dilate(radius)?
             .intersection(self)
+            .checked()
     }
 
     /// Morphological closing by a disk: `(self ⊕ D_radius) ⊖ D_radius`.
@@ -1081,15 +1165,11 @@ impl ContourSet {
     /// radius-sized disk contained in the source complement. Closing therefore
     /// fills void tips and gaps too small to accommodate the disk while
     /// rounding the surviving inward corners.
-    pub fn disk_close(&self, radius: f64) -> Self {
-        if self.is_empty() || radius <= 0.0 {
-            return self.clone();
-        }
-
-        // Round-offset tessellation approximates the mathematical disks. Union
-        // the contracted result with the source so the operation retains its
-        // defining extensive property at polygon tolerance.
-        self.disk_dilate(radius).disk_erode(radius).union(self)
+    pub fn disk_close(&self, radius: f64) -> Result<Self, AccuracyError> {
+        self.disk_dilate(radius)?
+            .disk_erode(radius)?
+            .union(self)
+            .checked()
     }
 
     /// Diagnose distinct components whose Euclidean separation is less than
@@ -1105,26 +1185,29 @@ impl ContourSet {
     /// [`ContourSet::disk_gap_violations`], which also covers gaps within one
     /// connected component.
     #[cfg(test)]
-    pub(crate) fn disk_inter_component_gap_violations(&self, radius: f64) -> Self {
+    pub(crate) fn disk_inter_component_gap_violations(
+        &self,
+        radius: f64,
+    ) -> Result<Self, AccuracyError> {
         if self.is_empty() || radius <= 0.0 {
-            return Self::empty(self.tolerance);
+            return Ok(Self::empty(self.resolution));
         }
 
         let components = self.connected_components();
-        let mut violations = Self::empty(self.tolerance);
+        let mut violations = Self::empty(self.resolution);
         for (index, left) in components.iter().enumerate() {
             for right in &components[index + 1..] {
                 if !regions_within_distance(left, right, 2.0 * radius) {
                     continue;
                 }
                 let overlap = left
-                    .disk_dilate(radius)
-                    .intersection(&right.disk_dilate(radius))
+                    .disk_dilate(radius)?
+                    .intersection(&right.disk_dilate(radius)?)
                     .difference(self);
                 violations = violations.union(&overlap);
             }
         }
-        violations
+        Ok(violations)
     }
 
     /// Enforce a diameter-`2 * gap_radius` minimum for every two-sided void gap.
@@ -1170,17 +1253,17 @@ impl ContourSet {
 
         let mut kept = self.clone();
         while let Some(next) = kept.narrow_gap_trim(gap_radius, filled_radius, guard)? {
-            if kept.difference(&next).area() <= self.tolerance * self.tolerance {
+            if kept.difference(&next).area() <= self.tolerance().powi(2) {
                 return Err(GapRegularizationError(format!(
                     "gap regularization stalled with {:.9} mm² of void-gap violations",
-                    kept.disk_gap_violations(gap_radius).area()
+                    kept.disk_gap_violations(gap_radius)?.area()
                 )));
             }
             kept = next;
         }
         Ok(DiskGapRegularization {
-            removed: self.difference(&kept),
-            kept,
+            removed: self.difference(&kept).checked()?,
+            kept: kept.checked()?,
         })
     }
 
@@ -1193,15 +1276,16 @@ impl ContourSet {
         filled_radius: f64,
         guard: f64,
     ) -> Result<Option<Self>, GapRegularizationError> {
-        let narrow_voids = self.disk_gap_violations(gap_radius);
+        let narrow_voids = self.disk_gap_violations(gap_radius)?;
         if narrow_voids.is_empty() {
             return Ok(None);
         }
         let keep_out = narrow_void_keep_out(self, &narrow_voids, gap_radius + guard)?;
         Ok(Some(
             self.difference(&keep_out)
-                .disk_open(filled_radius)
-                .intersection(self),
+                .disk_open(filled_radius)?
+                .intersection(self)
+                .checked()?,
         ))
     }
 
@@ -1214,11 +1298,11 @@ impl ContourSet {
     /// distinguishes hairpins and notches from the bite of a single smooth
     /// concavity. An empty result proves no two facing boundary branches fail
     /// the rolling-disk test.
-    pub fn disk_gap_violations(&self, radius: f64) -> Self {
+    pub fn disk_gap_violations(&self, radius: f64) -> Result<Self, AccuracyError> {
         if self.is_empty() || !(radius > 0.0 && radius.is_finite()) {
-            return Self::empty(self.tolerance);
+            return Ok(Self::empty(self.resolution));
         }
-        two_sided_gap_residual(self, &closing_residual(self, radius))
+        two_sided_gap_residual(self, &closing_residual(self, radius)?).checked()
     }
 
     /// Connected material residues of the opening by `radius` whose local
@@ -1227,7 +1311,7 @@ impl ContourSet {
         &self,
         radius: f64,
         width_mm: f64,
-    ) -> Vec<TwoSidedResidualComponent> {
+    ) -> Result<Vec<TwoSidedResidualComponent>, AccuracyError> {
         // A width is a disk touching two facing walls, so it is at least
         // their separation: material whose walls never face each other that
         // closely has no width to find. Any width lies within a radius of
@@ -1239,11 +1323,11 @@ impl ContourSet {
         // `M \ X`, so the opening's clip to the source is not needed to
         // find what the opening removed.
         self.two_sided_residual(radius, |region, radius| {
-            let facing = width_mm + 4.0 * region.tolerance;
-            let touching = 3.0 * region.tolerance + tol::FLATTEN_MM;
-            let reach = 3.0 * (radius + 2.0 * region.tolerance);
+            let facing = width_mm + 4.0 * region.tolerance();
+            let touching = 3.0 * region.tolerance() + region.uncertainty_mm;
+            let reach = 3.0 * (radius + 2.0 * region.tolerance());
             let candidates = region.facing_components(facing, touching, reach);
-            candidates.difference(&candidates.disk_erode(radius).disk_dilate(radius))
+            Ok(candidates.difference(&candidates.disk_erode(radius)?.disk_dilate(radius)?))
         })
     }
 
@@ -1253,15 +1337,15 @@ impl ContourSet {
         &self,
         radius: f64,
         width_mm: f64,
-    ) -> Vec<TwoSidedResidualComponent> {
+    ) -> Result<Vec<TwoSidedResidualComponent>, AccuracyError> {
         // A gap is a disk touching two walls facing across void, so it is
         // at least their separation. A residue point lies within a radius
         // of its walls and the disks that decide it reach a diameter
         // further, so the closing of the material within two diameters of
         // facing walls is the closing of the whole region there.
         self.two_sided_residual(radius, |region, radius| {
-            let facing = width_mm + 4.0 * region.tolerance;
-            let reach = 4.0 * (radius + 2.0 * region.tolerance);
+            let facing = width_mm + 4.0 * region.tolerance();
+            let reach = 4.0 * (radius + 2.0 * region.tolerance());
             let candidates = region.facing_components(0.0, facing, reach);
             closing_residual(&candidates, radius)
         })
@@ -1272,16 +1356,24 @@ impl ContourSet {
     fn two_sided_residual(
         &self,
         radius: f64,
-        residual: impl FnOnce(&Self, f64) -> Self,
-    ) -> Vec<TwoSidedResidualComponent> {
+        residual: impl FnOnce(&Self, f64) -> Result<Self, AccuracyError>,
+    ) -> Result<Vec<TwoSidedResidualComponent>, AccuracyError> {
         if self.is_empty() || !(radius > 0.0 && radius.is_finite()) {
-            return Vec::new();
+            return Ok(Vec::new());
         }
-        two_sided_residual_components(self, &residual(self, radius), radius)
+        Ok(two_sided_residual_components(
+            self,
+            &residual(self, radius)?,
+            radius,
+            self.budget().allowance(self.uncertainty_mm)?,
+        ))
     }
 
     pub fn to_contours(&self) -> Vec<ContourBuf> {
         rings_to_contours(self.rings.clone())
+            .into_iter()
+            .map(|c| c.with_uncertainty(self.uncertainty_mm))
+            .collect()
     }
 
     /// Convert each connected component to one positive contour.
@@ -1295,78 +1387,139 @@ impl ContourSet {
             .map(crate::geom::bridge::bridge_shape)
             .filter(|ring| ring.len() >= 3)
             .filter_map(ring_to_contour)
+            .map(|c| c.with_uncertainty(self.uncertainty_mm))
             .collect()
     }
 
-    fn disk_offset(&self, offset: f64) -> Self {
-        let radius = offset.abs();
-        let max_sagitta = tol::STROKE_OUTLINE_MM.min(radius);
-        // i_overlay rounds each join into floor(sweep / join_angle)
-        // segments. Use half the central angle allowed by the sagitta budget
-        // so that flooring cannot make the emitted segments too coarse.
-        let join_angle = (1.0 - max_sagitta / radius)
-            .acos()
-            .clamp(0.01 * std::f64::consts::PI, 0.25 * std::f64::consts::PI);
+    /// Disk dilation within the region's budget, input uncertainty included.
+    pub fn disk_dilate(&self, radius: f64) -> Result<Self, AccuracyError> {
+        if radius < 0.0 {
+            return Err(AccuracyError::InvalidGeometry("negative disk radius"));
+        }
+        self.disk_offset(radius)
+    }
+
+    /// Disk erosion within the region's budget, input uncertainty included.
+    pub fn disk_erode(&self, radius: f64) -> Result<Self, AccuracyError> {
+        if radius < 0.0 {
+            return Err(AccuracyError::InvalidGeometry("negative disk radius"));
+        }
+        self.disk_offset(-radius)
+    }
+
+    fn disk_offset(&self, offset: f64) -> Result<Self, AccuracyError> {
+        if !offset.is_finite() {
+            return Err(AccuracyError::InvalidGeometry("non-finite disk radius"));
+        }
+        let accuracy = self.budget();
+        accuracy.check(self.uncertainty_mm)?;
+        if self.is_empty() || offset == 0.0 {
+            return Ok(self.clone());
+        }
+        let numeric = numerical_error(self.bbox.expand(offset.abs()));
+        let inherited = self.uncertainty_mm + numeric;
+        let remaining = accuracy.allowance(inherited)?;
+        let join_angle = (2.0 * (remaining / (2.0 * offset.abs())).min(1.0).sqrt().asin())
+            .clamp(0.01 * std::f64::consts::PI, std::f64::consts::FRAC_PI_4);
         let style = OutlineStyle::new(offset).line_join(OutlineLineJoin::Round(join_angle));
-        let shapes = self.rings.outline_as::<i64>(&style);
-        Self::new(flatten_shapes(shapes), FillRule::NonZero, self.tolerance)
+        let rings = flatten_shapes(self.rings.outline_as::<i64>(&style));
+        // Only rounded corners incur chord error; inward corners intersect straight edges.
+        // The backend emits floor(sweep / join_angle) chords at each rounded corner.
+        let added = self
+            .rings
+            .iter()
+            .flat_map(|ring| {
+                let directions = ring_edges(ring)
+                    .filter_map(|(a, b)| {
+                        let d = b - a;
+                        (d.length() > 0.0).then(|| d / d.length())
+                    })
+                    .collect::<Vec<_>>();
+                directions
+                    .iter()
+                    .zip(directions.iter().cycle().skip(1))
+                    .take(directions.len())
+                    .filter(|(a, b)| (a.x * b.y - a.y * b.x) * offset > 0.0)
+                    .map(|(a, b)| {
+                        let sweep = (a.x * b.x + a.y * b.y).clamp(-1.0, 1.0).acos();
+                        let steps = (sweep / join_angle).floor().max(1.0);
+                        2.0 * offset.abs() * (sweep / steps / 4.0).sin().powi(2)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .fold(0.0, f64::max);
+        let simplified = decimate_rings_inward(&rings, numeric);
+        Self::from_regularized(
+            simplify_rings(simplified, FillRule::NonZero),
+            self.resolution,
+            inherited + added + numeric,
+        )
+        .checked()
     }
 }
 
 /// Compose an ordered dark/clear paint stream into a final positive image.
 ///
 /// Consecutive same-polarity pushes are batched into one boolean operation.
-#[derive(Debug, Default)]
+/// The image is prepared at the composer's resolution, tightened to the
+/// budget of any input.
+#[derive(Debug)]
 pub struct PaintComposer {
     image: Vec<Ring>,
     run: Vec<Ring>,
     run_polarity: Option<Polarity>,
+    resolution: Resolution,
+    uncertainty_mm: f64,
 }
 
 impl PaintComposer {
-    pub fn push(&mut self, polarity: Polarity, mut rings: Vec<Ring>) {
-        if rings.is_empty() {
+    pub fn new(resolution: Resolution) -> Self {
+        Self {
+            image: Vec::new(),
+            run: Vec::new(),
+            run_polarity: None,
+            resolution,
+            uncertainty_mm: 0.0,
+        }
+    }
+
+    pub fn push(&mut self, polarity: Polarity, mut region: ContourSet) {
+        // An empty input still contributes its history: material within its
+        // uncertainty band may have been lost before it arrived here.
+        self.uncertainty_mm = self.uncertainty_mm.max(region.uncertainty_mm);
+        self.resolution = self.resolution.meet(region.resolution);
+        if region.is_empty() {
             return;
         }
         if self.run_polarity != Some(polarity) {
             self.flush_run();
             self.run_polarity = Some(polarity);
         }
-        self.run.append(&mut rings);
+        self.run.append(&mut region.rings);
     }
 
-    pub fn finish(mut self) -> Vec<Ring> {
+    pub fn finish(mut self) -> ContourSet {
         self.flush_run();
-        self.image
-    }
-
-    pub fn finish_set(self, tolerance: f64) -> ContourSet {
-        ContourSet::new(self.finish(), FillRule::NonZero, tolerance)
+        ContourSet::from_regularized(self.image, self.resolution, self.uncertainty_mm)
     }
 
     fn flush_run(&mut self) {
         let Some(polarity) = self.run_polarity.take() else {
             return;
         };
-        if self.run.is_empty() {
-            return;
-        }
-
-        match polarity {
-            Polarity::Dark => {
-                let mut rings = std::mem::take(&mut self.image);
-                rings.append(&mut self.run);
-                self.image = union_rings(rings, FillRule::NonZero);
-            }
-            Polarity::Clear => {
-                if self.image.is_empty() {
-                    self.run.clear();
-                } else {
-                    let cutters = union_rings(std::mem::take(&mut self.run), FillRule::NonZero);
-                    self.image = difference_rings(std::mem::take(&mut self.image), cutters);
-                }
-            }
-        }
+        let rule = match polarity {
+            Polarity::Dark => OverlayRule::Union,
+            Polarity::Clear => OverlayRule::Difference,
+        };
+        let rings = flatten_shapes(self.image.overlay_as::<i64>(
+            &self.run,
+            rule,
+            OverlayFillRule::NonZero,
+        ));
+        self.uncertainty_mm +=
+            numerical_error(rings_bbox(&self.image).union(rings_bbox(&self.run)));
+        self.image = rings;
+        self.run.clear();
     }
 }
 
@@ -1404,14 +1557,6 @@ fn ring_winding(ring: &Ring, point: Point) -> i32 {
 
 fn flatten_shapes(shapes: Vec<Shape>) -> Vec<Ring> {
     shapes.into_iter().flatten().collect()
-}
-
-fn filter_significant_rings(mut rings: Vec<Ring>, tolerance: f64) -> Vec<Ring> {
-    if tolerance > 0.0 {
-        let min_area = tolerance.powi(2);
-        rings.retain(|ring| ring_signed_area(ring).abs() > min_area);
-    }
-    rings
 }
 
 fn push_ring(out: &mut Vec<Ring>, ring: &mut Ring) {
@@ -1471,8 +1616,8 @@ struct OrientedBoundarySegment {
     bbox: BBox,
 }
 
-fn closing_residual(region: &ContourSet, radius: f64) -> ContourSet {
-    region.disk_close(radius).difference(region)
+fn closing_residual(region: &ContourSet, radius: f64) -> Result<ContourSet, AccuracyError> {
+    region.disk_close(radius)?.difference(region).checked()
 }
 
 /// Every source boundary edge longer than the region tolerance, in ring
@@ -1487,10 +1632,14 @@ fn source_boundary_segments(source: &ContourSet) -> Vec<OrientedBoundarySegment>
             let metric = RingArcLength::new(ring);
             // Keep the two-sided chord local even when the whole ring is
             // smaller than the ordinary geometry resolution.
-            let tangent_radius = tol::FLATTEN_MM.min(metric.perimeter() / 8.0);
+            let tangent_radius = source
+                .uncertainty_mm
+                .max(source.tolerance())
+                .max(numerical_error(source.bbox))
+                .min(metric.perimeter() / 8.0);
             let kept = ring_edges(ring)
                 .enumerate()
-                .filter(|(_, (start, end))| start.distance_to(*end) > source.tolerance)
+                .filter(|(_, (start, end))| start.distance_to(*end) > source.tolerance())
                 .collect::<Vec<_>>();
             let ring_len = kept.len();
             kept.into_iter()
@@ -1573,6 +1722,7 @@ fn two_sided_residual_components(
     source: &ContourSet,
     residual: &ContourSet,
     reach: f64,
+    approximation_mm: f64,
 ) -> Vec<TwoSidedResidualComponent> {
     if residual.is_empty() {
         return Vec::new();
@@ -1583,8 +1733,13 @@ fn two_sided_residual_components(
             .iter()
             .map(|segment| (segment.start, segment.end))
             .collect(),
+        source.uncertainty_mm,
     );
-    let contact_tolerance = source.tolerance.max(residual.tolerance);
+    let contact_tolerance = source
+        .tolerance()
+        .max(residual.tolerance())
+        .max(numerical_error(source.bbox));
+    let boundary_uncertainty = source.uncertainty_mm + std::f64::consts::SQRT_2 * contact_tolerance;
     residual
         .connected_components()
         .into_iter()
@@ -1594,13 +1749,22 @@ fn two_sided_residual_components(
                 .into_iter()
                 .map(|id| segments[id])
                 .collect::<Vec<_>>();
-            component_width(&sites, &component, reach, contact_tolerance).map(|geometry| {
-                TwoSidedResidualComponent {
-                    region: component,
-                    width: geometry.disk.width(),
-                    disk: geometry.disk,
-                    axis: geometry.axis,
-                }
+            component_width(
+                &sites,
+                &component,
+                reach,
+                contact_tolerance,
+                approximation_mm,
+                boundary_uncertainty,
+            )
+            .map(|geometry| TwoSidedResidualComponent {
+                region: component,
+                width: geometry
+                    .disk
+                    .width()
+                    .also_uncertain(2.0 * boundary_uncertainty),
+                disk: geometry.disk,
+                axis: geometry.axis,
             })
         })
         .collect()
@@ -1731,7 +1895,7 @@ pub(crate) struct InscribedDisk {
 
 impl InscribedDisk {
     fn width(self) -> Distance {
-        Distance::flattened(2.0 * self.radius, self.first, self.second, 2)
+        Distance::exact(2.0 * self.radius, self.first, self.second)
     }
 }
 
@@ -1769,6 +1933,8 @@ fn component_width(
     component: &ContourSet,
     reach: f64,
     contact_tolerance: f64,
+    approximation_mm: f64,
+    boundary_uncertainty: f64,
 ) -> Option<ComponentWidth> {
     if one_wall(sites) {
         return None;
@@ -1851,7 +2017,7 @@ fn component_width(
         .map(farthest_vertex)
         .fold(f64::INFINITY, f64::min)
         + 2.0 * contact_tolerance
-        + tol::FLATTEN_MM;
+        + approximation_mm;
     let within_reach = sites
         .iter()
         .map(|site| {
@@ -1958,19 +2124,26 @@ fn component_width(
         if edge.id() > twin || !edge.is_primary() || incident(first, second) {
             continue;
         }
-        let samples =
-            voronoi_edge_samples(&diagram, edge.id(), &lines, component, reach, units_per_mm)
-                .expect("voronoi edge samples")
-                .into_iter()
-                .map(unquantize)
-                .collect::<Vec<_>>();
+        let samples = voronoi_edge_samples(
+            &diagram,
+            edge.id(),
+            &lines,
+            component,
+            reach,
+            units_per_mm,
+            approximation_mm,
+        )
+        .expect("voronoi edge samples")
+        .into_iter()
+        .map(unquantize)
+        .collect::<Vec<_>>();
         axis.extend(samples.windows(2).map(|pair| WidthAxisSegment {
             start: pair[0],
             end: pair[1],
             first_wall: (sites[first].start, sites[first].end),
             second_wall: (sites[second].start, sites[second].end),
             uncertainty_mm: if edge.is_curved() {
-                tol::FLATTEN_MM
+                approximation_mm
             } else {
                 0.0
             },
@@ -2024,14 +2197,14 @@ fn component_width(
         present.iter().any(|other| {
             other.radius > disk.radius
                 && disk.center.distance_to(other.center) + disk.radius
-                    <= other.radius + tol::FLATTEN_MM
+                    <= other.radius + approximation_mm
         })
     };
     let minimum = present
         .iter()
         .filter(|disk| !pruned(disk))
-        // Below two grid units a width is snapping noise, not geometry.
-        .filter(|disk| disk.width().mm > 2.0 * contact_tolerance)
+        // The disk must survive the uncertainty of its boundary sites.
+        .filter(|disk| disk.radius > boundary_uncertainty)
         .min_by(|left, right| left.width().mm.total_cmp(&right.width().mm))
         .copied()?;
     // Retain the actual interior axis, removing the portions rejected by the
@@ -2053,7 +2226,7 @@ fn component_width(
                 break;
             }
             if dist::point_segment(other.center, segment.start, segment.end).0
-                > other.radius + tol::FLATTEN_MM
+                > other.radius + approximation_mm
             {
                 continue;
             }
@@ -2063,7 +2236,7 @@ fn component_width(
             };
             let Some(contained) = convex_sublevel_interval(
                 |t| at(t).distance_to(other.center) + radius(t),
-                other.radius + tol::FLATTEN_MM,
+                other.radius + approximation_mm,
             ) else {
                 continue;
             };
@@ -2123,25 +2296,33 @@ fn component_width(
 /// the rounded bite of one smooth concavity is not mistaken for a gap.
 fn two_sided_gap_residual(source: &ContourSet, residual: &ContourSet) -> ContourSet {
     let source_segments = source_boundary_segments(source);
-    let contact_tolerance = source.tolerance.max(residual.tolerance);
+    let boundary = PreparedRegion::from_segments(
+        source_segments
+            .iter()
+            .map(|segment| (segment.start, segment.end))
+            .collect(),
+        source.uncertainty_mm,
+    );
+    let contact_tolerance = source
+        .tolerance()
+        .max(residual.tolerance())
+        .max(numerical_error(source.bbox));
 
     let rings = residual
         .connected_components()
         .into_iter()
         .filter(|component| {
-            let contacts = source_segments
-                .iter()
+            let contacts = boundary
+                .segment_ids_meeting(component.bbox.expand(contact_tolerance))
+                .into_iter()
+                .map(|id| &source_segments[id])
                 .filter(|segment| {
-                    segment
-                        .bbox
-                        .expand(contact_tolerance)
-                        .intersects(component.bbox)
-                        && region_boundary_within_distance(
-                            component,
-                            segment.start,
-                            segment.end,
-                            contact_tolerance,
-                        )
+                    region_boundary_within_distance(
+                        component,
+                        segment.start,
+                        segment.end,
+                        contact_tolerance,
+                    )
                 })
                 .collect::<Vec<_>>();
             contacts.iter().enumerate().any(|(index, left)| {
@@ -2162,7 +2343,11 @@ fn two_sided_gap_residual(source: &ContourSet, residual: &ContourSet) -> Contour
         })
         .flat_map(|component| component.rings)
         .collect();
-    ContourSet::new(rings, FillRule::NonZero, residual.tolerance)
+    ContourSet::from_regularized(
+        simplify_rings(rings, FillRule::NonZero),
+        residual.resolution,
+        residual.uncertainty_mm,
+    )
 }
 
 fn region_boundary_within_distance(
@@ -2205,9 +2390,11 @@ fn narrow_void_keep_out(
         .into_iter()
         .filter(|component| component.intersection(&axis_keep_out).is_empty())
         .collect::<Vec<_>>();
-    Ok(axisless.into_iter().fold(axis_keep_out, |keep_out, thin| {
-        keep_out.union(&thin.disk_dilate(radius))
-    }))
+    Ok(axisless
+        .into_iter()
+        .try_fold(axis_keep_out, |keep_out, thin| {
+            Ok::<_, AccuracyError>(keep_out.union(&thin.disk_dilate(radius)?))
+        })?)
 }
 
 fn narrow_void_medial_axis_keep_out(
@@ -2216,16 +2403,40 @@ fn narrow_void_medial_axis_keep_out(
     radius: f64,
 ) -> Result<ContourSet, GapRegularizationError> {
     if narrow_voids.is_empty() {
-        return Ok(ContourSet::empty(source.tolerance));
+        return Ok(ContourSet::empty(source.resolution));
     }
+    let accuracy = source.budget();
+    let boundary = PreparedRegion::from_segments(
+        source.rings.iter().flat_map(ring_edges).collect(),
+        source.uncertainty_mm,
+    );
+    // A closing residual is within the disk radius of its nearest source boundary.
+    let void_boundary = narrow_voids.prepare_query();
+    let relevant = narrow_voids
+        .ring_bounds
+        .iter()
+        .flat_map(|bounds| boundary.segment_ids_meeting(bounds.expand(radius)))
+        .filter(|&id| {
+            let (start, end) = boundary.segments[id];
+            void_boundary
+                .segment_nearest_within(start, end, radius)
+                .is_some()
+        })
+        .collect::<std::collections::HashSet<_>>();
+    let mut source_index = 0;
     let origin = Point::new(source.bbox.min.x, source.bbox.min.y);
     let mut segments = Vec::<VoronoiLine<i32>>::new();
     let mut boundary_segments = Vec::new();
     for (ring_id, ring) in source.rings.iter().enumerate() {
         for index in 0..ring.len() {
+            let needed = relevant.contains(&source_index);
+            source_index += 1;
+            if !needed {
+                continue;
+            }
             let [start_x, start_y] = ring[index];
             let [end_x, end_y] = ring[(index + 1) % ring.len()];
-            if (end_x - start_x).hypot(end_y - start_y) <= source.tolerance {
+            if (end_x - start_x).hypot(end_y - start_y) <= source.tolerance() {
                 continue;
             }
             let start = quantize_voronoi_point(ring[index], origin)?;
@@ -2291,6 +2502,7 @@ fn narrow_void_medial_axis_keep_out(
             source,
             radius,
             VORONOI_COORDINATES_PER_MM,
+            accuracy.allowance(source.uncertainty_mm)?,
         )?;
         let mut commands = Vec::with_capacity(samples.len());
         for sample in samples {
@@ -2312,12 +2524,16 @@ fn narrow_void_medial_axis_keep_out(
             });
         }
         if commands.len() >= 2 {
-            contours.push(ContourBuf::new(commands));
+            contours.push(ContourBuf::new(commands).with_uncertainty(
+                source.uncertainty_mm
+                    + accuracy.allowance(source.uncertainty_mm)?
+                    + std::f64::consts::SQRT_2 / VORONOI_COORDINATES_PER_MM,
+            ));
         }
     }
 
     if contours.is_empty() {
-        return Ok(ContourSet::empty(source.tolerance));
+        return Ok(ContourSet::empty(source.resolution));
     }
     // A narrow filled stroke makes the one-dimensional axis available to the
     // existing set algebra. Intersecting with a slightly eroded narrow-void
@@ -2331,12 +2547,12 @@ fn narrow_void_medial_axis_keep_out(
     let medial_axis = ContourSet::from_painted_paths(
         &arena,
         std::iter::once(&arena.paths[path as usize]),
-        source.tolerance,
-    );
+        source.resolution,
+    )?;
     let interior_axis =
-        medial_axis.intersection(&narrow_voids.disk_erode(2.0 * axis_stroke_radius));
-    let keep_out = interior_axis.disk_dilate(radius);
-    Ok(keep_out.intersection(&source.disk_dilate(radius)))
+        medial_axis.intersection(&narrow_voids.disk_erode(2.0 * axis_stroke_radius)?);
+    let keep_out = interior_axis.disk_dilate(radius)?;
+    Ok(keep_out.intersection(&source.disk_dilate(radius)?))
 }
 
 fn boundary_segments_are_incident(left: BoundarySegment, right: BoundarySegment) -> bool {
@@ -2378,6 +2594,7 @@ fn voronoi_edge_samples(
     region: &ContourSet,
     radius: f64,
     units_per_mm: f64,
+    approximation_mm: f64,
 ) -> Result<Vec<[f64; 2]>, GapRegularizationError> {
     let edge = diagram.edge(edge_id).map_err(gap_regularization_error)?;
     let affine = SimpleAffine::default();
@@ -2417,7 +2634,7 @@ fn voronoi_edge_samples(
         VoronoiVisualUtils::discretize(
             &point,
             segment,
-            tol::FLATTEN_MM * units_per_mm,
+            approximation_mm * units_per_mm,
             &affine,
             &mut samples,
         );
@@ -2553,7 +2770,7 @@ fn regions_within_distance(left: &ContourSet, right: &ContourSet, distance: f64)
     if !left.bbox.expand(distance).intersects(right.bbox) {
         return false;
     }
-    let threshold = distance + left.tolerance.max(right.tolerance);
+    let threshold = distance + left.tolerance().max(right.tolerance());
     for left_ring in &left.rings {
         for left_index in 0..left_ring.len() {
             let [left_start_x, left_start_y] = left_ring[left_index];
@@ -2588,15 +2805,48 @@ mod tests {
     use super::*;
     use crate::geom::shapes;
 
+    fn res(tolerance_mm: f64) -> Resolution {
+        Resolution::default().with_tolerance(tolerance_mm)
+    }
+
+    #[test]
+    fn width_requires_a_disk_that_survives_boundary_uncertainty() {
+        let mut region = ContourSet::rectangle(rect(0.0, 0.0, 1.0, 0.003), res(1e-6));
+        assert!(
+            !crate::geom::dfm::thin_features(&region, 0.127)
+                .unwrap()
+                .is_empty()
+        );
+        region.uncertainty_mm = 0.002;
+        assert!(
+            crate::geom::dfm::thin_features(&region, 0.127)
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn erosion_of_a_convex_polygon_does_not_spend_round_join_error() {
+        let accuracy = GeometryAccuracy::new(1e-6).unwrap();
+        let region =
+            ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), Resolution::new(0.0, accuracy));
+        let inset = region.disk_erode(1.0).unwrap();
+        assert!((inset.area() - 64.0).abs() < 1e-8);
+        assert!(inset.uncertainty_mm < 1e-9);
+        assert!(region.disk_dilate(1.0).is_err());
+    }
+
     #[test]
     fn component_width_prunes_only_beyond_grid_uncertainty() {
         let measure = |height| {
-            let component = ContourSet::rectangle(rect(0.0, 0.0, 1.0, height), tol::REGION_MM);
+            let component = ContourSet::rectangle(rect(0.0, 0.0, 1.0, height), res(tol::REGION_MM));
             component_width(
                 &source_boundary_segments(&component),
                 &component,
                 0.05,
                 tol::REGION_MM,
+                0.0025,
+                std::f64::consts::SQRT_2 * tol::REGION_MM,
             )
         };
 
@@ -2608,22 +2858,22 @@ mod tests {
 
     #[test]
     fn ring_components_group_holes_with_the_smallest_outer_ring_around_them() {
-        let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM)
+        let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM))
             .difference(&ContourSet::rectangle(
                 rect(2.0, 2.0, 8.0, 8.0),
-                tol::REGION_MM,
+                res(tol::REGION_MM),
             ))
             .union(&ContourSet::rectangle(
                 rect(3.0, 3.0, 7.0, 7.0),
-                tol::REGION_MM,
+                res(tol::REGION_MM),
             ))
             .difference(&ContourSet::rectangle(
                 rect(4.0, 4.0, 6.0, 6.0),
-                tol::REGION_MM,
+                res(tol::REGION_MM),
             ))
             .union(&ContourSet::rectangle(
                 rect(20.0, 0.0, 30.0, 10.0),
-                tol::REGION_MM,
+                res(tol::REGION_MM),
             ));
         assert_eq!(region.rings.len(), 5);
 
@@ -2645,9 +2895,9 @@ mod tests {
 
     #[test]
     fn facing_components_keep_only_walls_within_reach_of_each_other() {
-        let trace = ContourSet::rectangle(rect(0.0, 0.0, 5.0, 0.1), tol::REGION_MM);
-        let pad = ContourSet::rectangle(rect(10.0, 0.0, 12.0, 2.0), tol::REGION_MM);
-        let neighbour = ContourSet::rectangle(rect(12.15, 0.0, 14.0, 2.0), tol::REGION_MM);
+        let trace = ContourSet::rectangle(rect(0.0, 0.0, 5.0, 0.1), res(tol::REGION_MM));
+        let pad = ContourSet::rectangle(rect(10.0, 0.0, 12.0, 2.0), res(tol::REGION_MM));
+        let neighbour = ContourSet::rectangle(rect(12.15, 0.0, 14.0, 2.0), res(tol::REGION_MM));
         let region = trace.union(&pad).union(&neighbour);
         assert_eq!(region.rings.len(), 3);
 
@@ -2670,23 +2920,24 @@ mod tests {
         assert_eq!(with_context.rings.len(), 3);
 
         // A notch faces across void; a plane web between holes across material.
-        let notched = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM).difference(
-            &ContourSet::rectangle(rect(1.9, 2.0, 2.1, 4.5), tol::REGION_MM),
-        );
+        let notched =
+            ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM)).difference(
+                &ContourSet::rectangle(rect(1.9, 2.0, 2.1, 4.5), res(tol::REGION_MM)),
+            );
         assert_eq!(notched.facing_components(0.0, 0.3, 1.0).rings.len(), 1);
         assert!(notched.facing_components(0.15, 0.15, 1.0).is_empty());
-        let webbed = ContourSet::rectangle(rect(0.0, 0.0, 8.0, 4.0), tol::REGION_MM)
+        let webbed = ContourSet::rectangle(rect(0.0, 0.0, 8.0, 4.0), res(tol::REGION_MM))
             .difference(&ContourSet::rectangle(
                 rect(1.0, 1.0, 1.9, 3.0),
-                tol::REGION_MM,
+                res(tol::REGION_MM),
             ))
             .difference(&ContourSet::rectangle(
                 rect(2.1, 1.0, 3.0, 3.0),
-                tol::REGION_MM,
+                res(tol::REGION_MM),
             ))
             .difference(&ContourSet::rectangle(
                 rect(6.0, 1.0, 7.0, 3.0),
-                tol::REGION_MM,
+                res(tol::REGION_MM),
             ));
         let nearby_web = webbed.facing_components(0.3, 0.0, 1.0);
         assert_eq!(nearby_web.rings.len(), 3);
@@ -2735,37 +2986,18 @@ mod tests {
 
     #[test]
     fn inward_decimation_only_shrinks_and_respects_deviation() {
+        let spur = vec![[0.0, 0.0], [2.0, 0.0], [1.0, 1e-12], [1.0, 1.0], [0.0, 1.0]];
+        assert!(decimate_ring_inward(&spur, 1e-10).contains(&[2.0, 0.0]));
         let ring = ContourSet::from_contours(
             &[shapes::circle(10.0).unwrap(), shapes::circle(6.0).unwrap()],
             FillRule::EvenOdd,
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
         let deviation = 0.05;
-        let decimated = ring.decimate_inward(deviation);
+        let decimated = ring.decimate_inward(deviation).unwrap();
 
-        // The outer boundary decimates; the convex hole cannot lose a vertex
-        // without growing the region, so it stays exact.
-        let ring_len = |set: &ContourSet, hole: bool| {
-            set.rings
-                .iter()
-                .find(|ring| (ring_signed_area(ring) < 0.0) == hole)
-                .expect("annulus ring")
-                .len()
-        };
-        assert_eq!(
-            ring_len(&decimated, true),
-            ring_len(&ring, true),
-            "hole ring must stay exact"
-        );
-        assert!(
-            ring_len(&decimated, false) * 2 < ring_len(&ring, false),
-            "outer ring kept {} of {} vertices",
-            ring_len(&decimated, false),
-            ring_len(&ring, false)
-        );
-
-        // The region only shrinks: nothing outside the source survives.
-        assert!(decimated.difference(&ring).area() < 1e-9);
+        assert!(decimated.difference(&ring).area() <= ring.tolerance().powi(2));
 
         // Area loss is bounded by the deviation times the boundary length.
         let perimeter: f64 = ring
@@ -2780,22 +3012,18 @@ mod tests {
     #[test]
     fn inward_decimation_bounds_distance_to_segment_not_line() {
         // The spike is 0.01 mm from the chord's line, but 2 mm past its end.
-        let ring = vec![
+        let ring: Ring = vec![
             [0.0, 0.0],
             [12.0, -0.01],
             [10.0, 0.0],
             [10.0, 10.0],
             [0.0, 10.0],
         ];
-        let source = ContourSet::new(vec![ring.clone()], FillRule::NonZero, tol::REGION_MM);
         let deviation = 0.05;
-        let decimated = source.decimate_inward(deviation);
+        let decimated = decimate_ring_inward(&ring, deviation);
 
         for [x, y] in ring {
-            let distance = decimated
-                .rings
-                .iter()
-                .flat_map(ring_edges)
+            let distance = ring_edges(&decimated)
                 .map(|(a, b)| dist::point_segment(Point::new(x, y), a, b).0)
                 .fold(f64::INFINITY, f64::min);
             assert!(
@@ -2848,7 +3076,7 @@ mod tests {
     /// of these to nothing or to everything.
     #[test]
     fn grid_coverage_measures_partly_covered_cells_exactly() {
-        let square = ContourSet::rectangle(rect(0.5, 0.5, 2.5, 2.5), tol::REGION_MM);
+        let square = ContourSet::rectangle(rect(0.5, 0.5, 2.5, 2.5), res(tol::REGION_MM));
 
         let coverage = square.grid_coverage(rect(0.0, 0.0, 3.0, 3.0), 3, 3);
 
@@ -2870,8 +3098,8 @@ mod tests {
     /// fall in has to see that sign.
     #[test]
     fn grid_coverage_subtracts_holes() {
-        let ring = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM).difference(
-            &ContourSet::rectangle(rect(1.0, 1.0, 2.0, 3.0), tol::REGION_MM),
+        let ring = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM)).difference(
+            &ContourSet::rectangle(rect(1.0, 1.0, 2.0, 3.0), res(tol::REGION_MM)),
         );
 
         let coverage = ring.grid_coverage(rect(0.0, 0.0, 4.0, 4.0), 1, 1);
@@ -2881,13 +3109,13 @@ mod tests {
 
     #[test]
     fn contour_set_composes_region_operations() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let inner = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), tol::REGION_MM);
-        let clip = ContourSet::rectangle(rect(5.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let inner = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), res(tol::REGION_MM));
+        let clip = ContourSet::rectangle(rect(5.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
 
         let ring = outer.difference(&inner);
         let clipped = ring.intersection(&clip);
-        let expanded = clipped.disk_dilate(0.5);
+        let expanded = clipped.disk_dilate(0.5).unwrap();
 
         assert!(!expanded.is_empty());
         assert!((expanded.bbox.min.x - 4.5).abs() <= 1e-9);
@@ -2905,13 +3133,17 @@ mod tests {
             PathCmd::close(),
         ]);
 
-        let a = ContourSet::from_filled_contours(std::slice::from_ref(&clockwise), tol::REGION_MM);
+        let a =
+            ContourSet::from_filled_contours(std::slice::from_ref(&clockwise), res(tol::REGION_MM))
+                .unwrap();
         let b = ContourSet::from_filled_contours(
             std::slice::from_ref(&counter_clockwise),
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
         let unioned =
-            ContourSet::from_filled_contours(&[clockwise, counter_clockwise], tol::REGION_MM);
+            ContourSet::from_filled_contours(&[clockwise, counter_clockwise], res(tol::REGION_MM))
+                .unwrap();
 
         assert!(!a.is_empty());
         assert!((a.area() - b.area()).abs() <= 1e-9);
@@ -2920,8 +3152,8 @@ mod tests {
 
     #[test]
     fn area_subtracts_holes() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM);
-        let inner = ContourSet::rectangle(rect(1.0, 1.0, 3.0, 3.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM));
+        let inner = ContourSet::rectangle(rect(1.0, 1.0, 3.0, 3.0), res(tol::REGION_MM));
 
         let ring = outer.difference(&inner);
 
@@ -2930,8 +3162,8 @@ mod tests {
 
     #[test]
     fn containment_observes_boundaries_and_holes() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let hole = ContourSet::rectangle(rect(4.0, 4.0, 6.0, 6.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let hole = ContourSet::rectangle(rect(4.0, 4.0, 6.0, 6.0), res(tol::REGION_MM));
         let region = outer.difference(&hole);
 
         assert!(region.contains_point(Point::new(2.0, 2.0)));
@@ -2960,8 +3192,8 @@ mod tests {
 
     #[test]
     fn segment_spans_preserve_holes_and_clip_to_the_query() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let hole = ContourSet::rectangle(rect(4.0, 2.0, 6.0, 8.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let hole = ContourSet::rectangle(rect(4.0, 2.0, 6.0, 8.0), res(tol::REGION_MM));
         let ring = outer.difference(&hole);
 
         assert_spans(
@@ -2976,8 +3208,8 @@ mod tests {
 
     #[test]
     fn segment_spans_preserve_disconnected_and_concave_regions() {
-        let left = ContourSet::rectangle(rect(0.0, 0.0, 2.0, 2.0), tol::REGION_MM);
-        let concave = ContourSet::new(
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 2.0, 2.0), res(tol::REGION_MM));
+        let concave = ContourSet::from_rings(
             vec![vec![
                 [4.0, 0.0],
                 [8.0, 0.0],
@@ -2987,7 +3219,7 @@ mod tests {
                 [4.0, 2.0],
             ]],
             FillRule::NonZero,
-            tol::REGION_MM,
+            res(tol::REGION_MM),
         );
         assert_spans(
             left.union(&concave)
@@ -2998,7 +3230,7 @@ mod tests {
 
     #[test]
     fn segment_spans_follow_reversed_arbitrary_direction() {
-        let square = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM);
+        let square = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM));
         assert_spans(
             square.segment_spans(Point::new(6.0, 6.0), Point::new(-2.0, -2.0)),
             &[((4.0, 4.0), (0.0, 0.0))],
@@ -3007,7 +3239,7 @@ mod tests {
 
     #[test]
     fn segment_spans_include_boundary_but_not_tangencies() {
-        let square = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM);
+        let square = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM));
         assert_spans(
             square.segment_spans(Point::new(-1.0, 0.0), Point::new(3.0, 0.0)),
             &[((0.0, 0.0), (3.0, 0.0))],
@@ -3021,7 +3253,7 @@ mod tests {
 
     #[test]
     fn segment_spans_omit_degenerate_and_sub_tolerance_intervals() {
-        let square = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::EPSILON_MM);
+        let square = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::EPSILON_MM));
         assert!(
             square
                 .segment_spans(Point::new(1.0, 1.0), Point::new(1.0, 1.0))
@@ -3040,17 +3272,15 @@ mod tests {
 
     #[test]
     fn bridged_contour_preserves_local_holes_without_clear_polarity() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let circle = shapes::circle(2.0).unwrap();
-        let circle = crate::geom::path::transform_cmds(
-            circle.cmds,
-            crate::geom::Affine2::translation(Point::new(5.0, 5.0)),
-        );
-        let hole = ContourSet::from_filled_contours(&[circle], tol::REGION_MM);
+        let circle = circle.transformed(crate::geom::Affine2::translation(Point::new(5.0, 5.0)));
+        let hole = ContourSet::from_filled_contours(&[circle], res(tol::REGION_MM)).unwrap();
         let region = outer.difference(&hole);
 
         let contours = region.to_bridged_contours();
-        let round_trip = ContourSet::from_contours(&contours, FillRule::NonZero, tol::REGION_MM);
+        let round_trip =
+            ContourSet::from_contours(&contours, FillRule::NonZero, res(tol::REGION_MM)).unwrap();
 
         assert_eq!(contours.len(), 1);
         assert!(
@@ -3064,10 +3294,10 @@ mod tests {
 
     #[test]
     fn erodes_outer_boundaries_and_expands_holes() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let hole = ContourSet::rectangle(rect(4.0, 4.0, 6.0, 6.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let hole = ContourSet::rectangle(rect(4.0, 4.0, 6.0, 6.0), res(tol::REGION_MM));
 
-        let eroded = outer.difference(&hole).disk_erode(0.5);
+        let eroded = outer.difference(&hole).disk_erode(0.5).unwrap();
 
         assert!((eroded.bbox.min.x - 0.5).abs() <= 1e-9);
         assert!((eroded.bbox.min.y - 0.5).abs() <= 1e-9);
@@ -3082,18 +3312,18 @@ mod tests {
 
     #[test]
     fn erosion_can_remove_an_entire_region() {
-        let region = ContourSet::rectangle(rect(0.0, 0.0, 0.5, 0.5), tol::REGION_MM);
+        let region = ContourSet::rectangle(rect(0.0, 0.0, 0.5, 0.5), res(tol::REGION_MM));
 
-        let eroded = region.disk_erode(0.5);
+        let eroded = region.disk_erode(0.5).unwrap();
 
         assert!(eroded.is_empty());
     }
 
     #[test]
     fn disk_opening_rounds_corners_and_stays_inside_source() {
-        let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
 
-        let opened = region.disk_open(0.5);
+        let opened = region.disk_open(0.5).unwrap();
 
         assert!(opened.difference(&region).is_empty());
         assert!((opened.bbox.min.x - 0.0).abs() <= 1e-9);
@@ -3105,12 +3335,12 @@ mod tests {
 
     #[test]
     fn disk_opening_removes_sub_diameter_slivers_and_small_islands() {
-        let body = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let sliver = ContourSet::rectangle(rect(12.0, 0.0, 20.0, 0.8), tol::REGION_MM);
-        let island = ContourSet::rectangle(rect(22.0, 0.0, 22.8, 0.8), tol::REGION_MM);
+        let body = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let sliver = ContourSet::rectangle(rect(12.0, 0.0, 20.0, 0.8), res(tol::REGION_MM));
+        let island = ContourSet::rectangle(rect(22.0, 0.0, 22.8, 0.8), res(tol::REGION_MM));
         let region = body.union(&sliver).union(&island);
 
-        let opened = region.disk_open(0.5);
+        let opened = region.disk_open(0.5).unwrap();
 
         assert_eq!(opened.connected_components().len(), 1);
         assert!(opened.intersection(&body).area() > 99.0);
@@ -3120,12 +3350,12 @@ mod tests {
 
     #[test]
     fn disk_opening_is_idempotent_within_offset_tolerance() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let notch = ContourSet::rectangle(rect(4.0, 8.0, 6.0, 10.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let notch = ContourSet::rectangle(rect(4.0, 8.0, 6.0, 10.0), res(tol::REGION_MM));
         let region = outer.difference(&notch);
 
-        let once = region.disk_open(0.5);
-        let twice = once.disk_open(0.5);
+        let once = region.disk_open(0.5).unwrap();
+        let twice = once.disk_open(0.5).unwrap();
         let symmetric_difference = once.difference(&twice).union(&twice.difference(&once));
 
         assert!(
@@ -3137,12 +3367,12 @@ mod tests {
 
     #[test]
     fn disk_closing_fills_sub_diameter_gaps_and_stays_outside_source() {
-        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), tol::REGION_MM);
-        let right = ContourSet::rectangle(rect(4.8, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), res(tol::REGION_MM));
+        let right = ContourSet::rectangle(rect(4.8, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let region = left.union(&right);
 
-        let closed = region.disk_close(0.5);
-        let middle = ContourSet::rectangle(rect(4.0, 1.0, 4.8, 9.0), tol::REGION_MM);
+        let closed = region.disk_close(0.5).unwrap();
+        let middle = ContourSet::rectangle(rect(4.0, 1.0, 4.8, 9.0), res(tol::REGION_MM));
 
         assert!(region.difference(&closed).is_empty());
         assert!(closed.intersection(&middle).area() > 6.3);
@@ -3150,28 +3380,28 @@ mod tests {
 
     #[test]
     fn disk_closing_preserves_wide_gaps() {
-        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), tol::REGION_MM);
-        let right = ContourSet::rectangle(rect(5.2, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), res(tol::REGION_MM));
+        let right = ContourSet::rectangle(rect(5.2, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let region = left.union(&right);
 
-        let closed = region.disk_close(0.5);
-        let middle = ContourSet::rectangle(rect(4.0, 1.0, 5.2, 9.0), tol::REGION_MM);
+        let closed = region.disk_close(0.5).unwrap();
+        let middle = ContourSet::rectangle(rect(4.0, 1.0, 5.2, 9.0), res(tol::REGION_MM));
 
         assert!(closed.intersection(&middle).is_empty());
     }
 
     #[test]
     fn disk_gap_violations_report_close_distinct_components() {
-        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), tol::REGION_MM);
-        let close = ContourSet::rectangle(rect(4.8, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let wide = ContourSet::rectangle(rect(5.2, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), res(tol::REGION_MM));
+        let close = ContourSet::rectangle(rect(4.8, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let wide = ContourSet::rectangle(rect(5.2, 0.0, 10.0, 10.0), res(tol::REGION_MM));
 
-        let close_violations = left.union(&close).disk_gap_violations(0.5);
-        let wide_violations = left.union(&wide).disk_gap_violations(0.5);
+        let close_violations = left.union(&close).disk_gap_violations(0.5).unwrap();
+        let wide_violations = left.union(&wide).disk_gap_violations(0.5).unwrap();
 
         assert!(close_violations.area() > 1.5);
         assert!(wide_violations.is_empty());
-        assert!(left.disk_gap_violations(0.5).is_empty());
+        assert!(left.disk_gap_violations(0.5).unwrap().is_empty());
     }
 
     #[test]
@@ -3179,31 +3409,37 @@ mod tests {
         // A 3 µm gap is two-sided but too thin to carry a medial-axis stroke;
         // the whole-component sweep must still make progress instead of
         // stalling into an error.
-        let left = ContourSet::rectangle(rect(0.0, 0.0, 5.0, 6.0), tol::REGION_MM);
-        let right = ContourSet::rectangle(rect(5.003, 0.0, 10.0, 6.0), tol::REGION_MM);
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 5.0, 6.0), res(tol::REGION_MM));
+        let right = ContourSet::rectangle(rect(5.003, 0.0, 10.0, 6.0), res(tol::REGION_MM));
         let region = left.union(&right);
-        assert!(!region.disk_gap_violations(0.5).is_empty());
+        assert!(!region.disk_gap_violations(0.5).unwrap().is_empty());
 
         let regularization = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
 
-        assert!(regularization.kept.disk_gap_violations(0.5).is_empty());
+        assert!(
+            regularization
+                .kept
+                .disk_gap_violations(0.5)
+                .unwrap()
+                .is_empty()
+        );
         assert!(regularization.removed.area() > 0.0);
     }
 
     #[test]
     fn disk_gap_violations_exclude_isolated_void_corners() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let wide_hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let wide_hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), res(tol::REGION_MM));
         let region = outer.difference(&wide_hole);
-        let raw_closing_residual = region.disk_close(0.5).difference(&region);
+        let raw_closing_residual = region.disk_close(0.5).unwrap().difference(&region);
 
         assert!(raw_closing_residual.area() > 0.1);
-        assert!(region.disk_gap_violations(0.5).is_empty());
+        assert!(region.disk_gap_violations(0.5).unwrap().is_empty());
     }
 
     #[test]
     fn disk_gap_regularization_rejects_invalid_scales() {
-        let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
 
         assert!(region.disk_regularize_gaps(0.0, 0.5, 0.025).is_err());
         assert!(region.disk_regularize_gaps(0.5, f64::NAN, 0.025).is_err());
@@ -3212,24 +3448,24 @@ mod tests {
 
     #[test]
     fn disk_gap_regularization_widens_a_gap_thinner_than_the_guard() {
-        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), tol::REGION_MM);
-        let right = ContourSet::rectangle(rect(4.01, 0.0, 10.0, 10.0), tol::REGION_MM);
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 10.0), res(tol::REGION_MM));
+        let right = ContourSet::rectangle(rect(4.01, 0.0, 10.0, 10.0), res(tol::REGION_MM));
         let region = left.union(&right);
 
-        let before = region.disk_gap_violations(0.5);
+        let before = region.disk_gap_violations(0.5).unwrap();
         let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
 
         assert!(before.area() > 0.05);
-        assert!(before.disk_open(0.025).is_empty());
+        assert!(before.disk_open(0.025).unwrap().is_empty());
         assert!(result.removed.area() > 0.0);
-        assert!(result.kept.disk_gap_violations(0.5).is_empty());
+        assert!(result.kept.disk_gap_violations(0.5).unwrap().is_empty());
     }
 
     #[test]
     fn disk_gap_regularization_trims_a_close_pair_locally() {
-        let left = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let right = ContourSet::rectangle(rect(10.8, 0.0, 20.8, 10.0), tol::REGION_MM);
-        let distant = ContourSet::rectangle(rect(24.0, 0.0, 30.0, 10.0), tol::REGION_MM);
+        let left = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let right = ContourSet::rectangle(rect(10.8, 0.0, 20.8, 10.0), res(tol::REGION_MM));
+        let distant = ContourSet::rectangle(rect(24.0, 0.0, 30.0, 10.0), res(tol::REGION_MM));
         let region = left.union(&right).union(&distant);
 
         let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
@@ -3242,14 +3478,14 @@ mod tests {
             result.removed.area()
         );
         assert!(result.removed.intersection(&distant).area() <= 0.25);
-        assert!(result.kept.disk_gap_violations(0.5).is_empty());
+        assert!(result.kept.disk_gap_violations(0.5).unwrap().is_empty());
     }
 
     #[test]
     fn disk_gap_regularization_is_symmetric_at_a_three_way_conflict() {
-        let lower_left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), tol::REGION_MM);
-        let lower_right = ContourSet::rectangle(rect(4.8, 0.0, 8.8, 4.0), tol::REGION_MM);
-        let upper = ContourSet::rectangle(rect(2.4, 4.8, 6.4, 8.8), tol::REGION_MM);
+        let lower_left = ContourSet::rectangle(rect(0.0, 0.0, 4.0, 4.0), res(tol::REGION_MM));
+        let lower_right = ContourSet::rectangle(rect(4.8, 0.0, 8.8, 4.0), res(tol::REGION_MM));
+        let upper = ContourSet::rectangle(rect(2.4, 4.8, 6.4, 8.8), res(tol::REGION_MM));
         let region = lower_left.union(&lower_right).union(&upper);
 
         let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
@@ -3258,7 +3494,7 @@ mod tests {
         for source in [&lower_left, &lower_right, &upper] {
             assert!(result.kept.intersection(source).area() > 13.0);
         }
-        let violations = result.kept.disk_gap_violations(0.5);
+        let violations = result.kept.disk_gap_violations(0.5).unwrap();
         assert!(
             violations.is_empty(),
             "remaining void-gap violation area {:.9} mm²",
@@ -3268,13 +3504,13 @@ mod tests {
 
     #[test]
     fn disk_gap_regularization_widens_a_same_component_hairpin() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let narrow_notch = ContourSet::rectangle(rect(4.6, 3.0, 5.4, 10.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let narrow_notch = ContourSet::rectangle(rect(4.6, 3.0, 5.4, 10.0), res(tol::REGION_MM));
         let hairpin = outer.difference(&narrow_notch);
 
-        let before = hairpin.disk_gap_violations(0.5);
+        let before = hairpin.disk_gap_violations(0.5).unwrap();
         let result = hairpin.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
-        let after = result.kept.disk_gap_violations(0.5);
+        let after = result.kept.disk_gap_violations(0.5).unwrap();
 
         assert_eq!(hairpin.connected_components().len(), 1);
         assert!(before.area() > 1.0);
@@ -3288,13 +3524,13 @@ mod tests {
 
     #[test]
     fn disk_gap_regularization_widens_a_narrow_internal_void() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let narrow_hole = ContourSet::rectangle(rect(4.6, 3.0, 5.4, 7.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let narrow_hole = ContourSet::rectangle(rect(4.6, 3.0, 5.4, 7.0), res(tol::REGION_MM));
         let region = outer.difference(&narrow_hole);
 
-        let before = region.disk_gap_violations(0.5);
+        let before = region.disk_gap_violations(0.5).unwrap();
         let result = region.disk_regularize_gaps(0.5, 0.5, 0.025).unwrap();
-        let after = result.kept.disk_gap_violations(0.5);
+        let after = result.kept.disk_gap_violations(0.5).unwrap();
 
         assert!(before.area() > 3.0);
         assert!(result.removed.area() > 1.0);
@@ -3308,11 +3544,11 @@ mod tests {
 
     #[test]
     fn dilation_shrinks_but_preserves_a_large_hole() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), res(tol::REGION_MM));
 
-        let dilated = outer.difference(&hole).disk_dilate(0.5);
-        let expected_hole = ContourSet::rectangle(rect(3.5, 3.5, 6.5, 6.5), tol::REGION_MM);
+        let dilated = outer.difference(&hole).disk_dilate(0.5).unwrap();
+        let expected_hole = ContourSet::rectangle(rect(3.5, 3.5, 6.5, 6.5), res(tol::REGION_MM));
 
         assert!(dilated.intersection(&expected_hole).is_empty());
         let area = dilated.area();
@@ -3324,10 +3560,10 @@ mod tests {
 
     #[test]
     fn union_contains_both_regions_when_a_hole_overlaps_filled_material() {
-        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), tol::REGION_MM);
-        let hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), tol::REGION_MM);
+        let outer = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM));
+        let hole = ContourSet::rectangle(rect(3.0, 3.0, 7.0, 7.0), res(tol::REGION_MM));
         let frame = outer.difference(&hole);
-        let plug = ContourSet::rectangle(rect(4.0, 4.0, 6.0, 6.0), tol::REGION_MM);
+        let plug = ContourSet::rectangle(rect(4.0, 4.0, 6.0, 6.0), res(tol::REGION_MM));
 
         let union = frame.union(&plug);
 
@@ -3341,8 +3577,10 @@ mod tests {
     /// source point even when all of these holes collapse.
     #[test]
     fn dilation_is_monotone_for_a5_corner_hole_chain() {
-        let outer =
-            ContourSet::rectangle(rect(22.8473, 110.5175, 27.8973, 115.5675), tol::REGION_MM);
+        let outer = ContourSet::rectangle(
+            rect(22.8473, 110.5175, 27.8973, 115.5675),
+            res(tol::REGION_MM),
+        );
         let holes = ContourSet::from_filled_contours(
             &[
                 contour_from_vertices(&[
@@ -3421,11 +3659,12 @@ mod tests {
                     [27.402869582176223, 115.46750009059907],
                 ]),
             ],
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
         let source = outer.difference(&holes);
 
-        let dilated = source.disk_dilate(0.525);
+        let dilated = source.disk_dilate(0.525).unwrap();
         let removed_source = source.difference(&dilated);
 
         assert!(
@@ -3458,8 +3697,9 @@ mod tests {
             [filled, stroked, unpainted]
                 .iter()
                 .map(|&index| arena.path(index)),
-            tol::REGION_MM,
-        );
+            res(tol::REGION_MM),
+        )
+        .unwrap();
 
         assert!((region.bbox.min.x - 0.0).abs() <= 1e-9);
         assert!((region.bbox.min.y - 0.0).abs() <= 1e-9);
@@ -3543,9 +3783,9 @@ mod tests {
             [38.0666795, 160.249661],
             [38.0177281, 160.13243],
         ]);
-        let region = ContourSet::from_filled_contours(&[contour], tol::REGION_MM);
+        let region = ContourSet::from_filled_contours(&[contour], res(tol::REGION_MM)).unwrap();
 
-        let grown = region.disk_dilate(0.5);
+        let grown = region.disk_dilate(0.5).unwrap();
 
         assert!(grown.area() > region.area());
     }
@@ -3565,9 +3805,9 @@ mod tests {
             [32.689244031906, 63.673370048958],
             [33.861821055412, 62.191123053986],
         ]);
-        let region = ContourSet::from_filled_contours(&[contour], tol::REGION_MM);
+        let region = ContourSet::from_filled_contours(&[contour], res(tol::REGION_MM)).unwrap();
 
-        let grown = region.disk_dilate(0.5);
+        let grown = region.disk_dilate(0.5).unwrap();
 
         assert!(grown.area() > region.area());
     }

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -40,19 +40,28 @@ use crate::geom::tol;
 use crate::geom::{AccuracyError, GeometryAccuracy, Resolution};
 
 /// A closed polygon boundary, flattened to line segments.
+/// Chords past which a single curve is being flattened to an absurd budget.
+const MAX_CHORDS_PER_SEGMENT: f64 = 1.0e6;
+
 pub type Ring = Vec<[f64; 2]>;
 
 /// One connected polygon: an outer ring plus hole rings.
 pub type Shape = Vec<Ring>;
 
 fn flatten_contours(contours: &[ContourBuf], accuracy: f64) -> (Vec<Ring>, f64) {
+    // Arc-to-cubic conversion is cheap in error and reported exactly, so it
+    // gets a small target and chord flattening spends the rest.
     let (bez_path, conversion_error) =
-        crate::geom::path::contours_to_kurbo(contours, accuracy / 2.0);
+        crate::geom::path::contours_to_kurbo(contours, accuracy / 8.0);
     let curved = bez_path
         .elements()
         .iter()
         .any(|el| matches!(el, kurbo::PathEl::CurveTo(..) | kurbo::PathEl::QuadTo(..)));
-    let flatten_error = if curved { accuracy / 2.0 } else { 0.0 };
+    let flatten_error = if curved {
+        (accuracy - conversion_error).max(accuracy / 2.0)
+    } else {
+        0.0
+    };
     let mut rings = Vec::new();
     let mut current = Vec::new();
     kurbo::flatten(
@@ -451,12 +460,22 @@ impl ContourSet {
 
     /// Construct from known regularized polygons, preserving their history.
     /// `uncertainty_mm = 0` asserts these polygons are the actual source.
-    pub fn from_regularized(rings: Vec<Ring>, resolution: Resolution, uncertainty_mm: f64) -> Self {
+    /// Rings below the resolution's significance are dropped; significance
+    /// is independent of the approximation budget and is not charged.
+    pub fn from_regularized(
+        mut rings: Vec<Ring>,
+        resolution: Resolution,
+        uncertainty_mm: f64,
+    ) -> Self {
         let uncertainty_mm = if uncertainty_mm >= 0.0 {
             uncertainty_mm
         } else {
             f64::INFINITY
         };
+        if resolution.tolerance_mm > 0.0 {
+            let min_area = resolution.tolerance_mm.powi(2);
+            rings.retain(|ring| ring_signed_area(ring).abs() > min_area);
+        }
         let ring_bounds = rings
             .iter()
             .map(|ring| rings_bbox(std::slice::from_ref(ring)))
@@ -510,19 +529,20 @@ impl ContourSet {
         let bbox = contours.iter().fold(BBox::empty(), |b, c| b.union(c.bbox));
         let numeric = numerical_error(bbox);
         let remaining = accuracy.allowance(prior + numeric)?;
+        // Guard against absurd budgets segment by segment, never against
+        // input size: a flattened panel legitimately needs millions of
+        // vertices, while one curve needing a million chords is a budget
+        // no target can use.
+        let absurd = |segment: Segment| {
+            let bounds = segment.bbox();
+            (bounds.width().max(bounds.height()) / remaining).sqrt() > MAX_CHORDS_PER_SEGMENT
+        };
         if remaining < f64::EPSILON
             || contours
                 .iter()
                 .flat_map(ContourBuf::segments)
-                .map(|segment| match segment {
-                    Segment::Line { .. } => 1.0,
-                    _ => {
-                        let bounds = segment.bbox();
-                        (bounds.width().max(bounds.height()) / remaining).sqrt()
-                    }
-                })
-                .sum::<f64>()
-                > 1_000_000.0
+                .filter(|segment| !matches!(segment, Segment::Line { .. }))
+                .any(absurd)
         {
             return Err(AccuracyError::SubdivisionLimit);
         }
@@ -3814,5 +3834,40 @@ mod tests {
         let grown = region.disk_dilate(0.5).unwrap();
 
         assert!(grown.area() > region.area());
+    }
+    #[test]
+    fn regularization_drops_rings_below_significance() {
+        let square = vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
+        let sliver = vec![[2.0, 0.0], [12.0, 0.0], [12.0, 5e-6], [2.0, 5e-6]];
+        let rings = || vec![square.clone(), sliver.clone()];
+
+        let significant = ContourSet::from_rings(rings(), FillRule::NonZero, res(0.01));
+        assert_eq!(significant.rings.len(), 1);
+        assert!((significant.area() - 1.0).abs() < 1e-9);
+
+        let exact = ContourSet::from_rings(rings(), FillRule::NonZero, res(0.0));
+        assert_eq!(exact.rings.len(), 2);
+    }
+
+    #[test]
+    fn preparation_scales_to_panel_sized_curve_sets() {
+        // A flattened panel legitimately needs millions of chord vertices;
+        // the subdivision guard must only reject absurd budgets.
+        let circles = (0..125)
+            .flat_map(|row| (0..120).map(move |column| (row, column)))
+            .map(|(row, column)| {
+                crate::geom::shapes::circle(1.0)
+                    .unwrap()
+                    .transformed(Affine2::translation(Point::new(
+                        2.0 * column as f64,
+                        2.0 * row as f64,
+                    )))
+            })
+            .collect::<Vec<_>>();
+
+        let region =
+            ContourSet::from_contours(&circles, FillRule::NonZero, Resolution::default()).unwrap();
+
+        assert_eq!(region.rings.len(), circles.len());
     }
 }

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -50,15 +50,19 @@ pub type Shape = Vec<Ring>;
 
 fn flatten_contours(contours: &[ContourBuf], accuracy: f64) -> (Vec<Ring>, f64) {
     // Arc-to-cubic conversion is cheap in error and reported exactly, so it
-    // gets a small target and chord flattening spends the rest.
+    // gets a small target and chord flattening takes the rest. Source error
+    // the conversion reports, such as a mismatched arc radius, is charged on
+    // top rather than squeezed out of the chord tolerance, so an inconsistent
+    // arc fails its budget instead of being flattened without bound.
+    let conversion_target = accuracy / 8.0;
     let (bez_path, conversion_error) =
-        crate::geom::path::contours_to_kurbo(contours, accuracy / 8.0);
+        crate::geom::path::contours_to_kurbo(contours, conversion_target);
     let curved = bez_path
         .elements()
         .iter()
         .any(|el| matches!(el, kurbo::PathEl::CurveTo(..) | kurbo::PathEl::QuadTo(..)));
     let flatten_error = if curved {
-        accuracy - conversion_error
+        accuracy - conversion_target
     } else {
         0.0
     };
@@ -3826,6 +3830,19 @@ mod tests {
 
         assert!(grown.area() > region.area());
     }
+    #[test]
+    fn mismatched_arc_radii_fail_the_budget_instead_of_flattening_without_bound() {
+        // Start radius 1, end radius 1.5: the source arc is inconsistent by
+        // far more than the budget allows.
+        let contour = ContourBuf::new(vec![
+            PathCmd::move_to(Point::new(1.0, 0.0)),
+            PathCmd::arc_to(Point::new(0.0, 1.5), Point::ZERO, false),
+            PathCmd::close(),
+        ]);
+        let error = ContourSet::from_contours(&[contour], FillRule::NonZero, res(0.0)).unwrap_err();
+        assert!(matches!(error, AccuracyError::BudgetExceeded { .. }));
+    }
+
     #[test]
     fn regularization_drops_rings_below_significance() {
         let square = vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];

--- a/crates/pcb-ir/src/geom/region/query.rs
+++ b/crates/pcb-ir/src/geom/region/query.rs
@@ -12,7 +12,7 @@ pub struct PreparedRegion {
     pub(crate) segments: Vec<(Point, Point)>,
     order: Vec<usize>,
     nodes: Vec<Node>,
-    uncertainty_mm: f64,
+    pub(crate) uncertainty_mm: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -35,10 +35,11 @@ impl ContourSet {
     /// Requires finite, regularized rings. Zero-area rings are ignored.
     ///
     /// ```
-    /// use pcb_ir::geom::{BBox, ContourSet, Point};
+    /// use pcb_ir::geom::{BBox, ContourSet, Point, Resolution};
     ///
     /// let region = ContourSet::rectangle(
-    ///     BBox::new(Point::ZERO, Point::new(4.0, 2.0)), 0.001,
+    ///     BBox::new(Point::ZERO, Point::new(4.0, 2.0)),
+    ///     Resolution::default(),
     /// );
     /// let prepared = region.prepare_query();
     /// let inside = prepared.signed_distance(Point::new(2.0, 0.5)).unwrap();
@@ -52,17 +53,18 @@ impl ContourSet {
                 .filter(|ring| ring_signed_area(ring) != 0.0)
                 .flat_map(ring_edges)
                 .collect(),
+            self.uncertainty_mm,
         )
     }
 }
 
 impl PreparedRegion {
-    pub(super) fn from_segments(segments: Vec<(Point, Point)>) -> Self {
+    pub(super) fn from_segments(segments: Vec<(Point, Point)>, uncertainty_mm: f64) -> Self {
         let mut prepared = Self {
             order: (0..segments.len()).collect(),
             segments,
             nodes: Vec::new(),
-            uncertainty_mm: tol::FLATTEN_MM,
+            uncertainty_mm,
         };
         if !prepared.segments.is_empty() {
             prepared.build(0..prepared.segments.len());
@@ -78,8 +80,7 @@ impl PreparedRegion {
     /// `None` when the region has no filled boundary or the point is non-finite.
     ///
     /// Uses floating-point arithmetic without snapping to the region tolerance.
-    /// Like [`Distance::flattened`], uncertainty counts one flattened boundary;
-    /// it does not bound prior approximations, offsets, or discarded features.
+    /// Uncertainty is inherited from the source geometry.
     /// The source geometry's sign is uncertain when this band includes zero.
     pub fn signed_distance(&self, point: Point) -> Option<Distance> {
         self.point_distance(point, f64::INFINITY, true)

--- a/crates/pcb-ir/src/geom/region/query.rs
+++ b/crates/pcb-ir/src/geom/region/query.rs
@@ -80,8 +80,12 @@ impl PreparedRegion {
     /// `None` when the region has no filled boundary or the point is non-finite.
     ///
     /// Uses floating-point arithmetic without snapping to the region tolerance.
-    /// Uncertainty is inherited from the source geometry.
-    /// The source geometry's sign is uncertain when this band includes zero.
+    /// The distance is to the prepared boundary, every point of which lies
+    /// within `uncertainty_mm` of a source boundary (see
+    /// [`crate::geom::accuracy`]); the source geometry's sign is uncertain when
+    /// the band includes zero. A prepared boundary may carry seams the exact
+    /// composition would not, so the distance is a lower bound on the distance
+    /// to the exact composed set, never an upper bound.
     pub fn signed_distance(&self, point: Point) -> Option<Distance> {
         self.point_distance(point, f64::INFINITY, true)
     }

--- a/crates/pcb-ir/src/geom/shapes.rs
+++ b/crates/pcb-ir/src/geom/shapes.rs
@@ -4,22 +4,15 @@
 //! (IPC-2581 standard primitives, Gerber standard apertures) and by aperture
 //! flattening. All shapes are built in local coordinates centered on the
 //! origin; apply an [`Affine2`](crate::geom::Affine2) placement with
-//! [`transform_cmds`](crate::geom::path::transform_cmds).
+//! [`ContourBuf::transformed`].
 //!
-//! Builders that can represent corners either as circular arcs or as cubic
-//! Beziers take an `arcs` flag: arcs are exact and preferred, but only
-//! transform correctly under similarity transforms
-//! ([`Affine2::preserves_circles`](crate::geom::Affine2::preserves_circles)); pass
-//! `arcs = false` when the placement may skew or scale non-uniformly.
+//! Transformations convert arcs only when required by the placement.
 //!
 //! Constructors return `None` for degenerate dimensions.
 
 use crate::geom::path::{ContourBuf, PathCmd};
 use crate::geom::point::Point;
 use std::f64::consts::PI;
-
-/// Cubic Bezier circle approximation constant.
-const KAPPA: f64 = 0.552_284_749_830_793_6;
 
 /// A circle of the given diameter, as four quarter arcs.
 pub fn circle(diameter: f64) -> Option<ContourBuf> {
@@ -38,37 +31,26 @@ pub fn circle(diameter: f64) -> Option<ContourBuf> {
     ]))
 }
 
-/// An axis-aligned ellipse as four cubic segments. Safe under any affine
-/// transform; also the cubic fallback for circles.
+/// An axis-aligned ellipse as four exact quarter arcs. Circles retain
+/// circular arcs.
 pub fn ellipse(width: f64, height: f64) -> Option<ContourBuf> {
     if width <= 0.0 || height <= 0.0 {
         return None;
     }
+    if width == height {
+        return circle(width);
+    }
     let rx = width / 2.0;
     let ry = height / 2.0;
-    let k = KAPPA;
+    let x_axis = Point::new(rx, 0.0);
+    let y_axis = Point::new(0.0, ry);
+    let quarter = |end: Point| PathCmd::ellipse_to(end, Point::ZERO, x_axis, y_axis, false);
     Some(ContourBuf::new(vec![
         PathCmd::move_to(Point::new(rx, 0.0)),
-        PathCmd::cubic_to(
-            Point::new(rx, k * ry),
-            Point::new(k * rx, ry),
-            Point::new(0.0, ry),
-        ),
-        PathCmd::cubic_to(
-            Point::new(-k * rx, ry),
-            Point::new(-rx, k * ry),
-            Point::new(-rx, 0.0),
-        ),
-        PathCmd::cubic_to(
-            Point::new(-rx, -k * ry),
-            Point::new(-k * rx, -ry),
-            Point::new(0.0, -ry),
-        ),
-        PathCmd::cubic_to(
-            Point::new(k * rx, -ry),
-            Point::new(rx, -k * ry),
-            Point::new(rx, 0.0),
-        ),
+        quarter(Point::new(0.0, ry)),
+        quarter(Point::new(-rx, 0.0)),
+        quarter(Point::new(0.0, -ry)),
+        quarter(Point::new(rx, 0.0)),
         PathCmd::close(),
     ]))
 }
@@ -95,13 +77,7 @@ pub type Corners = [bool; 4];
 pub const ALL_CORNERS: Corners = [true; 4];
 
 /// A centered rectangle with the selected corners rounded to `radius`.
-pub fn rounded_rect(
-    width: f64,
-    height: f64,
-    radius: f64,
-    corners: Corners,
-    arcs: bool,
-) -> Option<ContourBuf> {
+pub fn rounded_rect(width: f64, height: f64, radius: f64, corners: Corners) -> Option<ContourBuf> {
     if width <= 0.0 || height <= 0.0 {
         return None;
     }
@@ -112,7 +88,6 @@ pub fn rounded_rect(
         return rect(width, height);
     }
 
-    let k = KAPPA;
     let [upper_right, lower_right, lower_left, upper_left] = corners;
     let mut cmds = Vec::new();
 
@@ -126,19 +101,11 @@ pub fn rounded_rect(
         -hh,
     )));
     if lower_right {
-        if arcs {
-            cmds.push(PathCmd::arc_to(
-                Point::new(hw, -hh + r),
-                Point::new(hw - r, -hh + r),
-                false,
-            ));
-        } else {
-            cmds.push(PathCmd::cubic_to(
-                Point::new(hw - r + k * r, -hh),
-                Point::new(hw, -hh + r - k * r),
-                Point::new(hw, -hh + r),
-            ));
-        }
+        cmds.push(PathCmd::arc_to(
+            Point::new(hw, -hh + r),
+            Point::new(hw - r, -hh + r),
+            false,
+        ));
     }
 
     cmds.push(PathCmd::line_to(Point::new(
@@ -146,19 +113,11 @@ pub fn rounded_rect(
         hh - if upper_right { r } else { 0.0 },
     )));
     if upper_right {
-        if arcs {
-            cmds.push(PathCmd::arc_to(
-                Point::new(hw - r, hh),
-                Point::new(hw - r, hh - r),
-                false,
-            ));
-        } else {
-            cmds.push(PathCmd::cubic_to(
-                Point::new(hw, hh - r + k * r),
-                Point::new(hw - r + k * r, hh),
-                Point::new(hw - r, hh),
-            ));
-        }
+        cmds.push(PathCmd::arc_to(
+            Point::new(hw - r, hh),
+            Point::new(hw - r, hh - r),
+            false,
+        ));
     }
 
     cmds.push(PathCmd::line_to(Point::new(
@@ -166,19 +125,11 @@ pub fn rounded_rect(
         hh,
     )));
     if upper_left {
-        if arcs {
-            cmds.push(PathCmd::arc_to(
-                Point::new(-hw, hh - r),
-                Point::new(-hw + r, hh - r),
-                false,
-            ));
-        } else {
-            cmds.push(PathCmd::cubic_to(
-                Point::new(-hw + r - k * r, hh),
-                Point::new(-hw, hh - r + k * r),
-                Point::new(-hw, hh - r),
-            ));
-        }
+        cmds.push(PathCmd::arc_to(
+            Point::new(-hw, hh - r),
+            Point::new(-hw + r, hh - r),
+            false,
+        ));
     }
 
     cmds.push(PathCmd::line_to(Point::new(
@@ -186,19 +137,11 @@ pub fn rounded_rect(
         -hh + if lower_left { r } else { 0.0 },
     )));
     if lower_left {
-        if arcs {
-            cmds.push(PathCmd::arc_to(
-                Point::new(-hw + r, -hh),
-                Point::new(-hw + r, -hh + r),
-                false,
-            ));
-        } else {
-            cmds.push(PathCmd::cubic_to(
-                Point::new(-hw, -hh + r - k * r),
-                Point::new(-hw + r - k * r, -hh),
-                Point::new(-hw + r, -hh),
-            ));
-        }
+        cmds.push(PathCmd::arc_to(
+            Point::new(-hw + r, -hh),
+            Point::new(-hw + r, -hh + r),
+            false,
+        ));
     }
     cmds.push(PathCmd::close());
 
@@ -248,102 +191,8 @@ pub fn chamfered_rect(
 }
 
 /// A stadium/obround: a rectangle with full-radius caps on the short axis.
-pub fn obround(width: f64, height: f64, arcs: bool) -> Option<ContourBuf> {
-    if width <= 0.0 || height <= 0.0 {
-        return None;
-    }
-    if (width - height).abs() < f64::EPSILON {
-        return if arcs {
-            circle(width)
-        } else {
-            ellipse(width, height)
-        };
-    }
-
-    let k = KAPPA;
-    let cmds = if width > height {
-        let r = height / 2.0;
-        let a = (width - height) / 2.0;
-        if arcs {
-            vec![
-                PathCmd::move_to(Point::new(-a, -r)),
-                PathCmd::line_to(Point::new(a, -r)),
-                PathCmd::arc_to(Point::new(a, r), Point::new(a, 0.0), false),
-                PathCmd::line_to(Point::new(-a, r)),
-                PathCmd::arc_to(Point::new(-a, -r), Point::new(-a, 0.0), false),
-                PathCmd::close(),
-            ]
-        } else {
-            vec![
-                PathCmd::move_to(Point::new(a, -r)),
-                PathCmd::line_to(Point::new(-a, -r)),
-                PathCmd::cubic_to(
-                    Point::new(-a - k * r, -r),
-                    Point::new(-a - r, -k * r),
-                    Point::new(-a - r, 0.0),
-                ),
-                PathCmd::cubic_to(
-                    Point::new(-a - r, k * r),
-                    Point::new(-a - k * r, r),
-                    Point::new(-a, r),
-                ),
-                PathCmd::line_to(Point::new(a, r)),
-                PathCmd::cubic_to(
-                    Point::new(a + k * r, r),
-                    Point::new(a + r, k * r),
-                    Point::new(a + r, 0.0),
-                ),
-                PathCmd::cubic_to(
-                    Point::new(a + r, -k * r),
-                    Point::new(a + k * r, -r),
-                    Point::new(a, -r),
-                ),
-                PathCmd::close(),
-            ]
-        }
-    } else {
-        let r = width / 2.0;
-        let a = (height - width) / 2.0;
-        if arcs {
-            vec![
-                PathCmd::move_to(Point::new(r, -a)),
-                PathCmd::line_to(Point::new(r, a)),
-                PathCmd::arc_to(Point::new(-r, a), Point::new(0.0, a), false),
-                PathCmd::line_to(Point::new(-r, -a)),
-                PathCmd::arc_to(Point::new(r, -a), Point::new(0.0, -a), false),
-                PathCmd::close(),
-            ]
-        } else {
-            vec![
-                PathCmd::move_to(Point::new(r, -a)),
-                PathCmd::line_to(Point::new(r, a)),
-                PathCmd::cubic_to(
-                    Point::new(r, a + k * r),
-                    Point::new(k * r, a + r),
-                    Point::new(0.0, a + r),
-                ),
-                PathCmd::cubic_to(
-                    Point::new(-k * r, a + r),
-                    Point::new(-r, a + k * r),
-                    Point::new(-r, a),
-                ),
-                PathCmd::line_to(Point::new(-r, -a)),
-                PathCmd::cubic_to(
-                    Point::new(-r, -a - k * r),
-                    Point::new(-k * r, -a - r),
-                    Point::new(0.0, -a - r),
-                ),
-                PathCmd::cubic_to(
-                    Point::new(k * r, -a - r),
-                    Point::new(r, -a - k * r),
-                    Point::new(r, -a),
-                ),
-                PathCmd::close(),
-            ]
-        }
-    };
-
-    Some(ContourBuf::new(cmds))
+pub fn obround(width: f64, height: f64) -> Option<ContourBuf> {
+    rounded_rect(width, height, width.min(height) / 2.0, ALL_CORNERS)
 }
 
 /// A regular polygon inscribed in a circle of `outer_diameter`, with the
@@ -440,7 +289,6 @@ pub fn closed_polygon(points: Vec<Point>) -> Option<ContourBuf> {
 mod tests {
     use super::*;
     use crate::geom::affine::Affine2;
-    use crate::geom::path::transform_cmds;
     use crate::geom::point::Mirror;
 
     #[test]
@@ -460,25 +308,10 @@ mod tests {
 
     #[test]
     fn rounded_rect_with_zero_radius_is_a_rect() {
-        let rounded = rounded_rect(4.0, 2.0, 0.0, ALL_CORNERS, true).unwrap();
+        let rounded = rounded_rect(4.0, 2.0, 0.0, ALL_CORNERS).unwrap();
         let plain = rect(4.0, 2.0).unwrap();
 
         assert_eq!(rounded.cmds, plain.cmds);
-    }
-
-    #[test]
-    fn obround_arcs_and_cubics_agree_on_bounds() {
-        let arcs = obround(5.0, 2.0, true).unwrap();
-        let cubics = obround(5.0, 2.0, false).unwrap();
-
-        for (a, c) in [
-            (arcs.bbox.min.x, cubics.bbox.min.x),
-            (arcs.bbox.min.y, cubics.bbox.min.y),
-            (arcs.bbox.max.x, cubics.bbox.max.x),
-            (arcs.bbox.max.y, cubics.bbox.max.y),
-        ] {
-            assert!((a - c).abs() <= 1e-9, "expected {a} to be close to {c}");
-        }
     }
 
     #[test]
@@ -486,7 +319,7 @@ mod tests {
         let contour = circle(2.0).unwrap();
         let transform = Affine2::placement(Point::new(10.0, 5.0), 0.0, Mirror::NONE, 1.0);
 
-        let placed = transform_cmds(contour.cmds, transform);
+        let placed = contour.transformed(transform);
 
         assert!((placed.bbox.min.x - 9.0).abs() <= 1e-9);
         assert!((placed.bbox.max.y - 6.0).abs() <= 1e-9);

--- a/crates/pcb-ir/src/geom/store.rs
+++ b/crates/pcb-ir/src/geom/store.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 
 use crate::geom::affine::Affine2;
 use crate::geom::bbox::BBox;
-use crate::geom::path::{ContourBuf, PathCmd, contour_bbox, transform_cmds, validate_cmd_points};
+use crate::geom::path::{ContourBuf, PathCmd, contour_bbox, validate_cmd_points};
 use crate::geom::style::{FillRule, Paint, StrokeStyle};
 
 /// A half-open range of `u32` indices into one of a document's flat arenas.
@@ -88,6 +88,7 @@ impl Span {
 pub struct Contour {
     pub cmds: Span,
     pub bbox: BBox,
+    pub uncertainty_mm: f64,
 }
 
 /// A styled path: how a contour span is painted.
@@ -191,6 +192,7 @@ impl PathArena {
         self.contours.push(Contour {
             cmds: Span::new(cmd_start, self.cmds.len() as u32 - cmd_start),
             bbox: contour.bbox,
+            uncertainty_mm: contour.uncertainty_mm,
         });
         id
     }
@@ -211,7 +213,11 @@ impl PathArena {
     pub fn contour_bufs(&self, span: Span) -> Vec<ContourBuf> {
         self.contours(span)
             .iter()
-            .map(|contour| ContourBuf::from_parts(contour.bbox, self.cmds(*contour).to_vec()))
+            .map(|contour| ContourBuf {
+                bbox: contour.bbox,
+                cmds: self.cmds(*contour).to_vec(),
+                uncertainty_mm: contour.uncertainty_mm,
+            })
             .collect()
     }
 
@@ -220,11 +226,11 @@ impl PathArena {
         self.contour_bufs(path.contours)
     }
 
-    /// Detach a contour span, transformed.
+    /// Detach a contour span, transformed exactly.
     pub fn transformed_contour_bufs(&self, span: Span, transform: Affine2) -> Vec<ContourBuf> {
-        self.contours(span)
-            .iter()
-            .map(|contour| transform_cmds(self.cmds(*contour).iter().copied(), transform))
+        self.contour_bufs(span)
+            .into_iter()
+            .map(|contour| contour.transformed(transform))
             .collect()
     }
 
@@ -237,9 +243,7 @@ impl PathArena {
 
     /// Union of contour bounds over a transformed contour span.
     pub fn transformed_contours_bbox(&self, span: Span, transform: Affine2) -> BBox {
-        self.transformed_contour_bufs(span, transform)
-            .iter()
-            .fold(BBox::empty(), |bbox, contour| bbox.union(contour.bbox))
+        self.contours_bbox(span).transformed(transform)
     }
 
     /// Union of path bounds over a path span.
@@ -253,11 +257,7 @@ impl PathArena {
     /// transformed. Returns the new path index.
     pub fn append_path_from(&mut self, other: &PathArena, path: u32, transform: Affine2) -> u32 {
         let source = other.paths[path as usize];
-        let contours = if transform.is_identity() {
-            other.path_contours(&source)
-        } else {
-            other.transformed_contour_bufs(source.contours, transform)
-        };
+        let contours = other.transformed_contour_bufs(source.contours, transform);
         self.push_path(source.paint, contours)
     }
 
@@ -297,6 +297,7 @@ impl PathArena {
                 contours.push(Contour {
                     cmds: Span::new(cmd_start, cmds.len() as u32 - cmd_start),
                     bbox: contour.bbox,
+                    uncertainty_mm: contour.uncertainty_mm,
                 });
             }
             mapping[index] = Some(paths.len() as u32);

--- a/crates/pcb-ir/src/geom/tol.rs
+++ b/crates/pcb-ir/src/geom/tol.rs
@@ -1,22 +1,14 @@
 //! Canonical geometric tolerances.
 //!
 //! All pcb-ir geometry is in millimeters; these constants document the
-//! precision assumptions shared by flattening, boolean composition, and
-//! validation. Pass an explicit tolerance where one is semantic (region
-//! significance, relief construction); use these as the defaults.
+//! coincidence and source validation thresholds. Numerical approximation
+//! uses GeometryAccuracy.
 
 /// Coincidence threshold for points and angles.
 pub const EPSILON_MM: f64 = 1e-9;
 
-/// Chord tolerance when flattening curves to polygon rings for boolean
-/// composition.
-pub const FLATTEN_MM: f64 = 0.005;
-
-/// Chord tolerance for stroke-outline expansion.
-pub const STROKE_OUTLINE_MM: f64 = 0.01;
-
 /// Default minimum significant feature size for regularized regions;
-/// contours whose area is below `REGION_MM²` are discarded.
+/// used for feature significance and containment slack.
 pub const REGION_MM: f64 = 0.001;
 
 /// Absolute slack when checking that arc start/end radii describe the same

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -1887,7 +1887,7 @@ fn validate_copper_balance_void_shape(
     let resolution = Resolution::default().with_tolerance(1e-5);
     let actual = ContourSet::from_contours(&[outline], fill_rule, resolution)?;
     let expected = ContourSet::from_contours(&[expected], FillRule::NonZero, resolution)?;
-    let mismatch = actual.difference(&expected).area() + expected.difference(&actual).area();
+    let mismatch = actual.difference(&expected)?.area() + expected.difference(&actual)?.area();
     if mismatch > 1e-5 {
         bail!(
             "copper-balance void contour disagrees with its rounded-hex metadata by {mismatch} mm^2"

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -1,3 +1,4 @@
+use crate::geom::Resolution;
 use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Context, Result, bail};
@@ -11,7 +12,6 @@ use ipc2581::{Interner, Ipc2581, Symbol};
 
 use crate::dialects::ipc::*;
 use crate::geom::Polarity as GeometryPolarity;
-use crate::geom::path::transform_cmds;
 use crate::geom::*;
 use crate::import::physical::{feature_definitely_spans_layer, physical_stackup_layers};
 
@@ -1153,17 +1153,27 @@ impl ImportedDesign {
         }
     }
 
-    pub fn feature_region(&self, occurrence: FeatureOccurrence) -> ContourSet {
-        let feature = &self.geometry.features[occurrence.id.feature.0 as usize];
-        ContourSet::from_placed_painted_paths(
+    /// Prepare this occurrence from the retained source curves. Any earlier
+    /// approximation in those curves remains part of the total budget.
+    pub fn feature_region(
+        &self,
+        occurrence: FeatureOccurrence,
+        resolution: Resolution,
+    ) -> Result<ContourSet> {
+        let feature = self
+            .geometry
+            .features
+            .get(occurrence.id.feature.0 as usize)
+            .context("feature occurrence is outside the imported design")?;
+        Ok(ContourSet::from_placed_painted_paths(
             &self.geometry.arena,
             feature
                 .paths
                 .slice(&self.geometry.arena.paths)
                 .iter()
                 .map(|path| (path, occurrence.root_from_local)),
-            tol::REGION_MM,
-        )
+            resolution,
+        )?)
     }
 
     pub fn component_occurrences(&self, scope: ArtworkScope) -> Result<Vec<ComponentOccurrence>> {
@@ -1261,11 +1271,9 @@ impl ImportedDesign {
         let mut copied_paths = HashMap::new();
         let mut copy_path = |source: u32, target: &mut GeometryDocument| {
             *copied_paths.entry(source).or_insert_with(|| {
-                let copied = target.arena.paths.len() as u32;
                 target
                     .arena
-                    .append_path_from(&self.geometry.arena, source, Affine2::IDENTITY);
-                copied
+                    .append_path_from(&self.geometry.arena, source, Affine2::IDENTITY)
             })
         };
 
@@ -1322,25 +1330,23 @@ impl ImportedDesign {
         target.layout.root_step = Some(0);
     }
 
-    pub fn composed_layer_image(&self, layer: LayerId, scope: ArtworkScope) -> Result<ContourSet> {
+    /// The final painted image of one layer, prepared at `resolution`.
+    pub fn composed_layer_image(
+        &self,
+        layer: LayerId,
+        scope: ArtworkScope,
+        resolution: Resolution,
+    ) -> Result<ContourSet> {
         let definition = self
             .layer_definitions
             .get(layer.0 as usize)
             .context("layer id is outside the imported design")?;
-        let mut document = self.materialize_layer(layer, scope)?;
-        crate::dialects::ipc::process::normalize_for_artwork(&mut document);
-        crate::dialects::ipc::validate_artwork_ready(&document).map_err(anyhow::Error::msg)?;
-        let artwork = crate::dialects::ipc::lower_layer_to_artwork(
-            &document,
+        self.materialize_layer(layer, scope)?.into_layer_image(
             0,
             layer_role(definition.layer_function),
             side_for_layer(definition.side),
-        );
-        let (mut images, _) = crate::dialects::artwork::compose_attributed(&artwork, |_| ());
-        Ok(images.pop().map_or_else(
-            || ContourSet::empty(tol::REGION_MM),
-            |image| ContourSet::new(image.image, FillRule::NonZero, tol::REGION_MM),
-        ))
+            resolution,
+        )
     }
 
     fn step_occurrences(&self, scope: ArtworkScope) -> Result<Vec<StepOccurrence>> {
@@ -1704,6 +1710,7 @@ pub fn extract_step_layer_local(
     Ok(doc)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn extract_set_feature(
     context: &ExtractContext<'_>,
     layer_ref: Symbol,
@@ -1765,6 +1772,7 @@ fn extract_set_feature(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn extract_feature_placement_group(
     context: &ExtractContext<'_>,
     layer_ref: Symbol,
@@ -1876,8 +1884,9 @@ fn validate_copper_balance_void_shape(
     let expected =
         crate::geom::shapes::rounded_hexagon(metadata.radius_mm, metadata.corner_radius_mm, 0.0)
             .context("copper-balance rounded-hex dimensions are invalid")?;
-    let actual = ContourSet::from_contours(&[outline], fill_rule, 1e-5);
-    let expected = ContourSet::from_contours(&[expected], FillRule::NonZero, 1e-5);
+    let resolution = Resolution::default().with_tolerance(1e-5);
+    let actual = ContourSet::from_contours(&[outline], fill_rule, resolution)?;
+    let expected = ContourSet::from_contours(&[expected], FillRule::NonZero, resolution)?;
     let mismatch = actual.difference(&expected).area() + expected.difference(&actual).area();
     if mismatch > 1e-5 {
         bail!(
@@ -1918,6 +1927,7 @@ fn append_span<T: Clone>(target: &mut Vec<T>, source: &[T], span: Span) -> Span 
     Span::new(start, span.count)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn append_transformed_layer(
     target: &mut GeometryDocument,
     source: &GeometryDocument,
@@ -2326,6 +2336,7 @@ fn slot_applies_to_layer<'a>(
     ))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn extract_pad(
     context: &ExtractContext<'_>,
     layer_ref: Symbol,
@@ -2469,6 +2480,7 @@ enum FeaturePrimitiveKind {
     User,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn extract_feature_primitive(
     context: &ExtractContext<'_>,
     net: Option<Symbol>,
@@ -2843,7 +2855,12 @@ fn extract_polygon(
     doc: &mut GeometryDocument,
 ) -> GeometryFeature {
     let path_start = doc.arena.paths.len() as u32;
-    push_polygon_path(doc, polygon, Affine2::identity(), FillRule::NonZero);
+    doc.push_path(
+        Paint::Fill {
+            rule: FillRule::NonZero,
+        },
+        [polygon_contour(polygon)],
+    );
     let paths = Span::new(path_start, doc.arena.paths.len() as u32 - path_start);
 
     let mut feature = GeometryFeature::new(FeatureKind::Polygon, polarity);
@@ -2889,7 +2906,7 @@ fn append_step_profile(doc: &mut GeometryDocument, step: &Step) -> ProfileRange 
 }
 
 fn push_profile_polygon(doc: &mut GeometryDocument, polygon: &ipc2581::types::Polygon) -> u32 {
-    let contour = polygon_contour(polygon, Affine2::identity());
+    let contour = polygon_contour(polygon);
     doc.push_path(Paint::None, [contour])
 }
 
@@ -2986,29 +3003,10 @@ fn push_stroked_steps(
     begin: Point,
     steps: &[PolyStep],
 ) -> GeometryFeature {
-    let mut current = begin;
-    let mut bbox = BBox::from_point(current);
-    let mut cmds = vec![PathCmd::move_to(current)];
-    for step in steps {
-        match step {
-            PolyStep::Segment(segment) => {
-                current = Point::new(segment.point.x, segment.point.y);
-                bbox.include_point(current);
-                cmds.push(PathCmd::line_to(current));
-            }
-            PolyStep::Curve(curve) => {
-                let end = Point::new(curve.point.x, curve.point.y);
-                let center = Point::new(curve.center.x, curve.center.y);
-                bbox = bbox.union(Arc::new(current, end, center, curve.clockwise).bbox());
-                cmds.push(PathCmd::arc_to(end, center, curve.clockwise));
-                current = end;
-            }
-        }
-    }
-
+    let contour = ContourBuf::new(poly_step_commands(begin, steps));
+    let bbox = contour.bbox.expand(style.width / 2.0);
     let path_start = doc.arena.paths.len() as u32;
-    doc.push_path(stroked_paint(style), [ContourBuf::from_parts(bbox, cmds)]);
-    bbox = bbox.expand(style.width / 2.0);
+    doc.push_path(stroked_paint(style), [contour]);
 
     let mut feature = GeometryFeature::new(FeatureKind::Trace, style.polarity);
     feature.net = style.net;
@@ -3036,12 +3034,16 @@ fn extract_hole(
     let placement = ipc_placement(Point::new(hole.x, hole.y), hole.xform);
     let path_start = doc.arena.paths.len() as u32;
     match hole.shape {
-        IpcHoleShape::Circle => {
-            push_ellipse_path(doc, placement.transform, hole.diameter, hole.diameter)
-        }
-        IpcHoleShape::Square => {
-            push_rect_path(doc, placement.transform, hole.diameter, hole.diameter)
-        }
+        IpcHoleShape::Circle => push_filled_shape(
+            doc,
+            placement.transform,
+            shapes::ellipse(hole.diameter, hole.diameter),
+        ),
+        IpcHoleShape::Square => push_filled_shape(
+            doc,
+            placement.transform,
+            shapes::rect(hole.diameter, hole.diameter),
+        ),
     }
     let paths = Span::new(path_start, doc.arena.paths.len() as u32 - path_start);
 
@@ -3119,30 +3121,31 @@ fn lower_standard_primitive(
     let path_start = doc.arena.paths.len() as u32;
     match primitive {
         StandardPrimitive::Circle(circle) => {
-            push_ellipse_path(doc, transform, circle.shape.diameter, circle.shape.diameter);
-        }
-        StandardPrimitive::Ellipse(ellipse) => {
-            push_ellipse_path(
+            push_filled_shape(
                 doc,
                 transform,
-                ellipse.shape.size.width,
-                ellipse.shape.size.height,
+                shapes::ellipse(circle.shape.diameter, circle.shape.diameter),
+            );
+        }
+        StandardPrimitive::Ellipse(ellipse) => {
+            push_filled_shape(
+                doc,
+                transform,
+                shapes::ellipse(ellipse.shape.size.width, ellipse.shape.size.height),
             );
         }
         StandardPrimitive::Oval(oval) => {
-            push_oval_path(
+            push_filled_shape(
                 doc,
                 transform,
-                oval.shape.size.width,
-                oval.shape.size.height,
+                shapes::obround(oval.shape.size.width, oval.shape.size.height),
             );
         }
         StandardPrimitive::RectCenter(rect) => {
-            push_rect_path(
+            push_filled_shape(
                 doc,
                 transform,
-                rect.shape.size.width,
-                rect.shape.size.height,
+                shapes::rect(rect.shape.size.width, rect.shape.size.height),
             );
         }
         StandardPrimitive::RectCorner(rect) => {
@@ -3152,41 +3155,47 @@ fn lower_standard_primitive(
                 Point::new(rect.shape.upper_right.x, rect.shape.upper_right.y),
                 Point::new(rect.shape.lower_left.x, rect.shape.upper_right.y),
             ];
-            push_closed_points_path(doc, transform, points, FillRule::NonZero);
+            push_filled_shape(doc, transform, shapes::closed_polygon(points));
         }
         StandardPrimitive::Diamond(diamond) => {
             let hw = diamond.shape.size.width / 2.0;
             let hh = diamond.shape.size.height / 2.0;
-            push_closed_points_path(
+            push_filled_shape(
                 doc,
                 transform,
-                vec![
+                shapes::closed_polygon(vec![
                     Point::new(0.0, -hh),
                     Point::new(hw, 0.0),
                     Point::new(0.0, hh),
                     Point::new(-hw, 0.0),
-                ],
-                FillRule::NonZero,
+                ]),
             );
         }
         StandardPrimitive::Hexagon(hexagon) => {
-            push_regular_polygon_path(doc, transform, 6, hexagon.shape.point_to_point / 2.0);
+            push_filled_shape(
+                doc,
+                transform,
+                shapes::regular_polygon(2.0 * (hexagon.shape.point_to_point / 2.0), 6, -90.0),
+            );
         }
         StandardPrimitive::Octagon(octagon) => {
-            push_regular_polygon_path(doc, transform, 8, octagon.shape.point_to_point / 2.0);
+            push_filled_shape(
+                doc,
+                transform,
+                shapes::regular_polygon(2.0 * (octagon.shape.point_to_point / 2.0), 8, -90.0),
+            );
         }
         StandardPrimitive::Triangle(triangle) => {
             let hw = triangle.shape.base / 2.0;
             let hh = triangle.shape.height / 2.0;
-            push_closed_points_path(
+            push_filled_shape(
                 doc,
                 transform,
-                vec![
+                shapes::closed_polygon(vec![
                     Point::new(0.0, -hh),
                     Point::new(hw, hh),
                     Point::new(-hw, hh),
-                ],
-                FillRule::NonZero,
+                ]),
             );
         }
         StandardPrimitive::Donut(donut) => {
@@ -3217,33 +3226,37 @@ fn lower_standard_primitive(
             push_contour_path(doc, contour, transform);
         }
         StandardPrimitive::RectRound(rect) => {
-            push_rounded_rect_path(
+            push_filled_shape(
                 doc,
                 transform,
-                rect.shape.size.width,
-                rect.shape.size.height,
-                rect.shape.radius,
-                [
-                    rect.shape.upper_right,
-                    rect.shape.lower_right,
-                    rect.shape.lower_left,
-                    rect.shape.upper_left,
-                ],
+                shapes::rounded_rect(
+                    rect.shape.size.width,
+                    rect.shape.size.height,
+                    rect.shape.radius,
+                    [
+                        rect.shape.upper_right,
+                        rect.shape.lower_right,
+                        rect.shape.lower_left,
+                        rect.shape.upper_left,
+                    ],
+                ),
             );
         }
         StandardPrimitive::RectCham(rect) => {
-            push_chamfered_rect_path(
+            push_filled_shape(
                 doc,
                 transform,
-                rect.shape.size.width,
-                rect.shape.size.height,
-                rect.shape.chamfer,
-                [
-                    rect.shape.upper_right,
-                    rect.shape.lower_right,
-                    rect.shape.lower_left,
-                    rect.shape.upper_left,
-                ],
+                shapes::chamfered_rect(
+                    rect.shape.size.width,
+                    rect.shape.size.height,
+                    rect.shape.chamfer,
+                    [
+                        rect.shape.upper_right,
+                        rect.shape.lower_right,
+                        rect.shape.lower_left,
+                        rect.shape.upper_left,
+                    ],
+                ),
             );
         }
         StandardPrimitive::Butterfly(butterfly) => {
@@ -3343,27 +3356,41 @@ fn lower_user_primitive(
                 let mut nested_paint = None;
                 match &shape.shape {
                     UserShapeType::Circle(circle) => {
-                        push_ellipse_path(doc, transform, circle.diameter, circle.diameter);
-                    }
-                    UserShapeType::RectCenter(rect) => {
-                        push_rect_path(doc, transform, rect.size.width, rect.size.height);
-                    }
-                    UserShapeType::Oval(oval) => {
-                        push_oval_path(doc, transform, oval.size.width, oval.size.height);
-                    }
-                    UserShapeType::RectRound(rect) => {
-                        push_rounded_rect_path(
+                        push_filled_shape(
                             doc,
                             transform,
-                            rect.size.width,
-                            rect.size.height,
-                            rect.radius,
-                            [
-                                rect.upper_right,
-                                rect.lower_right,
-                                rect.lower_left,
-                                rect.upper_left,
-                            ],
+                            shapes::ellipse(circle.diameter, circle.diameter),
+                        );
+                    }
+                    UserShapeType::RectCenter(rect) => {
+                        push_filled_shape(
+                            doc,
+                            transform,
+                            shapes::rect(rect.size.width, rect.size.height),
+                        );
+                    }
+                    UserShapeType::Oval(oval) => {
+                        push_filled_shape(
+                            doc,
+                            transform,
+                            shapes::obround(oval.size.width, oval.size.height),
+                        );
+                    }
+                    UserShapeType::RectRound(rect) => {
+                        push_filled_shape(
+                            doc,
+                            transform,
+                            shapes::rounded_rect(
+                                rect.size.width,
+                                rect.size.height,
+                                rect.radius,
+                                [
+                                    rect.upper_right,
+                                    rect.lower_right,
+                                    rect.lower_left,
+                                    rect.upper_left,
+                                ],
+                            ),
                         );
                     }
                     UserShapeType::Polygon(polygon) => {
@@ -3374,15 +3401,43 @@ fn lower_user_primitive(
                     }
                     UserShapeType::Line(line) => {
                         let line_desc = user_shape_line_desc(context, shape);
-                        push_user_line_path(doc, line, transform, line_desc);
+                        push_user_stroke(
+                            doc,
+                            ContourBuf::new(vec![
+                                PathCmd::move_to(Point::new(line.start.x, line.start.y)),
+                                PathCmd::line_to(Point::new(line.end.x, line.end.y)),
+                            ]),
+                            transform,
+                            line_desc,
+                        );
                     }
                     UserShapeType::Arc(arc) => {
                         let line_desc = user_shape_line_desc(context, shape);
-                        push_user_arc_path(doc, arc, transform, line_desc);
+                        push_user_stroke(
+                            doc,
+                            ContourBuf::new(vec![
+                                PathCmd::move_to(Point::new(arc.start.x, arc.start.y)),
+                                PathCmd::arc_to(
+                                    Point::new(arc.end.x, arc.end.y),
+                                    Point::new(arc.center.x, arc.center.y),
+                                    arc.clockwise,
+                                ),
+                            ]),
+                            transform,
+                            line_desc,
+                        );
                     }
                     UserShapeType::Polyline(polyline) => {
                         let line_desc = user_shape_line_desc(context, shape);
-                        push_user_polyline_path(doc, polyline, transform, line_desc);
+                        push_user_stroke(
+                            doc,
+                            ContourBuf::new(poly_step_commands(
+                                Point::new(polyline.begin.x, polyline.begin.y),
+                                &polyline.steps,
+                            )),
+                            transform,
+                            line_desc,
+                        );
                     }
                     UserShapeType::UserPrimitiveRef(primitive_ref) => {
                         if let Some(primitive) = context.user_primitives.get(primitive_ref).copied()
@@ -3451,7 +3506,9 @@ fn user_shape_is_filled_contour(shape: &ipc2581::types::UserShape) -> bool {
 
 fn push_user_shape_contours(out: &mut Vec<ContourBuf>, shape: &UserShapeType, transform: Affine2) {
     match shape {
-        UserShapeType::Polygon(polygon) => out.push(polygon_contour(polygon, transform)),
+        UserShapeType::Polygon(polygon) => {
+            out.push(polygon_contour(polygon).transformed(transform))
+        }
         UserShapeType::Contour(contour) => push_contour_payloads(out, contour, transform),
         _ => {}
     }
@@ -3480,110 +3537,18 @@ fn user_shape_line_desc(
     })
 }
 
-fn push_user_line_path(
+fn push_user_stroke(
     doc: &mut GeometryDocument,
-    line: &ipc2581::types::primitives::Line,
+    contour: ContourBuf,
     transform: Affine2,
     line_desc: Option<ipc2581::types::LineDesc>,
 ) {
-    let start = transform.transform_point(Point::new(line.start.x, line.start.y));
-    let end = transform.transform_point(Point::new(line.end.x, line.end.y));
-    let width = line_desc.map(|desc| desc.line_width).unwrap_or(0.25);
-    let line_cap = line_desc
-        .map(|desc| map_line_cap(desc.line_end))
-        .unwrap_or(LineCap::Round);
-    let line_pattern = map_line_pattern(line_desc.and_then(|desc| desc.line_property));
-    let bbox = BBox::from_point(start).union(BBox::from_point(end));
-    let mut stroke = StrokeStyle::new(width, line_cap);
-    stroke.pattern = line_pattern;
-    doc.push_path(
-        Paint::Stroke(stroke),
-        [ContourBuf::from_parts(
-            bbox,
-            vec![PathCmd::move_to(start), PathCmd::line_to(end)],
-        )],
+    let mut stroke = StrokeStyle::new(
+        line_desc.map_or(0.25, |desc| desc.line_width),
+        line_desc.map_or(LineCap::Round, |desc| map_line_cap(desc.line_end)),
     );
-}
-
-fn push_user_arc_path(
-    doc: &mut GeometryDocument,
-    arc: &ipc2581::types::Arc,
-    transform: Affine2,
-    line_desc: Option<ipc2581::types::LineDesc>,
-) {
-    let start = transform.transform_point(Point::new(arc.start.x, arc.start.y));
-    let end = transform.transform_point(Point::new(arc.end.x, arc.end.y));
-    let center = transform.transform_point(Point::new(arc.center.x, arc.center.y));
-    let clockwise = if transform.determinant() < 0.0 {
-        !arc.clockwise
-    } else {
-        arc.clockwise
-    };
-    let width = line_desc.map(|desc| desc.line_width).unwrap_or(0.25);
-    let line_cap = line_desc
-        .map(|desc| map_line_cap(desc.line_end))
-        .unwrap_or(LineCap::Round);
-    let line_pattern = map_line_pattern(line_desc.and_then(|desc| desc.line_property));
-    let bbox = Arc::new(start, end, center, clockwise).bbox();
-    let mut stroke = StrokeStyle::new(width, line_cap);
-    stroke.pattern = line_pattern;
-    doc.push_path(
-        Paint::Stroke(stroke),
-        [ContourBuf::from_parts(
-            bbox,
-            vec![
-                PathCmd::move_to(start),
-                PathCmd::arc_to(end, center, clockwise),
-            ],
-        )],
-    );
-}
-
-fn push_user_polyline_path(
-    doc: &mut GeometryDocument,
-    polyline: &ipc2581::types::Polyline,
-    transform: Affine2,
-    line_desc: Option<ipc2581::types::LineDesc>,
-) {
-    let width = line_desc.map(|desc| desc.line_width).unwrap_or(0.25);
-    let line_cap = line_desc
-        .map(|desc| map_line_cap(desc.line_end))
-        .unwrap_or(LineCap::Round);
-    let line_pattern = map_line_pattern(line_desc.and_then(|desc| desc.line_property));
-    let mut current = Point::new(polyline.begin.x, polyline.begin.y);
-    let start = transform.transform_point(current);
-    let mut bbox = BBox::from_point(start);
-    let mut cmds = vec![PathCmd::move_to(start)];
-
-    for step in &polyline.steps {
-        match step {
-            PolyStep::Segment(segment) => {
-                current = Point::new(segment.point.x, segment.point.y);
-                let point = transform.transform_point(current);
-                bbox.include_point(point);
-                cmds.push(PathCmd::line_to(point));
-            }
-            PolyStep::Curve(curve) => {
-                let end = Point::new(curve.point.x, curve.point.y);
-                let center = Point::new(curve.center.x, curve.center.y);
-                let start = transform.transform_point(current);
-                let end = transform.transform_point(end);
-                let center = transform.transform_point(center);
-                let clockwise = if transform.determinant() < 0.0 {
-                    !curve.clockwise
-                } else {
-                    curve.clockwise
-                };
-                bbox = bbox.union(Arc::new(start, end, center, clockwise).bbox());
-                cmds.push(PathCmd::arc_to(end, center, clockwise));
-                current = Point::new(curve.point.x, curve.point.y);
-            }
-        }
-    }
-
-    let mut stroke = StrokeStyle::new(width, line_cap);
-    stroke.pattern = line_pattern;
-    doc.push_path(Paint::Stroke(stroke), [ContourBuf::from_parts(bbox, cmds)]);
+    stroke.pattern = map_line_pattern(line_desc.and_then(|desc| desc.line_property));
+    doc.push_path(Paint::Stroke(stroke), [contour.transformed(transform)]);
 }
 
 fn push_polygon_path(
@@ -3592,7 +3557,7 @@ fn push_polygon_path(
     transform: Affine2,
     fill_rule: FillRule,
 ) {
-    let contour = polygon_contour(polygon, transform);
+    let contour = polygon_contour(polygon).transformed(transform);
     doc.push_path(Paint::Fill { rule: fill_rule }, [contour]);
 }
 
@@ -3691,40 +3656,25 @@ fn make_paths_unpainted(doc: &mut GeometryDocument, path_start: u32) {
     }
 }
 
-fn polygon_contour(polygon: &ipc2581::types::Polygon, transform: Affine2) -> ContourBuf {
-    let mut cmds = Vec::new();
-    let mut current = Point::new(polygon.begin.x, polygon.begin.y);
-    let start = transform.transform_point(current);
-    let mut bbox = BBox::from_point(start);
-    cmds.push(PathCmd::move_to(start));
-
-    for step in &polygon.steps {
-        match step {
+fn poly_step_commands(begin: Point, steps: &[PolyStep]) -> Vec<PathCmd> {
+    std::iter::once(PathCmd::move_to(begin))
+        .chain(steps.iter().map(|step| match step {
             PolyStep::Segment(segment) => {
-                current = Point::new(segment.point.x, segment.point.y);
-                let p = transform.transform_point(current);
-                bbox.include_point(p);
-                cmds.push(PathCmd::line_to(p));
+                PathCmd::line_to(Point::new(segment.point.x, segment.point.y))
             }
-            PolyStep::Curve(curve) => {
-                let end = Point::new(curve.point.x, curve.point.y);
-                let center = Point::new(curve.center.x, curve.center.y);
-                let start = transform.transform_point(current);
-                let end = transform.transform_point(end);
-                let center = transform.transform_point(center);
-                let clockwise = if transform.determinant() < 0.0 {
-                    !curve.clockwise
-                } else {
-                    curve.clockwise
-                };
-                bbox = bbox.union(Arc::new(start, end, center, clockwise).bbox());
-                cmds.push(PathCmd::arc_to(end, center, clockwise));
-                current = Point::new(curve.point.x, curve.point.y);
-            }
-        }
-    }
+            PolyStep::Curve(curve) => PathCmd::arc_to(
+                Point::new(curve.point.x, curve.point.y),
+                Point::new(curve.center.x, curve.center.y),
+                curve.clockwise,
+            ),
+        }))
+        .collect()
+}
+
+fn polygon_contour(polygon: &ipc2581::types::Polygon) -> ContourBuf {
+    let mut cmds = poly_step_commands(Point::new(polygon.begin.x, polygon.begin.y), &polygon.steps);
     cmds.push(PathCmd::close());
-    ContourBuf::from_parts(bbox, cmds)
+    ContourBuf::new(cmds)
 }
 
 fn push_contour_path(
@@ -3748,402 +3698,28 @@ fn push_contour_payloads(
     transform: Affine2,
 ) {
     out.reserve(1 + contour.cutouts.len());
-    out.push(polygon_contour(&contour.polygon, transform));
+    out.push(polygon_contour(&contour.polygon).transformed(transform));
     for cutout in &contour.cutouts {
-        out.push(polygon_contour(cutout, transform));
+        out.push(polygon_contour(cutout).transformed(transform));
     }
 }
 
-fn push_closed_points_path(
-    doc: &mut GeometryDocument,
-    transform: Affine2,
-    points: Vec<Point>,
-    fill_rule: FillRule,
-) {
-    if points.is_empty() {
-        return;
+fn push_filled_shape(doc: &mut GeometryDocument, transform: Affine2, contour: Option<ContourBuf>) {
+    if let Some(contour) = contour {
+        doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            [contour.transformed(transform)],
+        );
     }
-    let mut bbox = BBox::empty();
-    let mut cmds = Vec::with_capacity(points.len() + 1);
-    for (index, point) in points.into_iter().enumerate() {
-        let p = transform.transform_point(point);
-        bbox.include_point(p);
-        cmds.push(if index == 0 {
-            PathCmd::move_to(p)
-        } else {
-            PathCmd::line_to(p)
-        });
-    }
-    cmds.push(PathCmd::close());
-    doc.push_path(
-        Paint::Fill { rule: fill_rule },
-        [ContourBuf::from_parts(bbox, cmds)],
-    );
-}
-
-fn push_rect_path(doc: &mut GeometryDocument, transform: Affine2, width: f64, height: f64) {
-    let hw = width / 2.0;
-    let hh = height / 2.0;
-    push_closed_points_path(
-        doc,
-        transform,
-        vec![
-            Point::new(-hw, -hh),
-            Point::new(hw, -hh),
-            Point::new(hw, hh),
-            Point::new(-hw, hh),
-        ],
-        FillRule::NonZero,
-    );
-}
-
-fn push_rounded_rect_path(
-    doc: &mut GeometryDocument,
-    transform: Affine2,
-    width: f64,
-    height: f64,
-    radius: f64,
-    corners: [bool; 4],
-) {
-    let hw = width / 2.0;
-    let hh = height / 2.0;
-    let r = radius.min(hw).min(hh).max(0.0);
-    if r == 0.0 || !corners.iter().any(|corner| *corner) {
-        push_rect_path(doc, transform, width, height);
-        return;
-    }
-
-    let k = 0.552_284_749_830_793_6;
-    let use_arcs = affine_preserves_circles(transform);
-    let [upper_right, lower_right, lower_left, upper_left] = corners;
-    let mut cmds = Vec::new();
-
-    cmds.push(PathCmd::move_to(Point::new(
-        -hw + if lower_left { r } else { 0.0 },
-        -hh,
-    )));
-
-    cmds.push(PathCmd::line_to(Point::new(
-        hw - if lower_right { r } else { 0.0 },
-        -hh,
-    )));
-    if lower_right {
-        if use_arcs {
-            cmds.push(PathCmd::arc_to(
-                Point::new(hw, -hh + r),
-                Point::new(hw - r, -hh + r),
-                false,
-            ));
-        } else {
-            cmds.push(PathCmd::cubic_to(
-                Point::new(hw - r + k * r, -hh),
-                Point::new(hw, -hh + r - k * r),
-                Point::new(hw, -hh + r),
-            ));
-        }
-    }
-
-    cmds.push(PathCmd::line_to(Point::new(
-        hw,
-        hh - if upper_right { r } else { 0.0 },
-    )));
-    if upper_right {
-        if use_arcs {
-            cmds.push(PathCmd::arc_to(
-                Point::new(hw - r, hh),
-                Point::new(hw - r, hh - r),
-                false,
-            ));
-        } else {
-            cmds.push(PathCmd::cubic_to(
-                Point::new(hw, hh - r + k * r),
-                Point::new(hw - r + k * r, hh),
-                Point::new(hw - r, hh),
-            ));
-        }
-    }
-
-    cmds.push(PathCmd::line_to(Point::new(
-        -hw + if upper_left { r } else { 0.0 },
-        hh,
-    )));
-    if upper_left {
-        if use_arcs {
-            cmds.push(PathCmd::arc_to(
-                Point::new(-hw, hh - r),
-                Point::new(-hw + r, hh - r),
-                false,
-            ));
-        } else {
-            cmds.push(PathCmd::cubic_to(
-                Point::new(-hw + r - k * r, hh),
-                Point::new(-hw, hh - r + k * r),
-                Point::new(-hw, hh - r),
-            ));
-        }
-    }
-
-    cmds.push(PathCmd::line_to(Point::new(
-        -hw,
-        -hh + if lower_left { r } else { 0.0 },
-    )));
-    if lower_left {
-        if use_arcs {
-            cmds.push(PathCmd::arc_to(
-                Point::new(-hw + r, -hh),
-                Point::new(-hw + r, -hh + r),
-                false,
-            ));
-        } else {
-            cmds.push(PathCmd::cubic_to(
-                Point::new(-hw, -hh + r - k * r),
-                Point::new(-hw + r - k * r, -hh),
-                Point::new(-hw + r, -hh),
-            ));
-        }
-    }
-    cmds.push(PathCmd::close());
-
-    let contour = transform_cmds(cmds, transform);
-    doc.push_path(
-        Paint::Fill {
-            rule: FillRule::NonZero,
-        },
-        [contour],
-    );
-}
-
-fn push_chamfered_rect_path(
-    doc: &mut GeometryDocument,
-    transform: Affine2,
-    width: f64,
-    height: f64,
-    chamfer: f64,
-    corners: [bool; 4],
-) {
-    let hw = width / 2.0;
-    let hh = height / 2.0;
-    let c = chamfer.min(hw).min(hh).max(0.0);
-    if c == 0.0 || !corners.iter().any(|corner| *corner) {
-        push_rect_path(doc, transform, width, height);
-        return;
-    }
-
-    let [upper_right, lower_right, lower_left, upper_left] = corners;
-    let mut points = Vec::with_capacity(8);
-
-    points.push(Point::new(-hw + if lower_left { c } else { 0.0 }, -hh));
-
-    points.push(Point::new(hw - if lower_right { c } else { 0.0 }, -hh));
-    if lower_right {
-        points.push(Point::new(hw, -hh + c));
-    }
-
-    points.push(Point::new(hw, hh - if upper_right { c } else { 0.0 }));
-    if upper_right {
-        points.push(Point::new(hw - c, hh));
-    }
-
-    points.push(Point::new(-hw + if upper_left { c } else { 0.0 }, hh));
-    if upper_left {
-        points.push(Point::new(-hw, hh - c));
-    }
-
-    points.push(Point::new(-hw, -hh + if lower_left { c } else { 0.0 }));
-
-    push_closed_points_path(doc, transform, points, FillRule::NonZero);
-}
-
-fn push_regular_polygon_path(
-    doc: &mut GeometryDocument,
-    transform: Affine2,
-    sides: usize,
-    radius: f64,
-) {
-    let points = (0..sides)
-        .map(|index| {
-            let angle = -std::f64::consts::FRAC_PI_2
-                + (index as f64 * std::f64::consts::TAU / sides as f64);
-            Point::new(radius * angle.cos(), radius * angle.sin())
-        })
-        .collect();
-    push_closed_points_path(doc, transform, points, FillRule::NonZero);
-}
-
-fn push_ellipse_path(doc: &mut GeometryDocument, transform: Affine2, width: f64, height: f64) {
-    let contour = if nearly_equal(width, height) && affine_preserves_circles(transform) {
-        circle_contour(transform, width)
-    } else {
-        ellipse_contour(transform, width, height)
-    };
-    doc.push_path(
-        Paint::Fill {
-            rule: FillRule::NonZero,
-        },
-        [contour],
-    );
-}
-
-fn circle_contour(transform: Affine2, diameter: f64) -> ContourBuf {
-    let radius = diameter / 2.0;
-    let center = transform.transform_point(Point::default());
-    let points = [
-        transform.transform_point(Point::new(radius, 0.0)),
-        transform.transform_point(Point::new(0.0, radius)),
-        transform.transform_point(Point::new(-radius, 0.0)),
-        transform.transform_point(Point::new(0.0, -radius)),
-        transform.transform_point(Point::new(radius, 0.0)),
-    ];
-    let clockwise = transform.determinant() < 0.0;
-    let mut bbox = BBox::empty();
-    for pair in points.windows(2) {
-        bbox = bbox.union(Arc::new(pair[0], pair[1], center, clockwise).bbox());
-    }
-    let cmds = vec![
-        PathCmd::move_to(points[0]),
-        PathCmd::arc_to(points[1], center, clockwise),
-        PathCmd::arc_to(points[2], center, clockwise),
-        PathCmd::arc_to(points[3], center, clockwise),
-        PathCmd::arc_to(points[4], center, clockwise),
-        PathCmd::close(),
-    ];
-    ContourBuf::from_parts(bbox, cmds)
 }
 
 fn ellipse_contour(transform: Affine2, width: f64, height: f64) -> ContourBuf {
-    let rx = width / 2.0;
-    let ry = height / 2.0;
-    let k = 0.552_284_749_830_793_6;
-    let local = [
-        (
-            Point::new(rx, 0.0),
-            Point::new(rx, k * ry),
-            Point::new(k * rx, ry),
-            Point::new(0.0, ry),
-        ),
-        (
-            Point::new(0.0, ry),
-            Point::new(-k * rx, ry),
-            Point::new(-rx, k * ry),
-            Point::new(-rx, 0.0),
-        ),
-        (
-            Point::new(-rx, 0.0),
-            Point::new(-rx, -k * ry),
-            Point::new(-k * rx, -ry),
-            Point::new(0.0, -ry),
-        ),
-        (
-            Point::new(0.0, -ry),
-            Point::new(k * rx, -ry),
-            Point::new(rx, -k * ry),
-            Point::new(rx, 0.0),
-        ),
-    ];
-
-    let start = transform.transform_point(local[0].0);
-    let mut bbox = BBox::from_point(start);
-    let mut cmds = vec![PathCmd::move_to(start)];
-    for (_, c1, c2, end) in local {
-        let c1 = transform.transform_point(c1);
-        let c2 = transform.transform_point(c2);
-        let end = transform.transform_point(end);
-        bbox.include_point(c1);
-        bbox.include_point(c2);
-        bbox.include_point(end);
-        cmds.push(PathCmd::cubic_to(c1, c2, end));
-    }
-    cmds.push(PathCmd::close());
-    ContourBuf::from_parts(bbox, cmds)
+    shapes::ellipse(width, height)
+        .unwrap_or_default()
+        .transformed(transform)
 }
-
-fn push_oval_path(doc: &mut GeometryDocument, transform: Affine2, width: f64, height: f64) {
-    if (width - height).abs() < 1e-9 {
-        push_ellipse_path(doc, transform, width, height);
-        return;
-    }
-
-    let k = 0.552_284_749_830_793_6;
-    let mut local_cmds = Vec::new();
-    if width > height {
-        let r = height / 2.0;
-        let a = (width - height) / 2.0;
-        local_cmds.push(PathCmd::move_to(Point::new(a, -r)));
-        local_cmds.push(PathCmd::line_to(Point::new(-a, -r)));
-        local_cmds.push(PathCmd::cubic_to(
-            Point::new(-a - k * r, -r),
-            Point::new(-a - r, -k * r),
-            Point::new(-a - r, 0.0),
-        ));
-        local_cmds.push(PathCmd::cubic_to(
-            Point::new(-a - r, k * r),
-            Point::new(-a - k * r, r),
-            Point::new(-a, r),
-        ));
-        local_cmds.push(PathCmd::line_to(Point::new(a, r)));
-        local_cmds.push(PathCmd::cubic_to(
-            Point::new(a + k * r, r),
-            Point::new(a + r, k * r),
-            Point::new(a + r, 0.0),
-        ));
-        local_cmds.push(PathCmd::cubic_to(
-            Point::new(a + r, -k * r),
-            Point::new(a + k * r, -r),
-            Point::new(a, -r),
-        ));
-    } else {
-        let r = width / 2.0;
-        let a = (height - width) / 2.0;
-        local_cmds.push(PathCmd::move_to(Point::new(r, -a)));
-        local_cmds.push(PathCmd::line_to(Point::new(r, a)));
-        local_cmds.push(PathCmd::cubic_to(
-            Point::new(r, a + k * r),
-            Point::new(k * r, a + r),
-            Point::new(0.0, a + r),
-        ));
-        local_cmds.push(PathCmd::cubic_to(
-            Point::new(-k * r, a + r),
-            Point::new(-r, a + k * r),
-            Point::new(-r, a),
-        ));
-        local_cmds.push(PathCmd::line_to(Point::new(-r, -a)));
-        local_cmds.push(PathCmd::cubic_to(
-            Point::new(-r, -a - k * r),
-            Point::new(-k * r, -a - r),
-            Point::new(0.0, -a - r),
-        ));
-        local_cmds.push(PathCmd::cubic_to(
-            Point::new(k * r, -a - r),
-            Point::new(r, -a - k * r),
-            Point::new(r, -a),
-        ));
-    }
-    local_cmds.push(PathCmd::close());
-
-    let contour = transform_cmds(local_cmds, transform);
-    doc.push_path(
-        Paint::Fill {
-            rule: FillRule::NonZero,
-        },
-        [contour],
-    );
-}
-
-fn affine_preserves_circles(transform: Affine2) -> bool {
-    let sx = transform.m00.hypot(transform.m10);
-    let sy = transform.m01.hypot(transform.m11);
-    let dot = transform.m00 * transform.m01 + transform.m10 * transform.m11;
-    sx > GEOMETRY_EPSILON
-        && sy > GEOMETRY_EPSILON
-        && nearly_equal(sx, sy)
-        && dot.abs() <= GEOMETRY_EPSILON * sx.max(sy).max(1.0)
-}
-
-fn nearly_equal(left: f64, right: f64) -> bool {
-    (left - right).abs() <= GEOMETRY_EPSILON * left.abs().max(right.abs()).max(1.0)
-}
-
-const GEOMETRY_EPSILON: f64 = 1e-9;
 
 fn push_donut_path(
     doc: &mut GeometryDocument,
@@ -4203,34 +3779,28 @@ fn push_moire_path(doc: &mut GeometryDocument, transform: Affine2, moire: &ipc25
         if inner_diameter > 0.0 {
             push_donut_path(doc, transform, outer_diameter, inner_diameter);
         } else {
-            push_ellipse_path(doc, transform, outer_diameter, outer_diameter);
+            push_filled_shape(
+                doc,
+                transform,
+                shapes::ellipse(outer_diameter, outer_diameter),
+            );
         }
     }
 
     if let (Some(width), Some(length)) = (moire.line_width, moire.line_length) {
         let angle = moire.line_angle.unwrap_or(0.0);
-        push_rect_path(
-            doc,
-            transform.concat(Affine2::placement(
-                Point::default(),
-                angle,
-                Mirror::NONE,
-                1.0,
-            )),
-            length,
-            width,
-        );
-        push_rect_path(
-            doc,
-            transform.concat(Affine2::placement(
-                Point::default(),
-                angle + 90.0,
-                Mirror::NONE,
-                1.0,
-            )),
-            length,
-            width,
-        );
+        for line_angle in [angle, angle + 90.0] {
+            push_filled_shape(
+                doc,
+                transform.concat(Affine2::placement(
+                    Point::default(),
+                    line_angle,
+                    Mirror::NONE,
+                    1.0,
+                )),
+                shapes::rect(length, width),
+            );
+        }
     }
 }
 
@@ -4262,7 +3832,7 @@ fn push_thermal_path(
             Mirror::NONE,
             1.0,
         ));
-        push_rect_path(doc, spoke_transform, length, spoke_width);
+        push_filled_shape(doc, spoke_transform, shapes::rect(length, spoke_width));
     }
 }
 
@@ -4276,28 +3846,24 @@ fn circular_sector_contour(
     let end_angle = end_degrees.to_radians();
     let start = Point::new(radius * start_angle.cos(), radius * start_angle.sin());
     let end = Point::new(radius * end_angle.cos(), radius * end_angle.sin());
-    transform_cmds(
-        [
-            PathCmd::move_to(Point::default()),
-            PathCmd::line_to(start),
-            PathCmd::arc_to(end, Point::default(), false),
-            PathCmd::close(),
-        ],
-        transform,
-    )
+    ContourBuf::new(vec![
+        PathCmd::move_to(Point::default()),
+        PathCmd::line_to(start),
+        PathCmd::arc_to(end, Point::default(), false),
+        PathCmd::close(),
+    ])
+    .transformed(transform)
 }
 
 fn rect_contour(transform: Affine2, x0: f64, y0: f64, x1: f64, y1: f64) -> ContourBuf {
-    transform_cmds(
-        [
-            PathCmd::move_to(Point::new(x0, y0)),
-            PathCmd::line_to(Point::new(x1, y0)),
-            PathCmd::line_to(Point::new(x1, y1)),
-            PathCmd::line_to(Point::new(x0, y1)),
-            PathCmd::close(),
-        ],
-        transform,
-    )
+    ContourBuf::new(vec![
+        PathCmd::move_to(Point::new(x0, y0)),
+        PathCmd::line_to(Point::new(x1, y0)),
+        PathCmd::line_to(Point::new(x1, y1)),
+        PathCmd::line_to(Point::new(x0, y1)),
+        PathCmd::close(),
+    ])
+    .transformed(transform)
 }
 
 fn map_polarity(polarity: Polarity) -> GeometryPolarity {
@@ -5406,7 +4972,7 @@ mod tests {
             ]
         );
         let image = imported
-            .composed_layer_image(top, ArtworkScope::ArrayFlattened)
+            .composed_layer_image(top, ArtworkScope::ArrayFlattened, Resolution::default())
             .unwrap();
         assert!(image.contains_point(Point::new(10.0, 0.0)));
     }
@@ -5632,7 +5198,8 @@ mod tests {
             .expect("synthetic nested panel fixture should parse");
         let mut doc = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened)
             .expect("nested panel layer should extract");
-        crate::dialects::ipc::process::normalize_for_artwork(&mut doc);
+        crate::dialects::ipc::process::normalize_for_artwork(&mut doc, Resolution::default())
+            .unwrap();
 
         let artwork = crate::dialects::ipc::lower_layer_to_artwork(
             &doc,
@@ -5640,7 +5207,8 @@ mod tests {
             crate::dialects::LayerRole::Copper,
             crate::dialects::Side::None,
         );
-        let svg = crate::render::artwork_svg(&artwork, &crate::render::RenderOptions::default());
+        let svg =
+            crate::render::artwork_svg(&artwork, &crate::render::RenderOptions::default()).unwrap();
 
         // One drawn pad per board across both nested repeat levels.
         assert_eq!(svg.matches("<path d=").count(), 4, "{svg}");
@@ -5671,7 +5239,8 @@ mod tests {
                 ArtworkScope::ArrayFlattened,
             )
             .expect("panel layer should extract");
-        crate::dialects::ipc::process::compose_for_rendering(&mut doc);
+        crate::dialects::ipc::process::compose_for_rendering(&mut doc, Resolution::default())
+            .unwrap();
 
         let layer = &doc.layers[0];
         let traces = layer
@@ -5724,13 +5293,10 @@ mod tests {
     fn chamfered_rect_respects_corner_flags() {
         let mut doc = GeometryDocument::new();
 
-        push_chamfered_rect_path(
+        push_filled_shape(
             &mut doc,
             Affine2::identity(),
-            10.0,
-            6.0,
-            1.0,
-            [true, false, false, false],
+            shapes::chamfered_rect(10.0, 6.0, 1.0, [true, false, false, false]),
         );
 
         let path = &doc.arena.paths[0];
@@ -5751,7 +5317,11 @@ mod tests {
     fn rounded_rect_preserves_arcs_when_transform_preserves_circles() {
         let mut doc = GeometryDocument::new();
 
-        push_rounded_rect_path(&mut doc, Affine2::identity(), 10.0, 6.0, 1.0, [true; 4]);
+        push_filled_shape(
+            &mut doc,
+            Affine2::identity(),
+            shapes::rounded_rect(10.0, 6.0, 1.0, [true; 4]),
+        );
 
         let path = &doc.arena.paths[0];
         let contour = &doc.arena.contours[path.contours.start as usize];
@@ -5762,10 +5332,10 @@ mod tests {
     }
 
     #[test]
-    fn rounded_rect_uses_cubics_when_transform_distorts_circles() {
+    fn rounded_rect_uses_elliptical_arcs_when_transform_distorts_circles() {
         let mut doc = GeometryDocument::new();
 
-        push_rounded_rect_path(
+        push_filled_shape(
             &mut doc,
             Affine2 {
                 m00: 2.0,
@@ -5775,10 +5345,7 @@ mod tests {
                 m11: 1.0,
                 m12: 0.0,
             },
-            10.0,
-            6.0,
-            1.0,
-            [true; 4],
+            shapes::rounded_rect(10.0, 6.0, 1.0, [true; 4]),
         );
 
         let path = &doc.arena.paths[0];
@@ -5786,10 +5353,16 @@ mod tests {
         let cmds = contour.cmds.slice(&doc.arena.cmds);
 
         assert_eq!(
-            cmds.iter().filter(|cmd| cmd.op == PathOp::CubicTo).count(),
+            cmds.iter()
+                .filter(|cmd| cmd.op == PathOp::EllipseTo)
+                .count(),
             4
         );
-        assert!(!cmds.iter().any(|cmd| cmd.op == PathOp::ArcTo));
+        assert!(
+            !cmds
+                .iter()
+                .any(|cmd| matches!(cmd.op, PathOp::ArcTo | PathOp::CubicTo))
+        );
     }
 
     #[test]

--- a/crates/pcb-ir/src/import/ipc2581/assembly.rs
+++ b/crates/pcb-ir/src/import/ipc2581/assembly.rs
@@ -59,7 +59,8 @@ impl ImportedDesign {
                         .map(|profile| ir::Profile {
                             outer: self
                                 .geometry
-                                .transformed_path_contours(profile.outer_path, Affine2::IDENTITY)
+                                .arena
+                                .path_contours(self.geometry.arena.path(profile.outer_path))
                                 .into_iter()
                                 .next()
                                 .expect("IPC step profile has one outer contour"),
@@ -69,7 +70,8 @@ impl ImportedDesign {
                                 .iter()
                                 .map(|cutout| {
                                     self.geometry
-                                        .transformed_path_contours(cutout.path, Affine2::IDENTITY)
+                                        .arena
+                                        .path_contours(self.geometry.arena.path(cutout.path))
                                         .into_iter()
                                         .next()
                                         .expect("IPC step profile cutout has one contour")
@@ -269,6 +271,7 @@ fn map_package_pin(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn map_package_view(
     design: &ImportedDesign,
     context: &super::ExtractContext<'_>,
@@ -352,7 +355,7 @@ fn map_package_outline(
             polarity: Polarity::Dark,
             paths: vec![ir::PackagePath {
                 paint,
-                contours: vec![super::polygon_contour(&outline.polygon, Affine2::IDENTITY)],
+                contours: vec![super::polygon_contour(&outline.polygon)],
             }],
         },
     }

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -726,7 +726,12 @@ impl ImportedDesign {
                             stackup,
                         )
                         && land.image.bbox().intersects(hole.image.bbox())
-                        && land.image.intersection(&hole.image).area() > tol::REGION_MM.powi(2))
+                        && land
+                            .image
+                            .intersection(&hole.image)
+                            .expect("lands and holes share one resolution")
+                            .area()
+                            > tol::REGION_MM.powi(2))
                     .then_some((land.id, termination.id))
                 })
             })
@@ -789,7 +794,7 @@ impl ImportedDesign {
                     if protection_side_compatible(hole.assembly_side, evidence.side)
                         && feature_spans_overlap(hole.span, evidence.span, stackup)
                         && hole.image.bbox().intersects(image.bbox())
-                        && hole.image.intersection(&image).area() > tol::REGION_MM.powi(2)
+                        && hole.image.intersection(&image)?.area() > tol::REGION_MM.powi(2)
                     {
                         hole.protection.push(evidence.clone());
                     }
@@ -1087,7 +1092,13 @@ fn associate_land_candidates(
         .iter()
         .copied()
         .filter(|land| land.image.bbox().intersects(image.bbox()))
-        .filter(|land| land.image.intersection(image).area() > tol::REGION_MM.powi(2))
+        .filter(|land| {
+            land.image
+                .intersection(image)
+                .expect("lands share one resolution")
+                .area()
+                > tol::REGION_MM.powi(2)
+        })
         .map(|land| land.id)
         .collect::<Vec<_>>();
 
@@ -1395,7 +1406,7 @@ mod tests {
             if height < 1.0 {
                 let residue = residue.expect("narrow slot leaves copper on both sides");
                 assert_eq!(residue.image.connected_components().len(), 2);
-                assert!(residue.image.intersection(&hole.image).is_empty());
+                assert!(residue.image.intersection(&hole.image).unwrap().is_empty());
             } else {
                 assert!(residue.is_none(), "wide slot removes all land copper");
             }
@@ -1517,12 +1528,13 @@ mod tests {
                                 .disk_erode(image.uncertainty_mm + holes[0].image.uncertainty_mm)
                                 .unwrap()
                         )
+                        .unwrap()
                         .is_empty(),
                     "{name}, declarations {order:?}"
                 );
                 let expected = reference.get_or_insert_with(|| image.clone());
-                assert!(image.difference(expected).is_empty());
-                assert!(expected.difference(&image).is_empty());
+                assert!(image.difference(expected).unwrap().is_empty());
+                assert!(expected.difference(&image).unwrap().is_empty());
             }
         }
     }
@@ -1653,6 +1665,7 @@ mod tests {
                             .disk_erode(image.uncertainty_mm + holes[0].image.uncertainty_mm)
                             .unwrap()
                     )
+                    .unwrap()
                     .is_empty()
             );
         }

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -4,6 +4,7 @@
 //! geometry remains owned once by the canonical IPC document and final images
 //! are composed on demand for the requested layout scope.
 
+use crate::geom::Resolution;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use anyhow::{Context, Result, bail, ensure};
@@ -225,39 +226,55 @@ fn exact_coordinate(value: f64) -> u64 {
 }
 
 impl ImportedDesign {
-    /// Derive surviving final copper lands without materializing unrelated
-    /// physical layers.
-    pub fn physical_lands(&self, scope: ArtworkScope) -> Result<Vec<PhysicalLand>> {
+    /// Derive surviving final copper lands without materializing unrelated physical
+    /// layers.
+    pub fn physical_lands(
+        &self,
+        scope: ArtworkScope,
+        resolution: Resolution,
+    ) -> Result<Vec<PhysicalLand>> {
         let components = self.component_occurrences(scope)?;
-        self.derive_physical_lands(scope, &components, false)
+        self.derive_physical_lands(scope, &components, false, resolution)
     }
 
     /// Derive electrical package contacts using only exact IPC identities.
-    pub fn physical_terminations(&self, scope: ArtworkScope) -> Result<Vec<PhysicalTermination>> {
-        let lands = self.physical_lands(scope)?;
+    pub fn physical_terminations(
+        &self,
+        scope: ArtworkScope,
+        resolution: Resolution,
+    ) -> Result<Vec<PhysicalTermination>> {
+        let lands = self.physical_lands(scope, resolution)?;
         Ok(self.derive_physical_terminations(&lands))
     }
 
     /// Derive drilled openings and their source-land relationships without
     /// composing final copper or materializing assembly, paste, or mask layers.
-    pub fn physical_holes(&self, scope: ArtworkScope) -> Result<Vec<PhysicalHole>> {
+    pub fn physical_holes(
+        &self,
+        scope: ArtworkScope,
+        resolution: Resolution,
+    ) -> Result<Vec<PhysicalHole>> {
         let components = self.component_occurrences(scope)?;
-        let lands = self.derive_physical_lands(scope, &components, true)?;
-        self.derive_physical_holes(scope, &lands)
+        let lands = self.derive_physical_lands(scope, &components, true, resolution)?;
+        self.derive_physical_holes(scope, &lands, resolution)
     }
 
     /// Derive physical lands, exact electrical terminations, independent paste
     /// islands, mask openings, and drilled openings without reinterpreting
     /// source XML or duplicating geometry.
-    pub fn physical_view(&self, scope: ArtworkScope) -> Result<PhysicalView> {
+    pub fn physical_view(
+        &self,
+        scope: ArtworkScope,
+        resolution: Resolution,
+    ) -> Result<PhysicalView> {
         let components = self.component_occurrences(scope)?;
-        let lands = self.derive_physical_lands(scope, &components, false)?;
+        let lands = self.derive_physical_lands(scope, &components, false, resolution)?;
         let terminations = self.derive_physical_terminations(&lands);
-        let paste_islands = self.paste_islands(scope, &components, &terminations)?;
-        let mask_openings = self.mask_openings(scope, &lands)?;
-        let source_lands = self.derive_physical_lands(scope, &components, true)?;
-        let mut holes = self.derive_physical_holes(scope, &source_lands)?;
-        self.attach_hole_assembly_evidence(scope, &lands, &terminations, &mut holes)?;
+        let paste_islands = self.paste_islands(scope, &components, &terminations, resolution)?;
+        let mask_openings = self.mask_openings(scope, &lands, resolution)?;
+        let source_lands = self.derive_physical_lands(scope, &components, true, resolution)?;
+        let mut holes = self.derive_physical_holes(scope, &source_lands, resolution)?;
+        self.attach_hole_assembly_evidence(scope, &lands, &terminations, &mut holes, resolution)?;
         Ok(PhysicalView {
             lands,
             terminations,
@@ -272,6 +289,7 @@ impl ImportedDesign {
         scope: ArtworkScope,
         components: &[ComponentOccurrence],
         source_geometry: bool,
+        resolution: Resolution,
     ) -> Result<Vec<PhysicalLand>> {
         let mut lands = Vec::new();
         for (layer_index, layer) in self.layer_definitions.iter().enumerate() {
@@ -288,7 +306,7 @@ impl ImportedDesign {
                     .map(|occurrence| (occurrence, None))
                     .collect::<Vec<_>>()
             } else {
-                self.attributed_land_images(layer_id, scope)?
+                self.attributed_land_images(layer_id, scope, resolution)?
                     .into_iter()
                     .map(|(occurrence, image)| (occurrence, Some(image)))
                     .collect()
@@ -311,7 +329,7 @@ impl ImportedDesign {
                     layer: layer_id,
                     side,
                     at,
-                    image: image.unwrap_or_else(|| self.feature_region(occurrence)),
+                    image: image.map_or_else(|| self.feature_region(occurrence, resolution), Ok)?,
                     board: occurrence.board,
                     component: self.component_association(source, &evidence, components),
                     component_refs: evidence.component_refs.clone(),
@@ -422,6 +440,7 @@ impl ImportedDesign {
         scope: ArtworkScope,
         components: &[ComponentOccurrence],
         terminations: &[PhysicalTermination],
+        resolution: Resolution,
     ) -> Result<Vec<PasteIsland>> {
         let mut islands = Vec::new();
         for (layer_index, layer) in self.layer_definitions.iter().enumerate() {
@@ -433,7 +452,9 @@ impl ImportedDesign {
             }
             let layer_id = LayerId(layer_index as u32);
             let side = physical_side(layer.side);
-            for (occurrence, image) in self.attributed_feature_images(layer_id, scope)? {
+            for (occurrence, image) in
+                self.attributed_feature_images(layer_id, scope, resolution)?
+            {
                 let source = occurrence.id;
                 let feature = self
                     .feature_definition(source.feature)
@@ -482,6 +503,7 @@ impl ImportedDesign {
         &self,
         scope: ArtworkScope,
         lands: &[PhysicalLand],
+        resolution: Resolution,
     ) -> Result<Vec<MaskOpening>> {
         let mut lands_by_context = HashMap::<_, Vec<_>>::new();
         for land in lands {
@@ -503,7 +525,9 @@ impl ImportedDesign {
             }
             let layer_id = LayerId(layer_index as u32);
             let side = physical_side(layer.side);
-            for (occurrence, image) in self.attributed_feature_images(layer_id, scope)? {
+            for (occurrence, image) in
+                self.attributed_feature_images(layer_id, scope, resolution)?
+            {
                 let source = occurrence.id;
                 let evidence = self.feature_evidence(source);
                 let board = occurrence.board;
@@ -540,6 +564,7 @@ impl ImportedDesign {
         &self,
         scope: ArtworkScope,
         lands: &[PhysicalLand],
+        resolution: Resolution,
     ) -> Result<Vec<PhysicalHole>> {
         let layer_order = physical_stackup_layers(&self.stackups, &self.layer_definitions)?
             .unwrap_or_else(|| {
@@ -568,7 +593,7 @@ impl ImportedDesign {
                 if !matches!(feature.kind, FeatureKind::Hole | FeatureKind::Slot) {
                     continue;
                 }
-                let image = self.feature_region(occurrence);
+                let image = self.feature_region(occurrence, resolution)?;
                 let evidence = self.feature_evidence(occurrence.id);
                 let mut layer_lands = Vec::new();
                 for (&copper_layer, candidates) in &lands_by_layer {
@@ -632,6 +657,7 @@ impl ImportedDesign {
         lands: &[PhysicalLand],
         terminations: &[PhysicalTermination],
         holes: &mut [PhysicalHole],
+        resolution: Resolution,
     ) -> Result<()> {
         let stackup = physical_stackup_layers(&self.stackups, &self.layer_definitions)?;
         let land_by_id = lands
@@ -653,7 +679,7 @@ impl ImportedDesign {
             hole.termination = termination;
             hole.termination_basis = basis;
         }
-        self.attach_hole_protection(scope, holes, stackup.as_deref())
+        self.attach_hole_protection(scope, holes, stackup.as_deref(), resolution)
     }
 
     fn hole_termination_association(
@@ -730,6 +756,7 @@ impl ImportedDesign {
         scope: ArtworkScope,
         holes: &mut [PhysicalHole],
         stackup: Option<&[Symbol]>,
+        resolution: Resolution,
     ) -> Result<()> {
         for (layer_index, layer) in self.layer_definitions.iter().enumerate() {
             if !matches!(
@@ -741,7 +768,9 @@ impl ImportedDesign {
                 continue;
             }
             let layer_id = LayerId(layer_index as u32);
-            for (occurrence, image) in self.attributed_feature_images(layer_id, scope)? {
+            for (occurrence, image) in
+                self.attributed_feature_images(layer_id, scope, resolution)?
+            {
                 let feature = self
                     .feature_definition(occurrence.id.feature)
                     .context("hole protection references a missing feature definition")?;
@@ -807,20 +836,27 @@ impl ImportedDesign {
         &self,
         layer: LayerId,
         scope: ArtworkScope,
+        resolution: Resolution,
     ) -> Result<Vec<(crate::import::ipc2581::FeatureOccurrence, ContourSet)>> {
-        self.attributed_feature_images_where(layer, scope, |_| true)
+        self.attributed_feature_images_where(layer, scope, |_| true, resolution)
     }
 
     fn attributed_land_images(
         &self,
         layer: LayerId,
         scope: ArtworkScope,
+        resolution: Resolution,
     ) -> Result<Vec<(crate::import::ipc2581::FeatureOccurrence, ContourSet)>> {
-        self.attributed_feature_images_where(layer, scope, |feature| {
-            feature.kind == FeatureKind::Padstack
-                && feature.polarity == Polarity::Dark
-                && feature.intent.domain == FeatureDomain::Copper
-        })
+        self.attributed_feature_images_where(
+            layer,
+            scope,
+            |feature| {
+                feature.kind == FeatureKind::Padstack
+                    && feature.polarity == Polarity::Dark
+                    && feature.intent.domain == FeatureDomain::Copper
+            },
+            resolution,
+        )
     }
 
     fn attributed_feature_images_where(
@@ -828,6 +864,7 @@ impl ImportedDesign {
         layer: LayerId,
         scope: ArtworkScope,
         include: impl Fn(&Feature<Symbol>) -> bool,
+        resolution: Resolution,
     ) -> Result<Vec<(crate::import::ipc2581::FeatureOccurrence, ContourSet)>> {
         let definition = self
             .layer_definition(layer)
@@ -839,7 +876,7 @@ impl ImportedDesign {
             .collect::<std::collections::HashMap<_, _>>();
         let mut document = self.materialize_layer(layer, scope)?;
         crate::dialects::ipc::process::expand_feature_placement_groups(&mut document);
-        crate::dialects::ipc::process::normalize_for_artwork(&mut document);
+        crate::dialects::ipc::process::normalize_for_artwork(&mut document, resolution)?;
         crate::dialects::ipc::validate_artwork_ready(&document).map_err(anyhow::Error::msg)?;
         let header = artwork::Layer {
             name: document.layers[0].name.clone(),
@@ -850,23 +887,27 @@ impl ImportedDesign {
             meta: definition.layer_function,
         };
         let artwork = lower_layer_to_artwork_with(&document, 0, header, &mut OccurrenceAttribution);
-        let (mut layers, _) = artwork::compose_selected_owners(&artwork, |owner| {
-            let owner = (*owner)?;
-            self.feature_definition(owner.feature)
-                .filter(|feature| include(feature))
-                .map(|_| owner)
-        });
+        let (mut layers, _) = artwork::compose_owner_regions(
+            &artwork,
+            |owner| {
+                let owner = (*owner)?;
+                self.feature_definition(owner.feature)
+                    .filter(|feature| include(feature))
+                    .map(|_| owner)
+            },
+            resolution,
+        )?;
         let owners = layers
             .pop()
             .context("attributed physical composition produced no layer")?;
         owners
             .into_iter()
-            .map(|(owner, rings)| {
+            .map(|(owner, image)| {
                 Ok((
                     *occurrences
                         .get(&owner)
                         .context("composed feature has no canonical occurrence")?,
-                    ContourSet::from_regularized(rings, tol::REGION_MM),
+                    image,
                 ))
             })
             .collect()
@@ -1242,16 +1283,22 @@ mod tests {
         make_paste_artwork_invalid(&mut imported);
 
         assert_eq!(
-            imported.physical_lands(ArtworkScope::Board).unwrap().len(),
+            imported
+                .physical_lands(ArtworkScope::Board, Resolution::default())
+                .unwrap()
+                .len(),
             7
         );
         assert_eq!(
-            imported.physical_holes(ArtworkScope::Board).unwrap().len(),
+            imported
+                .physical_holes(ArtworkScope::Board, Resolution::default())
+                .unwrap()
+                .len(),
             1
         );
         assert!(
             imported
-                .physical_view(ArtworkScope::Board)
+                .physical_view(ArtworkScope::Board, Resolution::default())
                 .unwrap_err()
                 .to_string()
                 .contains("mixes Fill and Stroke paths")
@@ -1268,13 +1315,15 @@ mod tests {
         let mut imported = import_design(&ipc).unwrap();
         make_paste_artwork_invalid(&mut imported);
 
-        let holes = imported.physical_holes(ArtworkScope::Board).unwrap();
+        let holes = imported
+            .physical_holes(ArtworkScope::Board, Resolution::default())
+            .unwrap();
         assert_eq!(holes.len(), 1);
         assert_eq!(holes[0].termination, Association::Unresolved);
         assert!(holes[0].protection.is_empty());
         assert!(
             imported
-                .physical_view(ArtworkScope::Board)
+                .physical_view(ArtworkScope::Board, Resolution::default())
                 .unwrap_err()
                 .to_string()
                 .contains("mixes Fill and Stroke paths")
@@ -1290,7 +1339,9 @@ mod tests {
         Ipc2581::validate(&xml).expect("one-ended drill span conforms to IPC-2581C");
         let ipc = Ipc2581::parse(&xml).unwrap();
         let imported = import_design(&ipc).unwrap();
-        let holes = imported.physical_holes(ArtworkScope::Board).unwrap();
+        let holes = imported
+            .physical_holes(ArtworkScope::Board, Resolution::default())
+            .unwrap();
 
         assert_eq!(holes.len(), 1);
         assert_eq!(holes[0].lands.len(), 2);
@@ -1302,7 +1353,11 @@ mod tests {
         );
         assert_eq!(holes[0].termination, Association::Unresolved);
         assert_eq!(
-            imported.physical_view(ArtworkScope::Board).unwrap().holes[0].termination,
+            imported
+                .physical_view(ArtworkScope::Board, Resolution::default())
+                .unwrap()
+                .holes[0]
+                .termination,
             Association::Unresolved
         );
     }
@@ -1319,7 +1374,9 @@ mod tests {
             );
             Ipc2581::validate(&xml).unwrap();
             let imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
-            let holes = imported.physical_holes(ArtworkScope::Board).unwrap();
+            let holes = imported
+                .physical_holes(ArtworkScope::Board, Resolution::default())
+                .unwrap();
             assert_eq!(holes.len(), 1);
             let hole = &holes[0];
             assert_eq!(hole.kind, PhysicalHoleKind::Slot);
@@ -1331,7 +1388,9 @@ mod tests {
                 .expect("routing must not erase source identity");
             let source = imported.feature_definition(land.0.feature).unwrap();
             assert_eq!(source.center, Point::new(5.0, 5.0));
-            let final_lands = imported.physical_lands(ArtworkScope::Board).unwrap();
+            let final_lands = imported
+                .physical_lands(ArtworkScope::Board, Resolution::default())
+                .unwrap();
             let residue = final_lands.iter().find(|candidate| candidate.id == land);
             if height < 1.0 {
                 let residue = residue.expect("narrow slot leaves copper on both sides");
@@ -1340,7 +1399,9 @@ mod tests {
             } else {
                 assert!(residue.is_none(), "wide slot removes all land copper");
             }
-            let view = imported.physical_view(ArtworkScope::Board).unwrap();
+            let view = imported
+                .physical_view(ArtworkScope::Board, Resolution::default())
+                .unwrap();
             assert_eq!(view.lands.len(), final_lands.len());
             assert_eq!(
                 view.holes[0]
@@ -1406,12 +1467,14 @@ mod tests {
         for order in [["L0", "L1", "L2"], ["L2", "L0", "L1"], ["L1", "L2", "L0"]] {
             let xml = spanned_slot_fixture(order, true);
             let imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
-            let holes = imported.physical_holes(ArtworkScope::Board).unwrap();
+            let holes = imported
+                .physical_holes(ArtworkScope::Board, Resolution::default())
+                .unwrap();
             assert_eq!(holes.len(), 1);
             let inner = imported.layer_id("L1").unwrap();
             assert!(
                 imported
-                    .composed_layer_image(inner, ArtworkScope::Board)
+                    .composed_layer_image(inner, ArtworkScope::Board, Resolution::default())
                     .unwrap()
                     .is_empty()
             );
@@ -1437,15 +1500,24 @@ mod tests {
         for order in [["L0", "L1", "L2"], ["L2", "L0", "L1"], ["L1", "L2", "L0"]] {
             let xml = spanned_slot_fixture(order, false);
             let imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
-            let holes = imported.physical_holes(ArtworkScope::Board).unwrap();
+            let holes = imported
+                .physical_holes(ArtworkScope::Board, Resolution::default())
+                .unwrap();
             for name in ["L0", "L1", "L2"] {
                 let layer = imported.layer_id(name).unwrap();
                 let image = imported
-                    .composed_layer_image(layer, ArtworkScope::Board)
+                    .composed_layer_image(layer, ArtworkScope::Board, Resolution::default())
                     .unwrap();
                 assert!(!image.is_empty());
                 assert!(
-                    image.intersection(&holes[0].image).is_empty(),
+                    image
+                        .intersection(
+                            &holes[0]
+                                .image
+                                .disk_erode(image.uncertainty_mm + holes[0].image.uncertainty_mm)
+                                .unwrap()
+                        )
+                        .is_empty(),
                     "{name}, declarations {order:?}"
                 );
                 let expected = reference.get_or_insert_with(|| image.clone());
@@ -1489,7 +1561,9 @@ mod tests {
             // no slot extraction is needed to construct the canonical design.
             let mut imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
             imported.stackups = invalid.ecad().unwrap().cad_data.stackups.clone();
-            let error = imported.physical_holes(ArtworkScope::Board).unwrap_err();
+            let error = imported
+                .physical_holes(ArtworkScope::Board, Resolution::default())
+                .unwrap_err();
             assert!(error.to_string().contains(message), "{error}");
         }
     }
@@ -1562,14 +1636,25 @@ mod tests {
             let mut xml = xml.clone();
             xml.replace_range(start..end, stackup);
             let imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
-            let holes = imported.physical_holes(ArtworkScope::Board).unwrap();
+            let holes = imported
+                .physical_holes(ArtworkScope::Board, Resolution::default())
+                .unwrap();
             assert_eq!(holes[0].lands.len(), 3);
             let inner = imported.layer_id("L1").unwrap();
             let image = imported
-                .composed_layer_image(inner, ArtworkScope::Board)
+                .composed_layer_image(inner, ArtworkScope::Board, Resolution::default())
                 .unwrap();
             assert!(!image.is_empty());
-            assert!(image.intersection(&holes[0].image).is_empty());
+            assert!(
+                image
+                    .intersection(
+                        &holes[0]
+                            .image
+                            .disk_erode(image.uncertainty_mm + holes[0].image.uncertainty_mm)
+                            .unwrap()
+                    )
+                    .is_empty()
+            );
         }
     }
 
@@ -1578,7 +1663,9 @@ mod tests {
         Ipc2581::validate(physical_fixture()).expect("fixture conforms to IPC-2581C");
         let ipc = Ipc2581::parse(physical_fixture()).unwrap();
         let imported = import_design(&ipc).unwrap();
-        let physical = imported.physical_view(ArtworkScope::Board).unwrap();
+        let physical = imported
+            .physical_view(ArtworkScope::Board, Resolution::default())
+            .unwrap();
 
         assert_eq!(physical.lands.len(), 7);
         let u1_pin = imported
@@ -1734,6 +1821,65 @@ mod tests {
             ])],
         );
         imported.geometry.features[feature].paths = Span::new(start, 2);
+    }
+
+    #[test]
+    fn physical_preparation_can_refine_retained_source_geometry() {
+        let ipc = Ipc2581::parse(physical_fixture()).unwrap();
+        let imported = crate::import::ipc2581::import_design(&ipc).unwrap();
+        let coarse = imported
+            .physical_view(ArtworkScope::Board, Resolution::default())
+            .unwrap();
+        let accuracy = crate::geom::GeometryAccuracy::new(0.0001).unwrap();
+        let fine_resolution = Resolution::default().with_accuracy(accuracy);
+        let fine = imported
+            .physical_view(ArtworkScope::Board, fine_resolution)
+            .unwrap();
+        assert_eq!(fine.lands.len(), coarse.lands.len());
+        assert_eq!(fine.paste_islands.len(), coarse.paste_islands.len());
+        for (coarse, fine) in coarse.lands.iter().zip(&fine.lands) {
+            assert!(fine.image.uncertainty_mm < coarse.image.uncertainty_mm);
+            accuracy.check(fine.image.uncertainty_mm).unwrap();
+        }
+        for region in fine
+            .paste_islands
+            .iter()
+            .map(|p| &p.image)
+            .chain(fine.mask_openings.iter().map(|p| &p.image))
+            .chain(fine.holes.iter().map(|p| &p.image))
+        {
+            accuracy.check(region.uncertainty_mm).unwrap();
+        }
+        let layer = imported.layer_id("TOP").unwrap();
+        let image = imported
+            .composed_layer_image(layer, ArtworkScope::Board, fine_resolution)
+            .unwrap();
+        accuracy.check(image.uncertainty_mm).unwrap();
+    }
+
+    #[test]
+    fn headless_preparation_rejects_already_coarse_feature_commands() {
+        let ipc = Ipc2581::parse(physical_fixture()).unwrap();
+        let mut imported = crate::import::ipc2581::import_design(&ipc).unwrap();
+        let layer = imported.layer_id("TOP").unwrap();
+        let occurrence = imported
+            .feature_occurrences(layer, ArtworkScope::Board)
+            .unwrap()[0];
+        let coarse = imported
+            .feature_region(occurrence, Resolution::default())
+            .unwrap();
+        let start = imported.geometry.arena.paths.len() as u32;
+        imported.geometry.arena.push_path(
+            crate::geom::Paint::Fill {
+                rule: crate::geom::FillRule::NonZero,
+            },
+            coarse.to_contours(),
+        );
+        imported.geometry.features[occurrence.id.feature.0 as usize].paths = Span::single(start);
+        let fine = Resolution::default()
+            .with_accuracy(crate::geom::GeometryAccuracy::new(0.0001).unwrap());
+        assert!(imported.feature_region(occurrence, fine).is_err());
+        assert!(imported.physical_view(ArtworkScope::Board, fine).is_err());
     }
 
     fn physical_fixture() -> &'static str {

--- a/crates/pcb-ir/src/render/mod.rs
+++ b/crates/pcb-ir/src/render/mod.rs
@@ -29,6 +29,9 @@ pub struct RenderOptions {
     /// `None` fits the selected layers with the default padding. This changes
     /// the camera only; callers should cull large documents before rendering.
     pub viewport: Option<BBox>,
+    /// Budget for geometry the target cannot draw natively (patterned
+    /// strokes, contours already carrying approximation).
+    pub accuracy: crate::geom::GeometryAccuracy,
 }
 
 impl RenderOptions {
@@ -53,6 +56,11 @@ impl RenderOptions {
 
     pub fn with_viewport(mut self, viewport: BBox) -> Self {
         self.viewport = Some(viewport);
+        self
+    }
+
+    pub fn with_accuracy(mut self, accuracy: crate::geom::GeometryAccuracy) -> Self {
+        self.accuracy = accuracy;
         self
     }
 

--- a/crates/pcb-ir/src/render/png.rs
+++ b/crates/pcb-ir/src/render/png.rs
@@ -21,10 +21,10 @@ pub fn artwork_png<LayerMeta: Clone, ObjectMeta: Clone>(
     options: &RenderOptions,
 ) -> Result<Vec<u8>, String> {
     let bbox = options.viewport_or(crate::render::artwork_bbox(doc, options.layers.as_deref()));
-    svg_to_png(&crate::render::artwork_svg(
-        doc,
-        &raster_options(options, bbox),
-    ))
+    svg_to_png(
+        &crate::render::artwork_svg(doc, &raster_options(options, bbox))
+            .map_err(|error| error.to_string())?,
+    )
 }
 
 /// Resolve a size constraint into the fixed pixel size a raster needs.
@@ -42,6 +42,7 @@ fn raster_options(options: &RenderOptions, bbox: BBox) -> RenderOptions {
     RenderOptions {
         layers: options.layers.clone(),
         viewport: options.viewport,
+        accuracy: options.accuracy,
         size: SizeConstraint::Fixed {
             width_px,
             height_px,

--- a/crates/pcb-ir/src/render/svg.rs
+++ b/crates/pcb-ir/src/render/svg.rs
@@ -1,3 +1,4 @@
+use crate::geom::{AccuracyError, EllipticalArc, GeometryAccuracy};
 use std::fmt::Write;
 
 use crate::dialects::LayerRole;
@@ -42,23 +43,47 @@ pub fn svg<LayerMeta>(doc: &mask::Document<LayerMeta>, options: &RenderOptions) 
 pub fn artwork_svg<LayerMeta: Clone, ObjectMeta: Clone>(
     doc: &artwork::Document<LayerMeta, ObjectMeta>,
     options: &RenderOptions,
-) -> String {
+) -> Result<String, AccuracyError> {
     if !doc.blocks.is_empty() {
         return artwork_svg(&artwork::expand_instances(doc), options);
     }
+    let accuracy = options.accuracy;
     let layers = crate::render::layer_indices(doc.layers.len(), options.layers.as_deref());
     let bbox = options.viewport_or(crate::render::artwork_bbox(doc, Some(&layers)));
     let mut defs = String::new();
     let mut body = String::new();
 
+    let mut aperture_accuracy = vec![None::<GeometryAccuracy>; doc.apertures.len()];
+    for &layer_index in &layers {
+        for object in doc.layers[layer_index].objects.slice(&doc.objects) {
+            if let Geometry::Flash {
+                aperture,
+                transform,
+            } = object.geometry
+            {
+                let local = accuracy
+                    .before_transform(doc.apertures[aperture as usize].bbox(), transform)?;
+                let budget = &mut aperture_accuracy[aperture as usize];
+                *budget = Some(GeometryAccuracy::new(
+                    budget.map_or(local.max_error_mm(), |budget| {
+                        budget.max_error_mm().min(local.max_error_mm())
+                    }),
+                )?);
+            }
+        }
+    }
+
     for (aperture_index, aperture) in doc.apertures.iter().enumerate() {
+        let Some(accuracy) = aperture_accuracy[aperture_index] else {
+            continue;
+        };
         // Colour is inherited from the referencing group so one aperture can
         // serve both a dark run and a clear run's mask; `stroke` is not, or
         // every filled shape would gain the default one-unit outline.
         writeln!(
             defs,
             "    <path id='a{aperture_index}' d='{}' fill-rule='{}' stroke='none'/>",
-            svg_path_data(&aperture.contours()),
+            accurate_path_data(aperture.contours(), accuracy)?,
             fill_rule_name(aperture.fill_rule())
         )
         .unwrap();
@@ -66,7 +91,7 @@ pub fn artwork_svg<LayerMeta: Clone, ObjectMeta: Clone>(
 
     for &layer_index in &layers {
         let layer = &doc.layers[layer_index];
-        write_artwork_layer(&mut body, &mut defs, doc, layer);
+        write_artwork_layer(&mut body, &mut defs, doc, layer, accuracy)?;
     }
 
     let title = layers
@@ -76,7 +101,7 @@ pub fn artwork_svg<LayerMeta: Clone, ObjectMeta: Clone>(
     let mut svg = open_svg(&bbox, pixel_size(options, bbox), title);
     writeln!(svg, "  <defs>\n{defs}  </defs>").unwrap();
     svg.push_str(&body);
-    close_svg(svg)
+    Ok(close_svg(svg))
 }
 
 fn write_artwork_layer<LayerMeta, ObjectMeta>(
@@ -84,7 +109,8 @@ fn write_artwork_layer<LayerMeta, ObjectMeta>(
     defs: &mut String,
     doc: &artwork::Document<LayerMeta, ObjectMeta>,
     layer: &artwork::Layer<LayerMeta>,
-) {
+    accuracy: GeometryAccuracy,
+) -> Result<(), AccuracyError> {
     let objects = artwork::paint_ordered(layer.objects.slice(&doc.objects));
     let has_material = objects
         .iter()
@@ -107,7 +133,7 @@ fn write_artwork_layer<LayerMeta, ObjectMeta>(
             flush_run(&mut painted, defs, &mut run, run_polarity, layer);
             run_polarity = polarity;
         }
-        write_artwork_object(&mut run, doc, layer.role, object);
+        write_artwork_object(&mut run, doc, layer.role, object, accuracy)?;
     }
     flush_run(&mut painted, defs, &mut run, run_polarity, layer);
 
@@ -120,6 +146,8 @@ fn write_artwork_layer<LayerMeta, ObjectMeta>(
         fmt_num(opacity)
     )
     .unwrap();
+
+    Ok(())
 }
 
 fn flush_run<LayerMeta>(
@@ -155,7 +183,8 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
     doc: &artwork::Document<LayerMeta, ObjectMeta>,
     role: LayerRole,
     object: &artwork::Object<ObjectMeta>,
-) {
+    accuracy: GeometryAccuracy,
+) -> Result<(), AccuracyError> {
     match object.geometry {
         Geometry::Flash {
             aperture,
@@ -173,7 +202,7 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
             writeln!(
                 out,
                 "      <path d='{}' fill-rule='{}' stroke='none'/>",
-                path_data(&doc.arena, path),
+                accurate_path_data(doc.arena.path_contours(path), accuracy)?,
                 fill_rule_name(
                     path.fill_rule()
                         .expect("region geometry carries a fill paint")
@@ -187,7 +216,8 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
             let contours = crate::geom::path::stroke_to_fill(
                 &doc.arena.path_contours(doc.arena.path(path)),
                 stroke_of(doc, path).into(),
-            )
+                accuracy,
+            )?
             .unwrap_or_default();
             writeln!(
                 out,
@@ -206,7 +236,7 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
             writeln!(
                 out,
                 "      <path d='{}' fill='none' stroke-width='{}' stroke-linecap='{}' stroke-linejoin='{}'{outline}/>",
-                path_data(&doc.arena, doc.arena.path(path)),
+                accurate_path_data(doc.arena.path_contours(doc.arena.path(path)), accuracy)?,
                 fmt_num(stroke.width),
                 line_cap_name(stroke.cap),
                 line_join_name(stroke.join),
@@ -216,7 +246,20 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
         Geometry::Instance { .. } | Geometry::GridInstance { .. } => {
             unreachable!("artwork instances are expanded before SVG rendering")
         }
+    };
+    Ok(())
+}
+
+/// Path data for contours the SVG draws natively; only approximation the
+/// contours already carry counts against the budget.
+fn accurate_path_data(
+    contours: Vec<crate::geom::path::ContourBuf>,
+    accuracy: GeometryAccuracy,
+) -> Result<String, AccuracyError> {
+    for contour in &contours {
+        accuracy.check(contour.uncertainty_mm)?;
     }
+    Ok(svg_path_data(&contours))
 }
 
 fn stroke_of<LayerMeta, ObjectMeta>(
@@ -361,6 +404,20 @@ fn write_contour(data: &mut String, cmds: impl IntoIterator<Item = PathCmd>) {
                 write_arc(data, current, cmd);
                 current = cmd.p0;
             }
+            PathOp::EllipseTo => {
+                write_elliptical_arc(
+                    data,
+                    EllipticalArc {
+                        start: current,
+                        end: cmd.p0,
+                        center: cmd.p1,
+                        x_axis: cmd.p2,
+                        y_axis: cmd.p3,
+                        clockwise: cmd.clockwise,
+                    },
+                );
+                current = cmd.p0;
+            }
             PathOp::CubicTo => {
                 current = cmd.p2;
                 write!(
@@ -413,6 +470,40 @@ fn write_svg_arc(data: &mut String, radius: f64, large_arc: u8, sweep_flag: u8, 
     .unwrap();
 }
 
+/// An elliptical arc as one or two SVG `A` commands: the principal axes and
+/// their rotation describe the ellipse, the flags pick the arc.
+fn write_elliptical_arc(data: &mut String, arc: EllipticalArc) {
+    let (major, minor, rotation) = arc.principal_axes();
+    if arc.is_degenerate() || minor <= POINT_EPSILON_MM {
+        write!(data, " L{} {}", fmt_num(arc.end.x), fmt_num(arc.end.y)).unwrap();
+        return;
+    }
+    let sweep_flag = if arc.clockwise { 0 } else { 1 };
+    let rotation_degrees = rotation.to_degrees();
+    let mut write_piece = |large_arc: u8, end: Point| {
+        write!(
+            data,
+            " A{} {} {} {large_arc} {sweep_flag} {} {}",
+            fmt_num(major),
+            fmt_num(minor),
+            fmt_num(rotation_degrees),
+            fmt_num(end.x),
+            fmt_num(end.y)
+        )
+        .unwrap();
+    };
+    if arc.is_full_ellipse() {
+        // A full ellipse cannot be one SVG arc; split at the antipode.
+        write_piece(0, arc.center * 2.0 - arc.start);
+        write_piece(0, arc.end);
+        return;
+    }
+    write_piece(
+        u8::from(arc.sweep_radians() > std::f64::consts::PI),
+        arc.end,
+    );
+}
+
 fn layer_style(role: LayerRole) -> (&'static str, f64) {
     match role {
         LayerRole::Copper => ("#d87822", 0.9),
@@ -449,7 +540,7 @@ mod tests {
     use super::*;
     use crate::dialects::{Side, mask::Layer};
     use crate::geom::path::ContourBuf;
-    use crate::geom::{BBox, Paint};
+    use crate::geom::{BBox, Paint, Resolution};
 
     fn square(size: f64) -> ContourBuf {
         ContourBuf::new(vec![
@@ -500,13 +591,13 @@ mod tests {
         annulus.extend(crate::geom::shapes::circle(2.0).unwrap().cmds);
         let contours = vec![
             ContourBuf::new(annulus),
-            crate::geom::path::transform_cmds(
-                crate::geom::shapes::circle(2.0).unwrap().cmds,
-                Affine2::translation(Point::new(2.5, 0.0)),
-            ),
+            crate::geom::shapes::circle(2.0)
+                .unwrap()
+                .transformed(Affine2::translation(Point::new(2.5, 0.0))),
         ];
         let measured =
-            crate::geom::ContourSet::from_filled_contours(&contours, crate::geom::tol::REGION_MM);
+            crate::geom::ContourSet::from_filled_contours(&contours, Resolution::default())
+                .unwrap();
         let mut doc = mask::Document::<()>::new();
         let layer = doc.push_layer(mask::Layer::new("Routes", LayerRole::Drill, Side::None));
         for contour in contours {
@@ -554,7 +645,11 @@ mod tests {
                     height_px: 800,
                 });
         let native = crate::render::artwork_png(doc, &options).unwrap();
-        let composed = crate::render::png(&artwork::compose_to_mask(doc), &options).unwrap();
+        let composed = crate::render::png(
+            &artwork::compose_to_mask(doc, Resolution::default()).unwrap(),
+            &options,
+        )
+        .unwrap();
         for (name, png) in [("native", native), ("composed", composed)] {
             let raster = resvg::tiny_skia::Pixmap::decode_png(&png).unwrap();
             for &(at, filled) in samples {
@@ -610,7 +705,7 @@ mod tests {
                 (Point::new(15.0, 10.0), true),
             ],
         );
-        let rendered = artwork_svg(&doc, &RenderOptions::default());
+        let rendered = artwork_svg(&doc, &RenderOptions::default()).unwrap();
         assert_eq!(rendered.matches("<mask ").count(), 2);
         assert_eq!(rendered.matches(" A").count(), 12);
     }
@@ -693,7 +788,7 @@ mod tests {
             BBox::new(Point::ZERO, Point::new(16.0, 16.0)),
             &samples,
         );
-        let rendered = artwork_svg(&doc, &RenderOptions::default());
+        let rendered = artwork_svg(&doc, &RenderOptions::default()).unwrap();
         assert!(rendered.contains("fill-rule='evenodd'"));
         assert!(rendered.contains("<use href='#a0' transform='matrix("));
         assert!(rendered.contains(" A"), "native rounded edges stay arcs");
@@ -718,10 +813,119 @@ mod tests {
         assert_eq!(u32::from_be_bytes(png[20..24].try_into().unwrap()), 20);
 
         let artwork = copper_artwork();
-        assert!(artwork_svg(&artwork, &options).contains("viewBox='-4 -9 10 2'"));
+        assert!(
+            artwork_svg(&artwork, &options)
+                .unwrap()
+                .contains("viewBox='-4 -9 10 2'")
+        );
         let png = crate::render::artwork_png(&artwork, &options).unwrap();
         assert_eq!(u32::from_be_bytes(png[16..20].try_into().unwrap()), 100);
         assert_eq!(u32::from_be_bytes(png[20..24].try_into().unwrap()), 20);
+    }
+
+    #[test]
+    fn direct_and_instanced_svg_enforce_the_same_contour_budget() {
+        let accuracy = GeometryAccuracy::new(0.001).unwrap();
+        for contour in [
+            square(1.0).with_uncertainty(0.02),
+            crate::geom::shapes::ellipse(4.0, 2.0).unwrap(),
+        ] {
+            let refinable = contour.uncertainty_mm == 0.0;
+            let mut source = copper_artwork();
+            let aperture =
+                source.push_aperture(artwork::Aperture::solid(artwork::ApertureShape::Contour {
+                    outline: contour.clone(),
+                    fill_rule: FillRule::NonZero,
+                }));
+            let region = source.push_path(
+                Paint::Fill {
+                    rule: FillRule::NonZero,
+                },
+                vec![contour.clone()],
+            );
+            let stroke = source.push_path(Paint::Stroke(StrokeStyle::round(0.1)), vec![contour]);
+            for geometry in [
+                Geometry::Flash {
+                    aperture,
+                    transform: Affine2::IDENTITY,
+                },
+                Geometry::Region { path: region },
+                Geometry::Stroke { path: stroke },
+            ] {
+                for instanced in [false, true] {
+                    let mut doc = source.clone();
+                    let object = artwork::Object::new(Polarity::Dark, geometry);
+                    if instanced {
+                        let block = doc.push_block();
+                        doc.push_block_object(block, object);
+                        doc.push_object(
+                            0,
+                            artwork::Object::new(
+                                Polarity::Dark,
+                                Geometry::Instance {
+                                    block,
+                                    transform: Affine2::translation(Point::new(2.0, 3.0)),
+                                },
+                            ),
+                        );
+                    } else {
+                        doc.push_object(0, object);
+                    }
+                    artwork::normalize_bounds(&mut doc);
+                    assert_eq!(
+                        artwork_svg(
+                            &doc,
+                            &RenderOptions {
+                                accuracy,
+                                ..RenderOptions::default()
+                            }
+                        )
+                        .is_ok(),
+                        refinable,
+                        "geometry={geometry:?}, instanced={instanced}, refinable={refinable}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn svg_flash_budget_accounts_for_placement_scale() {
+        let accuracy = GeometryAccuracy::new(0.01).unwrap();
+        for (scale, succeeds) in [(0.1, true), (2.0, false)] {
+            let mut doc = copper_artwork();
+            let aperture =
+                doc.push_aperture(artwork::Aperture::solid(artwork::ApertureShape::Contour {
+                    outline: square(1.0).with_uncertainty(0.02),
+                    fill_rule: FillRule::NonZero,
+                }));
+            doc.push_object(
+                0,
+                artwork::Object::new(
+                    Polarity::Dark,
+                    Geometry::Flash {
+                        aperture,
+                        transform: Affine2 {
+                            m00: scale,
+                            m11: scale,
+                            ..Affine2::IDENTITY
+                        },
+                    },
+                ),
+            );
+            artwork::normalize_bounds(&mut doc);
+            assert_eq!(
+                artwork_svg(
+                    &doc,
+                    &RenderOptions {
+                        accuracy,
+                        ..RenderOptions::default()
+                    }
+                )
+                .is_ok(),
+                succeeds
+            );
+        }
     }
 
     #[test]
@@ -742,7 +946,7 @@ mod tests {
         }
         artwork::normalize_bounds(&mut doc);
 
-        let svg = artwork_svg(&doc, &RenderOptions::default());
+        let svg = artwork_svg(&doc, &RenderOptions::default()).unwrap();
 
         assert_eq!(svg.matches("<path id='a0'").count(), 1);
         assert_eq!(svg.matches("<use href='#a0'").count(), 4);
@@ -766,7 +970,7 @@ mod tests {
         );
         artwork::normalize_bounds(&mut doc);
 
-        let svg = artwork_svg(&doc, &RenderOptions::default());
+        let svg = artwork_svg(&doc, &RenderOptions::default()).unwrap();
 
         assert!(svg.contains("stroke='none'"), "{svg}");
     }
@@ -790,7 +994,7 @@ mod tests {
         );
         artwork::normalize_bounds(&mut doc);
 
-        let svg = artwork_svg(&doc, &RenderOptions::default());
+        let svg = artwork_svg(&doc, &RenderOptions::default()).unwrap();
 
         // Expanded into separate filled dashes rather than one native stroke.
         assert!(!svg.contains("stroke-width"), "{svg}");
@@ -822,7 +1026,7 @@ mod tests {
         );
         artwork::normalize_bounds(&mut doc);
 
-        let svg = artwork_svg(&doc, &RenderOptions::default());
+        let svg = artwork_svg(&doc, &RenderOptions::default()).unwrap();
 
         assert_eq!(svg.matches("<mask id='m0'").count(), 1);
         assert_eq!(svg.matches("<g mask='url(#m0)'>").count(), 1);

--- a/crates/pcb-ir/src/render/svg.rs
+++ b/crates/pcb-ir/src/render/svg.rs
@@ -250,14 +250,19 @@ fn write_artwork_object<LayerMeta, ObjectMeta>(
     Ok(())
 }
 
-/// Path data for contours the SVG draws natively; only approximation the
-/// contours already carry counts against the budget.
+/// Coordinates are written to six decimals, so every emitted point may sit
+/// this far from its source along each axis.
+const SVG_COORDINATE_GRID_MM: f64 = 1e-6;
+
+/// Path data for contours the SVG draws natively; the approximation the
+/// contours already carry plus coordinate rounding counts against the budget.
 fn accurate_path_data(
     contours: Vec<crate::geom::path::ContourBuf>,
     accuracy: GeometryAccuracy,
 ) -> Result<String, AccuracyError> {
     for contour in &contours {
-        accuracy.check(contour.uncertainty_mm)?;
+        accuracy
+            .check(contour.uncertainty_mm + SVG_COORDINATE_GRID_MM / std::f64::consts::SQRT_2)?;
     }
     Ok(svg_path_data(&contours))
 }
@@ -821,6 +826,16 @@ mod tests {
         let png = crate::render::artwork_png(&artwork, &options).unwrap();
         assert_eq!(u32::from_be_bytes(png[16..20].try_into().unwrap()), 100);
         assert_eq!(u32::from_be_bytes(png[20..24].try_into().unwrap()), 20);
+    }
+
+    #[test]
+    fn svg_charges_coordinate_rounding_against_the_budget() {
+        let contours = vec![square(1.0)];
+        assert!(accurate_path_data(contours.clone(), GeometryAccuracy::new(1e-6).unwrap()).is_ok());
+        assert!(matches!(
+            accurate_path_data(contours, GeometryAccuracy::new(1e-7).unwrap()),
+            Err(AccuracyError::BudgetExceeded { .. })
+        ));
     }
 
     #[test]

--- a/crates/pcb-ir/src/render/term.rs
+++ b/crates/pcb-ir/src/render/term.rs
@@ -36,6 +36,7 @@ fn terminal_options(options: &RenderOptions) -> RenderOptions {
         layers: options.layers.clone(),
         size: SizeConstraint::MaxDimension(terminal_max_dimension_px()),
         viewport: options.viewport,
+        accuracy: options.accuracy,
     }
 }
 

--- a/crates/pcb-ir/tests/geometry_accuracy.rs
+++ b/crates/pcb-ir/tests/geometry_accuracy.rs
@@ -1,0 +1,467 @@
+//! Accuracy budgets are chosen once, at preparation, and travel with the
+//! prepared region. These tests exercise that contract end to end.
+
+use pcb_ir::geom::dfm::region_clearance;
+use pcb_ir::geom::dist::point_segment;
+use pcb_ir::geom::{
+    Affine2, BBox, ContourBuf, ContourSet, FillRule, GeometryAccuracy, Paint, PathArena, Point,
+    Resolution, shapes,
+};
+
+fn accuracy(mm: f64) -> GeometryAccuracy {
+    GeometryAccuracy::new(mm).unwrap()
+}
+fn resolution(mm: f64) -> Resolution {
+    Resolution::new(1e-6, accuracy(mm))
+}
+fn prepare(contours: &[ContourBuf], mm: f64) -> ContourSet {
+    ContourSet::from_contours(contours, FillRule::EvenOdd, resolution(mm)).unwrap()
+}
+fn distance(region: &ContourSet, p: Point) -> f64 {
+    region
+        .rings
+        .iter()
+        .flat_map(|ring| {
+            ring.iter()
+                .zip(ring.iter().cycle().skip(1))
+                .take(ring.len())
+        })
+        .map(|(&a, &b)| point_segment(p, Point::new(a[0], a[1]), Point::new(b[0], b[1])).0)
+        .fold(f64::INFINITY, f64::min)
+}
+fn radial_error(region: &ContourSet, rx: f64, ry: f64) -> f64 {
+    (0..4096)
+        .map(|i| {
+            let angle = std::f64::consts::TAU * i as f64 / 4096.0;
+            distance(region, Point::new(rx * angle.cos(), ry * angle.sin()))
+        })
+        .fold(0.0, f64::max)
+}
+
+#[test]
+fn circles_converge_with_the_requested_budget() {
+    let circle = shapes::circle(2.0).unwrap();
+    let mut previous = f64::INFINITY;
+    for budget in [0.005, 0.001, 0.0001, 0.00001] {
+        let region = prepare(std::slice::from_ref(&circle), budget);
+        let error = radial_error(&region, 1.0, 1.0);
+        assert!(
+            error <= region.uncertainty_mm,
+            "{error} > {}",
+            region.uncertainty_mm
+        );
+        assert!(region.uncertainty_mm <= budget);
+        assert_eq!(region.budget(), accuracy(budget));
+        assert!(error < previous);
+        previous = error;
+        let measured = region
+            .prepare_query()
+            .nearest_within(Point::ZERO, 2.0)
+            .unwrap();
+        assert_eq!(measured.uncertainty_mm, region.uncertainty_mm);
+        assert!((measured.mm - 1.0).abs() <= measured.uncertainty_mm);
+    }
+}
+
+#[test]
+fn ellipses_are_exact_sources_and_prepare_arbitrarily_fine() {
+    let ellipse = shapes::ellipse(0.4, 0.2).unwrap();
+    assert_eq!(ellipse.uncertainty_mm, 0.0);
+    let coarse = prepare(std::slice::from_ref(&ellipse), 0.005);
+    let fine = prepare(std::slice::from_ref(&ellipse), 0.000001);
+    assert!(radial_error(&fine, 0.2, 0.1) < radial_error(&coarse, 0.2, 0.1));
+    assert!(radial_error(&fine, 0.2, 0.1) <= fine.uncertainty_mm);
+    // Commands that already carry approximation cannot be prepared below it.
+    assert!(
+        ContourSet::from_contours(
+            &[ellipse.with_uncertainty(0.0001)],
+            FillRule::NonZero,
+            resolution(0.00001)
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn coarse_polygon_history_prevents_finer_preparation_and_offsets() {
+    let circle = shapes::circle(0.2).unwrap();
+    let coarse = ContourSet::from_contours(
+        std::slice::from_ref(&circle),
+        FillRule::NonZero,
+        Resolution::new(1e-9, accuracy(0.01)),
+    )
+    .unwrap();
+    assert!(coarse.uncertainty_mm > 0.0001);
+    assert!(
+        ContourSet::from_contours(
+            &coarse.to_contours(),
+            FillRule::NonZero,
+            Resolution::new(1e-9, accuracy(0.0001))
+        )
+        .is_err()
+    );
+    // Tightening the budget below the recorded approximation is refused.
+    assert!(coarse.clone().rebudget(accuracy(0.0001)).is_err());
+    // Loosening always works, and derived regions inherit the budget.
+    let loose = coarse.clone().rebudget(accuracy(0.05)).unwrap();
+    assert_eq!(loose.disk_dilate(0.01).unwrap().budget(), accuracy(0.05));
+    // Polygon round trips through an arena keep their history.
+    let mut source = PathArena::default();
+    let path = source.push_path(
+        Paint::Fill {
+            rule: FillRule::NonZero,
+        },
+        coarse.to_contours(),
+    );
+    let mut copy = PathArena::default();
+    let copied = copy.append_path_from(&source, path, Affine2::IDENTITY);
+    assert!(
+        ContourSet::from_painted_paths(&copy, [copy.path(copied)], resolution(0.0001)).is_err()
+    );
+    let fine = prepare(&[circle], 0.0001);
+    assert!(fine.uncertainty_mm < coarse.uncertainty_mm);
+}
+
+#[test]
+fn explicit_offsets_converge_for_outside_and_concave_inside_rounds() {
+    let rectangle = |budget| {
+        ContourSet::rectangle(
+            BBox::new(Point::ZERO, Point::new(2.0, 2.0)),
+            Resolution::new(0.0, accuracy(budget)),
+        )
+    };
+    assert!(rectangle(0.00001).disk_dilate(0.2).is_err());
+    let concave = |budget| {
+        prepare(
+            &[shapes::closed_polygon(vec![
+                Point::ZERO,
+                Point::new(2.0, 0.0),
+                Point::new(2.0, 1.0),
+                Point::new(1.0, 1.0),
+                Point::new(1.0, 2.0),
+                Point::new(0.0, 2.0),
+            ])
+            .unwrap()],
+            budget,
+        )
+    };
+    for (inset, center) in [(false, Point::ZERO), (true, Point::new(1.0, 1.0))] {
+        let mut previous = f64::INFINITY;
+        for budget in [0.005, 0.001, 0.0001] {
+            let result = if inset {
+                concave(budget).disk_erode(0.2)
+            } else {
+                rectangle(budget).disk_dilate(0.2)
+            }
+            .unwrap();
+            let max_error = (0..1024)
+                .map(|i| {
+                    let angle =
+                        std::f64::consts::PI + std::f64::consts::FRAC_PI_2 * i as f64 / 1023.0;
+                    distance(&result, center + Point::new(angle.cos(), angle.sin()) * 0.2)
+                })
+                .fold(0.0, f64::max);
+            assert!(
+                max_error <= result.uncertainty_mm + 1e-10,
+                "{max_error} > {}",
+                result.uncertainty_mm
+            );
+            assert!(max_error < previous);
+            previous = max_error;
+        }
+    }
+}
+
+#[test]
+fn holes_islands_and_fifty_micron_gaps_survive_fine_preparation() {
+    let outer = shapes::circle(0.6).unwrap();
+    let hole = shapes::circle(0.2).unwrap();
+    let island = shapes::circle(0.2)
+        .unwrap()
+        .transformed(Affine2::translation(Point::new(0.45, 0.0)));
+    let region = prepare(&[outer, hole, island], 0.0001);
+    assert_eq!(region.connected_components().len(), 2);
+    assert!(!region.contains_point(Point::ZERO));
+    assert!(region.contains_point(Point::new(0.2, 0.0)));
+    assert!(!region.contains_point(Point::new(0.325, 0.0)));
+    assert_eq!(
+        region
+            .segment_spans(Point::new(-1.0, 0.0), Point::new(1.0, 0.0))
+            .len(),
+        3
+    );
+    let inset = region
+        .clone()
+        .rebudget(accuracy(0.0005))
+        .unwrap()
+        .disk_erode(0.025)
+        .unwrap();
+    assert_eq!(inset.connected_components().len(), 2);
+    assert_eq!(inset.rings.len(), 3);
+    assert!(!inset.contains_point(Point::new(0.11, 0.0)));
+    for (center, radius) in [
+        (Point::ZERO, 0.275),
+        (Point::ZERO, 0.125),
+        (Point::new(0.45, 0.0), 0.075),
+    ] {
+        for i in 0..512 {
+            let angle = std::f64::consts::TAU * i as f64 / 512.0;
+            assert!(
+                distance(
+                    &inset,
+                    center + Point::new(angle.cos(), angle.sin()) * radius
+                ) <= inset.uncertainty_mm
+            );
+        }
+    }
+    let grown = region
+        .clone()
+        .rebudget(accuracy(0.0005))
+        .unwrap()
+        .disk_dilate(0.01)
+        .unwrap();
+    assert_eq!(grown.connected_components().len(), 2);
+    assert_eq!(grown.rings.len(), 3);
+    let parts = region.connected_components();
+    let clearance = region_clearance(&parts[0], &parts[1]).unwrap();
+    assert!((clearance.mm - 0.05).abs() <= clearance.uncertainty_mm);
+}
+
+#[test]
+fn circles_and_ellipses_survive_arena_copies_and_affine_placement_exactly() {
+    for source in [
+        shapes::ellipse(0.4, 0.2).unwrap(),
+        shapes::circle(0.4).unwrap(),
+    ] {
+        let mut arena = PathArena::default();
+        let path = arena.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            [source.clone()],
+        );
+        let placement = Affine2 {
+            m00: -2.0,
+            m01: 0.3,
+            m02: 5.0,
+            m10: 0.2,
+            m11: 1.0,
+            m12: 7.0,
+        };
+        let mut copy = PathArena::default();
+        let id = copy.append_path_from(&arena, path, placement);
+        copy.compact(&[true]);
+        // The placed copy is still an exact source: no approximation yet.
+        assert_eq!(copy.contours[0].uncertainty_mm, 0.0);
+        let region = ContourSet::from_placed_painted_paths(
+            &copy,
+            [(copy.path(id), Affine2::IDENTITY)],
+            Resolution::new(0.0, accuracy(0.000001)),
+        )
+        .unwrap();
+        let (rx, ry) = (source.bbox.width() / 2.0, source.bbox.height() / 2.0);
+        for i in 0..4096 {
+            let angle = std::f64::consts::TAU * i as f64 / 4096.0;
+            let point = placement.transform_point(Point::new(rx * angle.cos(), ry * angle.sin()));
+            assert!(distance(&region, point) <= region.uncertainty_mm);
+        }
+    }
+}
+
+#[test]
+fn stroke_expansion_carries_its_own_round_cap_floor() {
+    use pcb_ir::geom::{PathCmd, StrokeStyle};
+    let line = ContourBuf::new(vec![
+        PathCmd::move_to(Point::ZERO),
+        PathCmd::line_to(Point::new(1.0, 0.0)),
+    ]);
+    let mut arena = PathArena::default();
+    let path = arena.push_path(Paint::Stroke(StrokeStyle::round(0.2)), [line]);
+    let fine = ContourSet::from_placed_painted_paths(
+        &arena,
+        [(arena.path(path), Affine2::IDENTITY)],
+        Resolution::new(0.0, accuracy(0.0002)),
+    )
+    .unwrap();
+    for i in 0..1024 {
+        let angle = std::f64::consts::FRAC_PI_2 + std::f64::consts::PI * i as f64 / 1023.0;
+        assert!(distance(&fine, Point::new(angle.cos(), angle.sin()) * 0.1) <= fine.uncertainty_mm);
+    }
+    assert!(
+        ContourSet::from_placed_painted_paths(
+            &arena,
+            [(arena.path(path), Affine2::IDENTITY)],
+            Resolution::new(0.0, accuracy(0.000001))
+        )
+        .is_err()
+    );
+}
+
+#[test]
+fn fine_artwork_budgets_reach_flashes_and_instanced_arcs() {
+    use pcb_ir::dialects::{LayerRole, Side, artwork};
+    use pcb_ir::geom::Polarity;
+    for instance in [false, true] {
+        let mut doc = artwork::Document::<(), ()>::new();
+        let layer = doc.push_layer(artwork::Layer::new("F.Cu", LayerRole::Copper, Side::Top));
+        let transform = Affine2 {
+            m00: 2.0,
+            m11: 0.5,
+            ..Affine2::IDENTITY
+        };
+        let geometry = if instance {
+            let block = doc.push_block();
+            let path = doc.push_path(
+                Paint::Fill {
+                    rule: FillRule::NonZero,
+                },
+                vec![shapes::circle(2.0).unwrap()],
+            );
+            doc.push_block_object(
+                block,
+                artwork::Object::new(Polarity::Dark, artwork::Geometry::Region { path }),
+            );
+            artwork::Geometry::Instance { block, transform }
+        } else {
+            let aperture = doc.push_aperture(artwork::Aperture::circle(2.0));
+            artwork::Geometry::Flash {
+                aperture,
+                transform,
+            }
+        };
+        doc.push_object(layer, artwork::Object::new(Polarity::Dark, geometry));
+        let (layers, _) = artwork::compose_owner_regions(
+            &doc,
+            |_| Some(()),
+            Resolution::new(0.0, accuracy(1e-6)),
+        )
+        .unwrap();
+        let region = &layers[0][0].1;
+        assert!(region.uncertainty_mm <= 1e-6);
+        assert!(radial_error(region, 2.0, 0.5) <= region.uncertainty_mm);
+    }
+}
+
+#[test]
+fn stroke_budget_reserves_and_records_coordinate_error() {
+    use pcb_ir::geom::{
+        LineCap, LineJoin, PathCmd,
+        path::{StrokeToFillStyle, stroke_to_fill},
+    };
+    let line = ContourBuf::new(vec![
+        PathCmd::move_to(Point::new(1e9, 0.0)),
+        PathCmd::line_to(Point::new(1e9 + 1.0, 0.0)),
+    ])
+    .with_uncertainty(0.00005);
+    let style = StrokeToFillStyle::new(0.2, LineCap::Round, LineJoin::Round);
+    assert!(stroke_to_fill(std::slice::from_ref(&line), style, accuracy(0.0001)).is_err());
+    let outlines = stroke_to_fill(&[line], style, accuracy(0.0002))
+        .unwrap()
+        .unwrap();
+    for outline in outlines {
+        assert!(outline.uncertainty_mm >= 0.00005 + 0.00004 + 64.0 * f64::EPSILON * 1e9);
+        assert!(outline.uncertainty_mm <= 0.0002);
+    }
+}
+
+#[test]
+fn tiny_rings_do_not_suppress_clearance_findings() {
+    let resolution = Resolution::default();
+    let first = ContourSet::from_regularized(
+        vec![
+            vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
+            vec![[4.0, 4.0], [4.0001, 4.0], [4.0, 4.0001]],
+        ],
+        resolution,
+        0.0,
+    );
+    let second = ContourSet::rectangle(
+        BBox::new(Point::new(1.05, 0.0), Point::new(2.0, 1.0)),
+        resolution,
+    );
+    let clipped = first.difference(&second);
+    let clearance = region_clearance(&clipped, &second).unwrap();
+    assert!(clearance.certainly_below(0.1));
+}
+
+#[test]
+fn stroke_preparation_uses_the_total_inherited_error_budget() {
+    use pcb_ir::dialects::{LayerRole, Side, artwork};
+    use pcb_ir::geom::{LineCap, LineJoin, PathCmd, Polarity, StrokeStyle};
+    let source = ContourBuf::new(vec![
+        PathCmd::move_to(Point::ZERO),
+        PathCmd::line_to(Point::new(1.0, 0.0)),
+    ])
+    .with_uncertainty(0.008);
+    let paint = Paint::Stroke(StrokeStyle {
+        join: LineJoin::Miter,
+        ..StrokeStyle::new(0.2, LineCap::Butt)
+    });
+    let mut doc = artwork::Document::<(), ()>::new();
+    let layer = doc.push_layer(artwork::Layer::new("F.Cu", LayerRole::Copper, Side::Top));
+    let path = doc.push_path(paint, vec![source]);
+    doc.push_object(
+        layer,
+        artwork::Object::new(Polarity::Dark, artwork::Geometry::Stroke { path }),
+    );
+    let resolution = Resolution::new(0.0, accuracy(0.01));
+    let direct = ContourSet::from_placed_painted_paths(
+        &doc.arena,
+        [(doc.arena.path(path), Affine2::IDENTITY)],
+        resolution,
+    )
+    .unwrap();
+    assert!((0.008..=0.01).contains(&direct.uncertainty_mm));
+    let (layers, _) = artwork::compose_owner_regions(&doc, |_| Some(()), resolution).unwrap();
+    assert!((0.008..=0.01).contains(&layers[0][0].1.uncertainty_mm));
+}
+
+#[test]
+fn fine_geometry_reports_widths_inside_the_legacy_blind_band() {
+    use pcb_ir::geom::dfm::{thin_features, thin_gaps};
+    let rect = |x0, y0, x1, y1| {
+        ContourSet::rectangle(
+            BBox::new(Point::new(x0, y0), Point::new(x1, y1)),
+            Resolution::new(1e-6, accuracy(0.01)),
+        )
+    };
+    let feature = rect(0.0, 0.0, 1.0, 0.095);
+    assert!(!thin_features(&feature, 0.1).unwrap().is_empty());
+    let gap = rect(0.0, 0.0, 1.0, 1.0).union(&rect(1.095, 0.0, 2.0, 1.0));
+    assert!(!thin_gaps(&gap, 0.1).unwrap().is_empty());
+}
+
+#[test]
+fn polygon_rounding_and_filled_union_respect_total_budget() {
+    let polygon = ContourSet::from_rings(
+        vec![vec![
+            [1e9, 0.0],
+            [1e9 + 1.0, 0.0],
+            [1e9 + 1.0, 1.0],
+            [1e9, 1.0],
+        ]],
+        FillRule::NonZero,
+        Resolution::new(0.0, accuracy(0.01)),
+    );
+    assert!(polygon.uncertainty_mm > 0.0);
+    assert!(
+        polygon
+            .clone()
+            .rebudget(accuracy(polygon.uncertainty_mm / 2.0))
+            .is_err()
+    );
+    let contours = polygon.to_contours();
+    let prepared = ContourSet::from_contours(
+        &contours,
+        FillRule::EvenOdd,
+        Resolution::new(0.0, accuracy(0.01)),
+    )
+    .unwrap();
+    assert!(
+        ContourSet::from_filled_contours(
+            &contours,
+            Resolution::new(0.0, accuracy(prepared.uncertainty_mm * 1.1))
+        )
+        .is_err()
+    );
+}

--- a/crates/pcb-ir/tests/geometry_accuracy.rs
+++ b/crates/pcb-ir/tests/geometry_accuracy.rs
@@ -379,7 +379,7 @@ fn tiny_rings_do_not_suppress_clearance_findings() {
         BBox::new(Point::new(1.05, 0.0), Point::new(2.0, 1.0)),
         resolution,
     );
-    let clipped = first.difference(&second);
+    let clipped = first.difference(&second).unwrap();
     let clearance = region_clearance(&clipped, &second).unwrap();
     assert!(clearance.certainly_below(0.1));
 }
@@ -427,7 +427,9 @@ fn fine_geometry_reports_widths_inside_the_legacy_blind_band() {
     };
     let feature = rect(0.0, 0.0, 1.0, 0.095);
     assert!(!thin_features(&feature, 0.1).unwrap().is_empty());
-    let gap = rect(0.0, 0.0, 1.0, 1.0).union(&rect(1.095, 0.0, 2.0, 1.0));
+    let gap = rect(0.0, 0.0, 1.0, 1.0)
+        .union(&rect(1.095, 0.0, 2.0, 1.0))
+        .unwrap();
     assert!(!thin_gaps(&gap, 0.1).unwrap().is_empty());
 }
 
@@ -442,7 +444,8 @@ fn polygon_rounding_and_filled_union_respect_total_budget() {
         ]],
         FillRule::NonZero,
         Resolution::new(0.0, accuracy(0.01)),
-    );
+    )
+    .unwrap();
     assert!(polygon.uncertainty_mm > 0.0);
     assert!(
         polygon

--- a/crates/pcb-ir/tests/region_query.rs
+++ b/crates/pcb-ir/tests/region_query.rs
@@ -1,5 +1,6 @@
 //! Public prepared-region API, including the headless placed-path consumer.
 
+use pcb_ir::geom::Resolution;
 use pcb_ir::geom::dist::{self, Distance};
 use pcb_ir::geom::region::{ring_edges, rings_to_contours};
 use pcb_ir::geom::{
@@ -28,8 +29,10 @@ fn query(prepared: &PreparedRegion, point: Point, expected: f64) -> Distance {
 
 #[test]
 fn boundary_and_near_boundary_points_keep_their_signed_distance() {
-    let region =
-        ContourSet::rectangle(BBox::new(Point::ZERO, Point::new(4.0, 4.0)), tol::REGION_MM);
+    let region = ContourSet::rectangle(
+        BBox::new(Point::ZERO, Point::new(4.0, 4.0)),
+        Resolution::default(),
+    );
     let prepared = region.prepare_query();
     for point in [
         Point::ZERO,
@@ -53,7 +56,7 @@ fn boundary_and_near_boundary_points_keep_their_signed_distance() {
 
 #[test]
 fn concave_corners_return_a_euclidean_boundary_witness() {
-    let region = ContourSet::new(
+    let region = ContourSet::from_rings(
         vec![vec![
             [0.0, 0.0],
             [6.0, 0.0],
@@ -63,7 +66,7 @@ fn concave_corners_return_a_euclidean_boundary_witness() {
             [0.0, 6.0],
         ]],
         FillRule::NonZero,
-        tol::REGION_MM,
+        Resolution::default(),
     );
     let prepared = region.prepare_query();
     for (point, expected, witness) in [
@@ -88,7 +91,7 @@ fn nested_rings() -> Vec<Ring> {
 
 #[test]
 fn holes_nested_islands_and_separate_islands_follow_the_fill_rule() {
-    let region = ContourSet::new(nested_rings(), FillRule::EvenOdd, tol::REGION_MM);
+    let region = ContourSet::from_rings(nested_rings(), FillRule::EvenOdd, Resolution::default());
     let prepared = region.prepare_query();
     for (point, expected) in [
         (Point::new(1.0, 5.0), -1.0),
@@ -100,7 +103,7 @@ fn holes_nested_islands_and_separate_islands_follow_the_fill_rule() {
     ] {
         query(&prepared, point, expected);
     }
-    let filled = ContourSet::new(nested_rings(), FillRule::NonZero, tol::REGION_MM);
+    let filled = ContourSet::from_rings(nested_rings(), FillRule::NonZero, Resolution::default());
     query(&filled.prepare_query(), Point::new(3.0, 5.0), -3.0);
 }
 
@@ -120,8 +123,9 @@ fn headless_placements_transform_holes_distances_and_witnesses() {
             let region = ContourSet::from_placed_painted_paths(
                 &arena,
                 [(arena.path(id), transform)],
-                tol::REGION_MM,
-            );
+                Resolution::default(),
+            )
+            .unwrap();
             let prepared = region.prepare_query();
             for (point, expected, witness) in [
                 (Point::new(3.0, 2.5), 0.5, Point::new(3.0, 2.0)),
@@ -150,8 +154,9 @@ fn curve_distance_bands_cover_the_source_circle() {
     let region = ContourSet::from_contours(
         &[shapes::circle(2.0 * radius).unwrap()],
         FillRule::NonZero,
-        tol::REGION_MM,
-    );
+        Resolution::default(),
+    )
+    .unwrap();
     let prepared = region.prepare_query();
     for index in 0..128 {
         let angle = (index as f64 + 0.37) * std::f64::consts::TAU / 128.0;
@@ -176,7 +181,7 @@ fn batches_match_exhaustive_measurements_and_repeated_queries() {
         let y = (index / 8) as f64 * 4.0;
         rings.push(vec![[x, y], [x + 2.0, y], [x + 1.0, y + 3.0]]);
     }
-    let region = ContourSet::new(rings, FillRule::EvenOdd, tol::REGION_MM);
+    let region = ContourSet::from_rings(rings, FillRule::EvenOdd, Resolution::default());
     let prepared = region.prepare_query();
     let points = (0..51)
         .flat_map(|x| {
@@ -242,23 +247,24 @@ fn batches_match_exhaustive_measurements_and_repeated_queries() {
 #[test]
 fn empty_degenerate_and_invalid_queries_have_no_witness() {
     for region in [
-        ContourSet::empty(0.0),
+        ContourSet::empty(Resolution::default().with_tolerance(0.0)),
         ContourSet::from_regularized(
             vec![
                 vec![],
                 vec![[1.0, 1.0]],
                 vec![[0.0, 0.0], [1.0, 1.0], [2.0, 2.0]],
             ],
+            Resolution::default().with_tolerance(0.0),
             0.0,
         ),
     ] {
         let prepared = region.prepare_query();
         assert_eq!(prepared.signed_distance(Point::ZERO), None);
     }
-    let prepared = ContourSet::new(
+    let prepared = ContourSet::from_rings(
         vec![rectangle(0.0, 0.0, 2.0, 2.0)],
         FillRule::NonZero,
-        tol::REGION_MM,
+        Resolution::default(),
     )
     .prepare_query();
     let points = [
@@ -274,8 +280,12 @@ fn empty_degenerate_and_invalid_queries_have_no_witness() {
 
 #[test]
 fn short_nonzero_edges_remain_segments() {
-    let prepared =
-        ContourSet::from_regularized(vec![rectangle(0.0, 0.0, 1e-8, 1e-8)], 0.0).prepare_query();
+    let prepared = ContourSet::from_regularized(
+        vec![rectangle(0.0, 0.0, 1e-8, 1e-8)],
+        Resolution::default().with_tolerance(0.0),
+        0.0,
+    )
+    .prepare_query();
     let distance = prepared.signed_distance(Point::new(1e-9, 5e-9)).unwrap();
     assert!((distance.mm + 1e-9).abs() < 1e-20, "{distance:?}");
     assert!(distance.second.distance_to(Point::new(0.0, 5e-9)) < 1e-20);
@@ -290,7 +300,11 @@ fn far_translated_rings_keep_area_holes_and_distances() {
         assert_eq!(pcb_ir::geom::region::ring_signed_area(&outer), 16.0);
         assert_eq!(pcb_ir::geom::region::ring_signed_area(&hole), -4.0);
         for tolerance in [0.0, tol::REGION_MM] {
-            let region = ContourSet::from_regularized(vec![outer.clone(), hole.clone()], tolerance);
+            let region = ContourSet::from_regularized(
+                vec![outer.clone(), hole.clone()],
+                Resolution::default().with_tolerance(tolerance),
+                0.0,
+            );
             assert_eq!(region.rings.len(), 2);
             let prepared = region.prepare_query();
             for (offset, expected) in [(0.5, -0.5), (2.0, 1.0), (5.0, 1.0)] {

--- a/crates/pcb-ir/tests/region_query.rs
+++ b/crates/pcb-ir/tests/region_query.rs
@@ -67,7 +67,8 @@ fn concave_corners_return_a_euclidean_boundary_witness() {
         ]],
         FillRule::NonZero,
         Resolution::default(),
-    );
+    )
+    .unwrap();
     let prepared = region.prepare_query();
     for (point, expected, witness) in [
         (Point::new(3.0, 3.5), 1.0, Point::new(2.0, 3.5)),
@@ -91,7 +92,8 @@ fn nested_rings() -> Vec<Ring> {
 
 #[test]
 fn holes_nested_islands_and_separate_islands_follow_the_fill_rule() {
-    let region = ContourSet::from_rings(nested_rings(), FillRule::EvenOdd, Resolution::default());
+    let region =
+        ContourSet::from_rings(nested_rings(), FillRule::EvenOdd, Resolution::default()).unwrap();
     let prepared = region.prepare_query();
     for (point, expected) in [
         (Point::new(1.0, 5.0), -1.0),
@@ -103,7 +105,8 @@ fn holes_nested_islands_and_separate_islands_follow_the_fill_rule() {
     ] {
         query(&prepared, point, expected);
     }
-    let filled = ContourSet::from_rings(nested_rings(), FillRule::NonZero, Resolution::default());
+    let filled =
+        ContourSet::from_rings(nested_rings(), FillRule::NonZero, Resolution::default()).unwrap();
     query(&filled.prepare_query(), Point::new(3.0, 5.0), -3.0);
 }
 
@@ -181,7 +184,7 @@ fn batches_match_exhaustive_measurements_and_repeated_queries() {
         let y = (index / 8) as f64 * 4.0;
         rings.push(vec![[x, y], [x + 2.0, y], [x + 1.0, y + 3.0]]);
     }
-    let region = ContourSet::from_rings(rings, FillRule::EvenOdd, Resolution::default());
+    let region = ContourSet::from_rings(rings, FillRule::EvenOdd, Resolution::default()).unwrap();
     let prepared = region.prepare_query();
     let points = (0..51)
         .flat_map(|x| {
@@ -266,6 +269,7 @@ fn empty_degenerate_and_invalid_queries_have_no_witness() {
         FillRule::NonZero,
         Resolution::default(),
     )
+    .unwrap()
     .prepare_query();
     let points = [
         Point::new(f64::NAN, 1.0),

--- a/crates/pcbc/src/dfm.rs
+++ b/crates/pcbc/src/dfm.rs
@@ -1,3 +1,4 @@
+use pcb_ir::geom::Resolution;
 use std::path::PathBuf;
 
 use anyhow::{Context, Result};
@@ -31,6 +32,8 @@ pub struct DfmArgs {
 }
 
 pub fn execute(args: DfmArgs) -> Result<()> {
+    let resolution = Resolution::default();
+
     let temporary_output = if args.open && args.output.is_none() {
         Some(tempfile::tempdir().context("failed to create temporary DFM report directory")?)
     } else {
@@ -56,7 +59,7 @@ pub fn execute(args: DfmArgs) -> Result<()> {
     commands::dfm::validate_output(&args.file, &options)?;
     let dfm_result = match export_layout(&args) {
         Ok((_temporary_dir, ipc_path)) => {
-            match commands::dfm::execute_check(&ipc_path, &options)? {
+            match commands::dfm::execute_check(&ipc_path, &options, resolution)? {
                 commands::dfm::CheckOutcome::Passed => Ok(()),
                 commands::dfm::CheckOutcome::Failed(error) => Err(error),
             }

--- a/crates/pcbc/src/gerber.rs
+++ b/crates/pcbc/src/gerber.rs
@@ -1,3 +1,4 @@
+use pcb_ir::geom::{GeometryAccuracy, Resolution};
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, bail};
@@ -85,9 +86,11 @@ pub fn execute(args: GerberArgs) -> Result<()> {
 }
 
 fn normalize(file: &Path, output: Option<&Path>) -> Result<()> {
+    let accuracy = GeometryAccuracy::default();
+
     let gerber = gerberx2::GerberX2::parse_file(file)
         .with_context(|| format!("failed to parse Gerber file {}", file.display()))?;
-    let normalized = gerberx2::from_artwork::normalize_layer(&gerber)
+    let normalized = gerberx2::from_artwork::normalize_layer(&gerber, accuracy)
         .with_context(|| format!("failed to normalize Gerber file {}", file.display()))?;
     match output {
         Some(path) => std::fs::write(path, normalized)
@@ -103,8 +106,10 @@ fn compare(
     bbox_tolerance_mm: f64,
     area_tolerance_mm2: f64,
 ) -> Result<()> {
-    let reference_geometry = load_geometry(reference)?;
-    let candidate_geometry = load_geometry(candidate)?;
+    let resolution = Resolution::default();
+
+    let reference_geometry = load_geometry(reference, resolution.accuracy)?;
+    let candidate_geometry = load_geometry(candidate, resolution.accuracy)?;
     let report = pcb_ir::dialects::artwork::compare::compare_documents(
         &reference_geometry,
         &candidate_geometry,
@@ -112,7 +117,8 @@ fn compare(
             bbox_mm: bbox_tolerance_mm,
             area_mm2: area_tolerance_mm2,
         },
-    );
+        resolution,
+    )?;
 
     println!(
         "reference area {:.6} mm², candidate area {:.6} mm², delta {:.6} mm²",
@@ -176,8 +182,10 @@ fn print_difference_components(
 }
 
 fn render(file: &Path, output: Option<&Path>, format: RenderFormat) -> Result<()> {
+    let resolution = Resolution::default();
+
     let target = resolve_target(output, format)?;
-    let geometry = load_geometry(file)?;
+    let geometry = load_geometry(file, resolution.accuracy)?;
 
     for diagnostic in &geometry.diagnostics {
         eprintln!("warning: {}", diagnostic.message);
@@ -185,7 +193,7 @@ fn render(file: &Path, output: Option<&Path>, format: RenderFormat) -> Result<()
 
     match target {
         RenderTarget::Svg => {
-            let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry);
+            let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry, resolution)?;
             let svg = pcb_ir::render::svg(&mask, &pcb_ir::render::RenderOptions::default());
             if let Some(output) = output {
                 std::fs::write(output, svg)
@@ -196,7 +204,7 @@ fn render(file: &Path, output: Option<&Path>, format: RenderFormat) -> Result<()
             }
         }
         RenderTarget::Png => {
-            let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry);
+            let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry, resolution)?;
             let png = pcb_ir::render::png(&mask, &pcb_ir::render::RenderOptions::default())
                 .map_err(gerberx2::GerberError::Render)?;
             if let Some(output) = output {
@@ -209,7 +217,7 @@ fn render(file: &Path, output: Option<&Path>, format: RenderFormat) -> Result<()
             }
         }
         RenderTarget::Terminal => {
-            let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry);
+            let mask = pcb_ir::dialects::artwork::compose_to_mask(&geometry, resolution)?;
             pcb_ir::render::to_terminal(&mask, &pcb_ir::render::RenderOptions::default())
                 .map_err(gerberx2::GerberError::Render)?;
         }
@@ -218,10 +226,13 @@ fn render(file: &Path, output: Option<&Path>, format: RenderFormat) -> Result<()
     Ok(())
 }
 
-fn load_geometry(file: &Path) -> Result<gerberx2::geometry::GerberArtworkDocument> {
+fn load_geometry(
+    file: &Path,
+    accuracy: GeometryAccuracy,
+) -> Result<gerberx2::geometry::GerberArtworkDocument> {
     let gerber = gerberx2::GerberX2::parse_file(file)
         .with_context(|| format!("Failed to parse Gerber file {}", file.display()))?;
-    Ok(gerberx2::geometry::extract_document(&gerber))
+    Ok(gerberx2::geometry::extract_document(&gerber, accuracy)?)
 }
 
 fn resolve_target(output: Option<&Path>, format: RenderFormat) -> Result<RenderTarget> {

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -1,4 +1,5 @@
 use clap::{Args, Subcommand, ValueEnum};
+use pcb_ir::geom::Resolution;
 use std::path::PathBuf;
 
 use pcb_ipc2581_tools::{
@@ -339,6 +340,8 @@ impl FabPanelSize {
 }
 
 pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
+    let resolution = Resolution::default();
+
     utils::color::init_color();
 
     match args.command {
@@ -350,7 +353,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
         Commands::Assembly { file, scope } => {
             let ipc = pcb_ipc2581_tools::ipc2581::Ipc2581::parse_file(&file)?;
             let imported = pcb_ir::import::ipc2581::import_design(&ipc)?;
-            let report = pcb_ipc2581_tools::assembly::build_report(&imported, scope)?;
+            let report = pcb_ipc2581_tools::assembly::build_report(&imported, scope, resolution)?;
             let output = serde_json::to_vec_pretty(&report)?;
             pcb_ui::write_stdout(|stdout| {
                 stdout.write_all(&output)?;
@@ -475,7 +478,13 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                             "--auto/--sheet cannot be combined with manual board array options"
                         );
                     }
-                    commands::board_array::execute_auto(&input, &output, sheet, copper_balance)
+                    commands::board_array::execute_auto(
+                        &input,
+                        &output,
+                        sheet,
+                        copper_balance,
+                        resolution,
+                    )
                 } else {
                     let board_margin_mm = if board_margin.is_empty() {
                         commands::board_array::BoardMarginMm::all(5.0)
@@ -581,6 +590,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                     output,
                     layout_target,
                 },
+                resolution,
             )? {
                 commands::dfm::CheckOutcome::Passed => Ok(()),
                 commands::dfm::CheckOutcome::Failed(error) => Err(error),
@@ -593,13 +603,14 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             output,
             debug_reliefs,
         } => {
-            let package = manufacturing::execute_file_with_options(
+            let package = manufacturing::export_manufacturing_package(
                 &file,
+                &output,
                 &manufacturing::ManufacturingExportOptions {
-                    output: output.clone(),
                     view: layout_target.artwork_scope(),
                     relief_debug_dir: debug_reliefs,
                 },
+                resolution,
             )?;
             println!(
                 "✓ IPC-2581 exported {} manufacturing file(s) to {}",

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use clap::ValueEnum;
 use log::{debug, warn};
+use pcb_ir::geom::Resolution;
 use pcb_kicad::{KiCadCliBuilder, ensure_board_compatible_with_installed_kicad};
 use pcb_layout::utils as layout_utils;
 use pcb_ui::{Colorize, Spinner, Style, StyledText};
@@ -1332,6 +1333,8 @@ fn generate_odb(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
 
 /// Generate IPC-2581 file
 fn generate_ipc2581(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
+    let resolution = Resolution::default();
+
     let manufacturing_dir = info.staging_dir.join("manufacturing");
     fs::create_dir_all(&manufacturing_dir)?;
 
@@ -1352,6 +1355,7 @@ fn generate_ipc2581(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
     let html = pcb_ipc2581_tools::commands::html_export::generate_html(
         &accessor,
         pcb_ipc2581_tools::UnitFormat::Mm,
+        resolution,
     )
     .context("Failed to generate HTML from IPC-2581")?;
     fs::write(&ipc2581_html_path, html).context("Failed to write IPC-2581 HTML export")?;

--- a/crates/pcbc/tests/dfm.rs
+++ b/crates/pcbc/tests/dfm.rs
@@ -583,11 +583,18 @@ fn ipc_dfm_geometry_distinguishes_canonical_board_arrays_and_mixed_fab_scope() {
         board_margin_mm: EdgeInsetsMm::all(5.0),
         edge_rail_mm: EdgeInsetsMm::all(5.0),
     };
-    let first = create_board_array(IPC_BOARD, &array_options, false).unwrap();
+    let first = create_board_array(
+        IPC_BOARD,
+        &array_options,
+        false,
+        pcb_ir::geom::Resolution::default(),
+    )
+    .unwrap();
     let second = create_board_array(
         &IPC_BOARD.replace("name=\"board\"", "name=\"other\""),
         &array_options,
         false,
+        pcb_ir::geom::Resolution::default(),
     )
     .unwrap();
     let mut sandbox = Sandbox::new();


### PR DESCRIPTION
Regions carry the resolution they were prepared at, so approximation budgets are chosen once and inherited instead of threaded through every signature. Elliptical arcs close the IR under affine transforms, making placement and expansion exact.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches Gerber round-trip geometry, manufacturing export, and panel copper balancing with new accuracy contracts and widespread API signature changes that can shift areas and fail exports when budgets are too tight.
> 
> **Overview**
> Introduces **`GeometryAccuracy`** and **`Resolution`** as the shared budget for curve approximation, region preparation, and composition. Curved geometry (cubics, ellipses, circles) is flattened or prepared within that budget instead of fixed step counts or implicit tolerances.
> 
> **Gerber X2** paths now require an accuracy argument: `extract_document`, `lower_artwork_layer`, and `normalize_layer` propagate it through region export (`prepare_on_grid` checks uncertainty against the 0.001 mm grid), stroke/region lowering (`ContourBuf::flattened_curves`), and shaped-aperture sweeps (accuracy-based arc subdivision plus continuous boundary sweeps with subdivision limits). `GerberError` surfaces **`AccuracyError`**.
> 
> **IPC-2581 tooling and WASM** thread **`Resolution::default()`** (or explicit resolution) through DFM, manufacturing export, layer render/SVG/PNG, assembly reports, drill stats, board-array overview SVG, copper balancing, and CPL/ICT—often via **`ImportedDesign`** instead of re-parsing geometry ad hoc. Board-array balancing drops the separate **`numerical_guard_mm`** CLI flag in favor of construction clearance derived from resolution; assembly path reporting adds **`EllipseTo`**.
> 
> Tests and examples are updated for the new signatures; changelog notes exact circles/ellipses through placement, export, and rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55bb597ee464b7637466281d86830422c57ee26e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->