### PR TITLE
fix(schematic): allow placement outside page bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Place generated schematic content outside the page when it cannot fit, instead of failing schematic apply.
+- Place generated schematic content outside the page when it cannot fit, instead of failing schematic apply, and reserve space for existing text and graphics.
 
 ## [0.4.49] - 2026-09-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Place generated schematic content outside the page when it cannot fit, instead of failing schematic apply.
+
 ## [0.4.49] - 2026-09-04
 
 ### Added

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -3816,6 +3816,30 @@ mod tests {
     }
 
     #[test]
+    fn shallow_page_arc_does_not_force_overflow() {
+        let mut page = SchPage::new("shallow-arc");
+        page.items.push(SchItem::Unsupported(
+            pcb_sexpr::parse("(arc (start 10 10) (mid 20 9.9) (end 30 10))").unwrap(),
+        ));
+        let block = test_placement_block(
+            "new",
+            GridRect {
+                min_x: 0,
+                min_y: 0,
+                max_x: 100,
+                max_y: 60,
+            },
+        );
+        let (mut packer, bounds, _) =
+            arrange_existing_page_blocks(&page, &[&block], &BTreeSet::new()).unwrap();
+        assert!(packer.can_place_without_overlap(bounds));
+        let placed = bounds.translated(packer.place_anchored(bounds));
+        let usable = packer.usable_bounds();
+        assert!(placed.min_x >= usable.min_x && placed.max_x <= usable.max_x);
+        assert!(placed.min_y >= usable.min_y && placed.max_y <= usable.max_y);
+    }
+
+    #[test]
     fn overflow_avoids_opaque_page_text_and_graphics() {
         for (source, right_edge) in [
             (

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -1004,11 +1004,11 @@ fn arrange_new_page_blocks(
 ) -> Result<(GridPacker, GridRect, Vec<GridPoint>)> {
     for paper in placement_paper_candidates(&page.paper) {
         let packer = occupied_page_packer(page, &paper, excluded_symbol_ids)?;
-        if let Some((bounds, offsets)) = arrange_placement_blocks(blocks, &packer) {
-            if packer.can_place_without_overlap(bounds) {
-                page.paper = paper;
-                return Ok((packer, bounds, offsets));
-            }
+        if let Some((bounds, offsets)) = arrange_placement_blocks(blocks, &packer)
+            && packer.can_place_without_overlap(bounds)
+        {
+            page.paper = paper;
+            return Ok((packer, bounds, offsets));
         }
     }
     arrange_existing_page_blocks(page, blocks, excluded_symbol_ids)

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -964,9 +964,8 @@ fn pack_generated_symbols(
             .filter(|block| block.page_index == page_index)
             .collect::<Vec<_>>();
         // Fit and placement share one occupancy: the title block, hierarchy
-        // sheets, and every preserved item. A batch that fits therefore has
-        // a collision-free spot, and place_anchored takes that spot rather
-        // than its least-overlap fallback over preserved work.
+        // sheets, and every preserved item. If no grid fits, placement spills
+        // outside the page rather than covering preserved work.
         let relocatable_ids = relocatable
             .iter()
             .map(|slot| slot.symbol_id())
@@ -1006,14 +1005,13 @@ fn arrange_new_page_blocks(
     for paper in placement_paper_candidates(&page.paper) {
         let packer = occupied_page_packer(page, &paper, excluded_symbol_ids)?;
         if let Some((bounds, offsets)) = arrange_placement_blocks(blocks, &packer) {
-            page.paper = paper;
-            return Ok((packer, bounds, offsets));
+            if packer.can_place_without_overlap(bounds) {
+                page.paper = paper;
+                return Ok((packer, bounds, offsets));
+            }
         }
     }
-    bail!(
-        "generated component batch is too large for automatic schematic placement on {}",
-        page.file_name.as_deref().unwrap_or(&page.id)
-    )
+    arrange_existing_page_blocks(page, blocks, excluded_symbol_ids)
 }
 
 fn arrange_existing_page_blocks(
@@ -1022,12 +1020,8 @@ fn arrange_existing_page_blocks(
     excluded_symbol_ids: &BTreeSet<String>,
 ) -> Result<(GridPacker, GridRect, Vec<GridPoint>)> {
     let packer = occupied_page_packer(page, &page.paper, excluded_symbol_ids)?;
-    let Some((bounds, offsets)) = arrange_placement_blocks(blocks, &packer) else {
-        bail!(
-            "generated component batch does not fit existing schematic page {}",
-            page.file_name.as_deref().unwrap_or(&page.id)
-        );
-    };
+    let (bounds, offsets) =
+        arrange_placement_blocks(blocks, &packer).expect("a generated cohort has blocks");
     Ok((packer, bounds, offsets))
 }
 
@@ -1093,21 +1087,25 @@ fn arrange_placement_blocks(
     packer: &GridPacker,
 ) -> Option<(GridRect, Vec<GridPoint>)> {
     // Pick one page-shaped shelf grid for the whole generated cohort, among
-    // the column counts the page still has room for. Placing the grid as a
-    // unit avoids the radial pattern produced by repeatedly extending a
-    // centered cluster one block at a time.
+    // the column counts, preferring those the page still has room for.
+    // Placing the grid as a unit avoids the radial pattern produced by
+    // repeatedly extending a centered cluster one block at a time.
     let usable = packer.usable_bounds();
     (1..=blocks.len())
         .map(|columns| {
             let (bounds, offsets) = placement_grid_with_columns(blocks, columns);
             (columns, bounds, offsets)
         })
-        .filter(|(_, bounds, _)| packer.can_place_without_overlap(*bounds))
         .min_by_key(|(columns, bounds, _)| {
             let aspect_error = (i64::from(bounds.width()) * i64::from(usable.height())
                 - i64::from(bounds.height()) * i64::from(usable.width()))
             .abs();
-            (aspect_error, bounds.area(), *columns)
+            (
+                !packer.can_place_without_overlap(*bounds),
+                aspect_error,
+                bounds.area(),
+                *columns,
+            )
         })
         .map(|(_, bounds, offsets)| (bounds, offsets))
 }
@@ -3804,18 +3802,48 @@ mod tests {
         assert!(
             arrange_existing_page_blocks(&SchPage::new("empty"), &blocks, &BTreeSet::new()).is_ok()
         );
-        let error = arrange_existing_page_blocks(
-            &test_page_with_sheet("occupied"),
-            &blocks,
-            &BTreeSet::new(),
-        )
-        .err()
-        .expect("a covered page rejects the batch");
-        assert!(
-            error
-                .to_string()
-                .contains("does not fit existing schematic page")
+        let page = test_page_with_sheet("occupied");
+        let (mut packer, bounds, _) =
+            arrange_existing_page_blocks(&page, &blocks, &BTreeSet::new()).unwrap();
+        assert!(!packer.can_place_without_overlap(bounds));
+        let placed = bounds.translated(packer.place_anchored(bounds));
+        assert!(placed.min_x > packer.usable_bounds().max_x);
+        assert_eq!(page.paper, Paper::default());
+    }
+
+    #[test]
+    fn oversized_batches_spill_outside_new_and_existing_pages() {
+        let block = test_placement_block(
+            "oversized",
+            GridRect {
+                min_x: -10,
+                min_y: -20,
+                max_x: 2000,
+                max_y: 2000,
+            },
         );
+        for paper in [
+            Paper::default(),
+            Paper::Custom {
+                width_mm: 5.0,
+                height_mm: 5.0,
+            },
+        ] {
+            let mut page = SchPage::new("overflow");
+            page.paper = paper.clone();
+            for new_page in [false, true] {
+                let (mut packer, bounds, offsets) = if new_page {
+                    arrange_new_page_blocks(&mut page, &[&block], &BTreeSet::new())
+                } else {
+                    arrange_existing_page_blocks(&page, &[&block], &BTreeSet::new())
+                }
+                .unwrap();
+                let placed = bounds.translated(packer.place_anchored(bounds));
+                assert!(placed.min_x > packer.usable_bounds().max_x);
+                assert_eq!(offsets.len(), 1);
+                assert_eq!(page.paper, paper);
+            }
+        }
     }
 
     fn multi_pad_symbol() -> BTreeMap<SymbolSlotKey, PlacedSymbol> {

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -964,8 +964,8 @@ fn pack_generated_symbols(
             .filter(|block| block.page_index == page_index)
             .collect::<Vec<_>>();
         // Fit and placement share one occupancy: the title block, hierarchy
-        // sheets, and every preserved item. If no grid fits, placement spills
-        // outside the page rather than covering preserved work.
+        // sheets, and preserved items with known bounds. If no grid fits,
+        // placement spills outside the page rather than covering that work.
         let relocatable_ids = relocatable
             .iter()
             .map(|slot| slot.symbol_id())
@@ -1025,9 +1025,8 @@ fn arrange_existing_page_blocks(
     Ok((packer, bounds, offsets))
 }
 
-/// A packer for `paper` with the page's title block and every item other than
-/// the excluded symbols occupied: the one occupancy fit checks and final
-/// placement must agree on.
+/// A packer for `paper` with the title block and known item bounds occupied,
+/// except excluded symbols: fit checks and final placement share this occupancy.
 fn occupied_page_packer(
     page: &SchPage,
     paper: &Paper,
@@ -1483,7 +1482,12 @@ fn occupy_page_items_except(
             }
             SchItem::Junction(junction) => packer.occupy(point_rect(junction.at)),
             SchItem::NoConnect(no_connect) => packer.occupy(point_rect(no_connect.at)),
-            SchItem::Symbol(_) | SchItem::Unsupported(_) => {}
+            SchItem::Unsupported(item) => {
+                if let Some(bounds) = field_autoplace::page_graphic_bounds(item) {
+                    packer.occupy(GridRect::from_bounds(bounds));
+                }
+            }
+            SchItem::Symbol(_) => {}
         }
     }
     Ok(())
@@ -3809,6 +3813,48 @@ mod tests {
         let placed = bounds.translated(packer.place_anchored(bounds));
         assert!(placed.min_x > packer.usable_bounds().max_x);
         assert_eq!(page.paper, Paper::default());
+    }
+
+    #[test]
+    fn overflow_avoids_opaque_page_text_and_graphics() {
+        for (source, right_edge) in [
+            (
+                r#"(text "off-page note\nsecond line" (at 500 10 90)
+                (effects (font (size 2 2)) (justify left bottom)))"#,
+                532.0,
+            ),
+            ("(text_box \"note\" (at 500 10 90) (size 100 20))", 620.0),
+            (
+                "(rectangle (start 500 10) (end 600 100) (stroke (width 10)))",
+                605.0,
+            ),
+            ("(polyline (pts (xy 500 10) (xy 600 100)))", 600.0),
+            ("(bezier (pts (xy 500 10) (xy 700 20) (xy 600 100)))", 700.0),
+            ("(circle (center 500 10) (radius 50))", 550.0),
+            // A major arc whose rightmost point is not a control point.
+            ("(arc (start 470 40) (mid 540 30) (end 470 -40))", 550.0),
+        ] {
+            let mut page = test_page_with_sheet("opaque");
+            let opaque = SchItem::Unsupported(pcb_sexpr::parse(source).unwrap());
+            page.items.push(opaque.clone());
+            let block = test_placement_block(
+                "new",
+                GridRect {
+                    min_x: 0,
+                    min_y: 0,
+                    max_x: 100,
+                    max_y: 60,
+                },
+            );
+            let (mut packer, bounds, _) =
+                arrange_existing_page_blocks(&page, &[&block], &BTreeSet::new()).unwrap();
+            let placed = bounds.translated(packer.place_anchored(bounds));
+            assert!(
+                f64::from(placed.min_x) * CONNECTION_GRID_MM > right_edge,
+                "{source}"
+            );
+            assert_eq!(page.items.last(), Some(&opaque));
+        }
     }
 
     #[test]

--- a/crates/pcb-kicad-sch/src/field_autoplace.rs
+++ b/crates/pcb-kicad-sch/src/field_autoplace.rs
@@ -363,10 +363,18 @@ fn include_primitives(bounds: &mut Option<Bounds>, items: &[Sexpr], placed: &Sym
 }
 
 fn include_primitive(bounds: &mut Option<Bounds>, items: &[Sexpr], placed: &Symbol) {
-    let Some(tag) = items.first().and_then(Sexpr::as_sym) else {
+    let Some(local) = primitive_bounds(items) else {
         return;
     };
-    let local = match tag {
+    let transformed = transform_bounds(local, placed);
+    match bounds {
+        Some(bounds) => bounds.union(transformed),
+        None => *bounds = Some(transformed),
+    }
+}
+
+fn primitive_bounds(items: &[Sexpr]) -> Option<Bounds> {
+    match items.first().and_then(Sexpr::as_sym)? {
         "polyline" | "bezier" => pcb_sexpr::find_child_list(items, "pts").and_then(|pts| {
             Bounds::from_points(
                 pts.iter()
@@ -400,15 +408,87 @@ fn include_primitive(bounds: &mut Option<Bounds>, items: &[Sexpr], placed: &Symb
                 .filter_map(|tag| pcb_sexpr::find_child_list(items, tag).and_then(parse_xy)),
         ),
         _ => None,
-    };
-    let Some(local) = local else {
-        return;
-    };
-    let transformed = transform_bounds(local, placed);
-    match bounds {
-        Some(bounds) => bounds.union(transformed),
-        None => *bounds = Some(transformed),
     }
+}
+
+/// Conservative placement envelopes for common opaque page graphics. These
+/// stay in page coordinates; unlike library primitives, their Y is not flipped.
+/// Unknown item types remain preserved but do not have a placement envelope.
+pub(crate) fn page_graphic_bounds(item: &Sexpr) -> Option<Bounds> {
+    let items = item.as_list()?;
+    let child_point = |tag| pcb_sexpr::find_child_list(items, tag).and_then(parse_xy);
+    let mut bounds = match items.first().and_then(Sexpr::as_sym)? {
+        "text" => {
+            let at = child_point("at")?;
+            let text = items.get(1)?.as_atom()?;
+            let effects = pcb_sexpr::find_child_list(items, "effects")?;
+            let font = pcb_sexpr::find_child_list(effects, "font")?;
+            let size = pcb_sexpr::find_child_list(font, "size").and_then(parse_xy)?;
+            let width = text
+                .lines()
+                .map(|line| line.chars().count())
+                .max()
+                .unwrap_or(0) as f64
+                * size.x.abs()
+                * ESTIMATED_TEXT_WIDTH_EM;
+            let height = text.lines().count().max(1) as f64 * size.y.abs() * 1.5;
+            // Reserve the full text extent in every direction to cover any
+            // rotation and justification, including multiline annotations.
+            let radius = width + height;
+            Bounds::from_points([
+                Point::new(at.x - radius, at.y - radius),
+                Point::new(at.x + radius, at.y + radius),
+            ])?
+        }
+        "text_box" => {
+            let at = child_point("at")?;
+            let size = child_point("size")?;
+            let radius = size.x.abs() + size.y.abs();
+            Bounds::from_points([
+                Point::new(at.x - radius, at.y - radius),
+                Point::new(at.x + radius, at.y + radius),
+            ])?
+        }
+        "arc" => {
+            let start = child_point("start")?;
+            let mid = child_point("mid")?;
+            let end = child_point("end")?;
+            let bx = mid.x - start.x;
+            let by = mid.y - start.y;
+            let cx = end.x - start.x;
+            let cy = end.y - start.y;
+            let determinant = 2.0 * (bx * cy - by * cx);
+            if determinant.abs() <= GEOMETRY_EPS_MM {
+                Bounds::from_points([start, mid, end])?
+            } else {
+                // The full circumcircle conservatively includes extrema that
+                // lie between the three control points, even for major arcs.
+                let b2 = bx * bx + by * by;
+                let c2 = cx * cx + cy * cy;
+                let dx = (cy * b2 - by * c2) / determinant;
+                let dy = (bx * c2 - cx * b2) / determinant;
+                let radius = dx.hypot(dy);
+                let center = Point::new(start.x + dx, start.y + dy);
+                Bounds::from_points([
+                    Point::new(center.x - radius, center.y - radius),
+                    Point::new(center.x + radius, center.y + radius),
+                ])?
+            }
+        }
+        _ => primitive_bounds(items)?,
+    };
+    let stroke = pcb_sexpr::find_child_list(items, "stroke")
+        .and_then(|stroke| pcb_sexpr::find_child_list(stroke, "width"))
+        .and_then(|width| width.get(1))
+        .and_then(number)
+        .unwrap_or(0.0)
+        .abs()
+        * 0.5;
+    bounds.min_x -= stroke;
+    bounds.min_y -= stroke;
+    bounds.max_x += stroke;
+    bounds.max_y += stroke;
+    Some(bounds)
 }
 
 fn transform_bounds(bounds: Bounds, placed: &Symbol) -> Bounds {

--- a/crates/pcb-kicad-sch/src/field_autoplace.rs
+++ b/crates/pcb-kicad-sch/src/field_autoplace.rs
@@ -461,18 +461,42 @@ pub(crate) fn page_graphic_bounds(item: &Sexpr) -> Option<Bounds> {
             if determinant.abs() <= GEOMETRY_EPS_MM {
                 Bounds::from_points([start, mid, end])?
             } else {
-                // The full circumcircle conservatively includes extrema that
-                // lie between the three control points, even for major arcs.
                 let b2 = bx * bx + by * by;
                 let c2 = cx * cx + cy * cy;
                 let dx = (cy * b2 - by * c2) / determinant;
                 let dy = (bx * c2 - cx * b2) / determinant;
                 let radius = dx.hypot(dy);
                 let center = Point::new(start.x + dx, start.y + dy);
-                Bounds::from_points([
-                    Point::new(center.x - radius, center.y - radius),
-                    Point::new(center.x + radius, center.y + radius),
-                ])?
+                // The determinant selects the sweep through mid. Include only
+                // cardinal extrema on that sweep, not the rest of the circle.
+                let direction = determinant.signum();
+                let start_angle = (-dy).atan2(-dx);
+                let end_angle = (end.y - center.y).atan2(end.x - center.x);
+                let sweep =
+                    ((end_angle - start_angle) * direction).rem_euclid(std::f64::consts::TAU);
+                let mut bounds = Bounds::from_points([start, mid, end])?;
+                for (angle, point) in [
+                    (0.0, Point::new(center.x + radius, center.y)),
+                    (
+                        std::f64::consts::FRAC_PI_2,
+                        Point::new(center.x, center.y + radius),
+                    ),
+                    (
+                        std::f64::consts::PI,
+                        Point::new(center.x - radius, center.y),
+                    ),
+                    (
+                        3.0 * std::f64::consts::FRAC_PI_2,
+                        Point::new(center.x, center.y - radius),
+                    ),
+                ] {
+                    let distance =
+                        ((angle - start_angle) * direction).rem_euclid(std::f64::consts::TAU);
+                    if distance <= sweep + 1e-12 {
+                        bounds.include(point);
+                    }
+                }
+                bounds
             }
         }
         _ => primitive_bounds(items)?,
@@ -688,6 +712,62 @@ mod tests {
 
     use super::*;
     use crate::SymbolField;
+
+    #[test]
+    fn page_arc_bounds_follow_the_sweep_in_both_directions() {
+        for (start, mid, end, expected) in [
+            (
+                "10 10",
+                "20 9.9",
+                "30 10",
+                Bounds {
+                    min_x: 10.0,
+                    min_y: 9.9,
+                    max_x: 30.0,
+                    max_y: 10.0,
+                },
+            ),
+            (
+                "470 40",
+                "540 30",
+                "470 -40",
+                Bounds {
+                    min_x: 470.0,
+                    min_y: -50.0,
+                    max_x: 550.0,
+                    max_y: 50.0,
+                },
+            ),
+            (
+                "10 10",
+                "20 10",
+                "30 10",
+                Bounds {
+                    min_x: 10.0,
+                    min_y: 10.0,
+                    max_x: 30.0,
+                    max_y: 10.0,
+                },
+            ),
+        ] {
+            for (start, end) in [(start, end), (end, start)] {
+                let source =
+                    format!("(arc (start {start}) (mid {mid}) (end {end}) (stroke (width 2)))");
+                let actual = page_graphic_bounds(&pcb_sexpr::parse(&source).unwrap()).unwrap();
+                for (actual, expected) in [
+                    (actual.min_x, expected.min_x - 1.0),
+                    (actual.min_y, expected.min_y - 1.0),
+                    (actual.max_x, expected.max_x + 1.0),
+                    (actual.max_y, expected.max_y + 1.0),
+                ] {
+                    assert!(
+                        (actual - expected).abs() < GEOMETRY_EPS_MM,
+                        "{source}: {actual} != {expected}"
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn places_visible_fields_on_the_first_pin_free_side() {

--- a/crates/pcb-kicad-sch/src/placement.rs
+++ b/crates/pcb-kicad-sch/src/placement.rs
@@ -265,8 +265,9 @@ impl GridPacker {
     }
 
     fn place_outside(&mut self, relative: GridRect, align_anchor: bool) -> GridPoint {
-        // Include off-page items, which are not represented in the occupancy
-        // bitmap, so repeated applies never stack overflow on existing work.
+        // Include known off-page bounds, which are not represented in the
+        // occupancy bitmap. Opaque items without known geometry remain a
+        // best-effort limitation of automatic placement.
         let right = self.occupied_bounds.map_or(self.usable.max_x, |bounds| {
             bounds.max_x.max(self.usable.max_x)
         });

--- a/crates/pcb-kicad-sch/src/placement.rs
+++ b/crates/pcb-kicad-sch/src/placement.rs
@@ -100,6 +100,7 @@ pub(crate) struct GridPacker {
     usable: GridRect,
     width: usize,
     occupied: Vec<bool>,
+    occupied_bounds: Option<GridRect>,
     placed_cluster: Option<GridRect>,
     placement_anchors: Vec<GridPoint>,
 }
@@ -110,18 +111,16 @@ impl GridPacker {
         let usable = GridRect {
             min_x: PACKING_MARGIN_CELLS,
             min_y: PACKING_MARGIN_CELLS,
-            max_x: grid_floor(width_mm) - PACKING_MARGIN_CELLS,
-            max_y: grid_floor(height_mm) - PACKING_MARGIN_CELLS,
+            max_x: (grid_floor(width_mm) - PACKING_MARGIN_CELLS).max(PACKING_MARGIN_CELLS + 1),
+            max_y: (grid_floor(height_mm) - PACKING_MARGIN_CELLS).max(PACKING_MARGIN_CELLS + 1),
         };
-        if usable.max_x <= usable.min_x || usable.max_y <= usable.min_y {
-            bail!("schematic page is too small for automatic placement");
-        }
         let width = usable.width() as usize;
         let height = usable.height() as usize;
         let mut packer = Self {
             usable,
             width,
             occupied: vec![false; width * height],
+            occupied_bounds: None,
             placed_cluster: None,
             placement_anchors: Vec::new(),
         };
@@ -140,6 +139,10 @@ impl GridPacker {
 
     pub(crate) fn occupy(&mut self, rect: GridRect) {
         let rect = rect.expanded(PACKING_CLEARANCE_CELLS);
+        self.occupied_bounds = Some(
+            self.occupied_bounds
+                .map_or(rect, |bounds| bounds.union(rect)),
+        );
         let min_x = rect.min_x.max(self.usable.min_x);
         let min_y = rect.min_y.max(self.usable.min_y);
         let max_x = rect.max_x.min(self.usable.max_x);
@@ -198,9 +201,7 @@ impl GridPacker {
         let max_anchor_x = self.usable.max_x - relative.max_x;
         let max_anchor_y = self.usable.max_y - relative.max_y;
         if max_anchor_x < min_anchor_x || max_anchor_y < min_anchor_y {
-            let anchor = self.centered_anchor(relative);
-            self.record_placement(relative.translated(anchor), align_anchor.then_some(anchor));
-            return anchor;
+            return self.place_outside(relative, align_anchor);
         }
         let occupied = self.occupancy_prefix();
         let aligned_x = self
@@ -244,10 +245,12 @@ impl GridPacker {
                 }
             }
         }
-        let anchor = best_aligned
+        let (rank, anchor) = best_aligned
             .or(best_fallback)
-            .expect("a non-empty anchor range has a candidate")
-            .1;
+            .expect("a non-empty anchor range has a candidate");
+        if rank.0 > 0 {
+            return self.place_outside(relative, align_anchor);
+        }
         self.record_placement(relative.translated(anchor), align_anchor.then_some(anchor));
         anchor
     }
@@ -261,17 +264,18 @@ impl GridPacker {
         self.placement_anchors.extend(anchor);
     }
 
-    fn centered_anchor(&self, relative: GridRect) -> GridPoint {
-        let x2 = i64::from(self.usable.min_x) + i64::from(self.usable.max_x)
-            - i64::from(relative.min_x)
-            - i64::from(relative.max_x);
-        let y2 = i64::from(self.usable.min_y) + i64::from(self.usable.max_y)
-            - i64::from(relative.min_y)
-            - i64::from(relative.max_y);
-        GridPoint {
-            x: x2.div_euclid(2) as i32,
-            y: y2.div_euclid(2) as i32,
-        }
+    fn place_outside(&mut self, relative: GridRect, align_anchor: bool) -> GridPoint {
+        // Include off-page items, which are not represented in the occupancy
+        // bitmap, so repeated applies never stack overflow on existing work.
+        let right = self.occupied_bounds.map_or(self.usable.max_x, |bounds| {
+            bounds.max_x.max(self.usable.max_x)
+        });
+        let anchor = GridPoint {
+            x: right + PACKING_MARGIN_CELLS - relative.min_x,
+            y: self.usable.min_y - relative.min_y,
+        };
+        self.record_placement(relative.translated(anchor), align_anchor.then_some(anchor));
+        anchor
     }
 
     fn distance_from_center_squared(&self, rect: GridRect) -> i64 {
@@ -380,6 +384,32 @@ mod tests {
         let center_dy = placed.min_y + placed.max_y - packer.usable.min_y - packer.usable.max_y;
         assert!(center_dx.abs() <= 1);
         assert!(center_dy.abs() <= 1);
+    }
+
+    #[test]
+    fn overflow_avoids_existing_off_page_items_and_other_overflow() {
+        let mut packer = GridPacker::for_page(&Paper::default()).unwrap();
+        packer.occupy(packer.usable_bounds());
+        let existing = GridRect {
+            min_x: 1000,
+            min_y: 0,
+            max_x: 1100,
+            max_y: 100,
+        };
+        packer.occupy(existing);
+        let relative = GridRect {
+            min_x: -2,
+            min_y: -3,
+            max_x: 2,
+            max_y: 3,
+        };
+
+        let first = relative.translated(packer.place_anchored(relative));
+        let second = relative.translated(packer.place(relative));
+
+        assert!(first.min_x > existing.max_x + PACKING_CLEARANCE_CELLS);
+        assert!(second.min_x > first.max_x + PACKING_CLEARANCE_CELLS);
+        assert_eq!(first.min_y, packer.usable.min_y);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fall back to off-page placement instead of failing when generated content cannot fit.
- Preserve existing paper sizes and avoid collisions with existing on-page and off-page content.
- Keep automatic growth for new pages, with overflow when no candidate fits.
- Add regression coverage for crowded pages, oversized batches, tiny custom pages, and repeated overflow.

Related to [ENG-1191](https://linear.app/diodeinc/issue/ENG-1191).

## Verification
- `cargo nextest run -p pcb-kicad-sch`: 175 passed, 0 skipped.
- `cargo test --doc -p pcb-kicad-sch`: passed (0 doctests).
- `cargo fmt --all -- --check` and `git diff --check`: passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core schematic auto-placement geometry and failure modes; mis-estimated graphic bounds could still place content over unknown items, but apply should no longer abort on crowded pages.
> 
> **Overview**
> **Automatic schematic placement no longer fails** when generated component batches cannot fit on the usable page area. Instead, `GridPacker` **spills content to the right of the page** (past known occupied bounds), including chained overflow for multiple off-page placements.
> 
> **Fit logic changes:** new pages still try larger paper sizes, but only accept a layout when it **fits without overlap**; otherwise placement continues with the current paper and may overflow. On existing pages, arrangement **always succeeds** (errors removed). Grid column choice **prefers in-page layouts** but can pick an overlapping grid when overflow is the only option.
> 
> **Occupancy is more conservative:** unsupported page items (text, text boxes, rectangles, arcs, etc.) get **bounding envelopes** via new `page_graphic_bounds`, so generated symbols are less likely to cover user annotations; shallow arcs no longer reserve a full circle and block on-page placement incorrectly.
> 
> **`GridPacker`** tracks `occupied_bounds` for off-page collision avoidance, drops the “page too small” hard error for tiny custom paper, and routes oversized or fully occupied cases through **`place_outside`** instead of centered overlap placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07de626c825a3c7ffe0d90520db1c22ed1a7ebec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->