### PR TITLE
Remove redundant pricing and layout helpers

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  KICAD_VERSION: 10.0.5
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -907,23 +907,8 @@ pub fn has_search_availability(availability: &Availability) -> bool {
     availability.us.is_some() || availability.global.is_some() || !availability.offers.is_empty()
 }
 
-/// Fetch pricing for multiple components in a single batch request
-pub fn fetch_pricing_batch(
-    auth_token: Option<&str>,
-    components: &[ComponentKey],
-) -> Result<Vec<Availability>> {
-    fetch_pricing_batch_once(auth_token, components)
-}
-
 /// Fetch pricing for grouped alternate components as one planned BOM line per group.
 pub fn fetch_pricing_grouped_batch(
-    auth_token: Option<&str>,
-    groups: &[Vec<ComponentKey>],
-) -> Result<Vec<Availability>> {
-    fetch_pricing_grouped_batch_once(auth_token, groups)
-}
-
-fn fetch_pricing_grouped_batch_once(
     auth_token: Option<&str>,
     groups: &[Vec<ComponentKey>],
 ) -> Result<Vec<Availability>> {
@@ -975,7 +960,8 @@ fn fetch_pricing_grouped_batch_once(
     Ok(results)
 }
 
-fn fetch_pricing_batch_once(
+/// Fetch pricing for multiple components in a single batch request
+pub fn fetch_pricing_batch(
     auth_token: Option<&str>,
     components: &[ComponentKey],
 ) -> Result<Vec<Availability>> {

--- a/crates/pcb-diode-api/src/component.rs
+++ b/crates/pcb-diode-api/src/component.rs
@@ -908,7 +908,11 @@ fn execute_registry_symbol_search(
         return Ok(());
     }
 
-    let availability_map = registry_symbol_search_availability(&hits);
+    let groups: Vec<_> = hits
+        .iter()
+        .map(|hit| hit.availability_lookups.clone())
+        .collect();
+    let availability_map = search_availability(&groups);
 
     if json {
         let results: Vec<_> = hits
@@ -1010,7 +1014,11 @@ fn execute_kicad_symbols_search(query: &str, json: bool) -> Result<()> {
         return Ok(());
     }
 
-    let availability_map = kicad_symbol_search_availability(&results);
+    let groups: Vec<_> = results
+        .iter()
+        .map(crate::kicad_symbols::KicadSymbol::availability_lookup_keys)
+        .collect();
+    let availability_map = search_availability(&groups);
 
     if json {
         let combined: Vec<_> = results
@@ -1070,14 +1078,9 @@ fn execute_kicad_symbols_search(query: &str, json: bool) -> Result<()> {
     Ok(())
 }
 
-fn registry_symbol_search_availability(
-    results: &[crate::RegistrySymbolHit],
+fn search_availability(
+    groups: &[Vec<crate::bom::ComponentKey>],
 ) -> std::collections::HashMap<usize, pcb_sch::bom::Availability> {
-    let groups: Vec<_> = results
-        .iter()
-        .map(|hit| hit.availability_lookups.clone())
-        .collect();
-
     if groups.iter().all(Vec::is_empty) {
         return std::collections::HashMap::new();
     }
@@ -1086,40 +1089,13 @@ fn registry_symbol_search_availability(
         return std::collections::HashMap::new();
     };
     let pricing =
-        crate::bom::fetch_pricing_grouped_batch(token.as_deref(), &groups).unwrap_or_default();
+        crate::bom::fetch_pricing_grouped_batch(token.as_deref(), groups).unwrap_or_default();
 
     pricing
         .into_iter()
         .enumerate()
         .filter(|(_, availability)| crate::bom::has_search_availability(availability))
         .collect()
-}
-
-fn kicad_symbol_search_availability(
-    results: &[crate::kicad_symbols::KicadSymbol],
-) -> std::collections::HashMap<usize, pcb_sch::bom::Availability> {
-    let groups: Vec<_> = results
-        .iter()
-        .map(crate::kicad_symbols::KicadSymbol::availability_lookup_keys)
-        .collect();
-
-    if groups.iter().all(Vec::is_empty) {
-        return std::collections::HashMap::new();
-    }
-
-    let Ok(token) = crate::auth::get_api_token() else {
-        return std::collections::HashMap::new();
-    };
-    let pricing =
-        crate::bom::fetch_pricing_grouped_batch(token.as_deref(), &groups).unwrap_or_default();
-
-    let mut map = std::collections::HashMap::new();
-    for (result_idx, availability) in pricing.into_iter().enumerate() {
-        if crate::bom::has_search_availability(&availability) {
-            map.insert(result_idx, availability);
-        }
-    }
-    map
 }
 
 fn print_search_scoring(scoring: Option<&crate::registry::tui::search::SearchScoring>) {

--- a/crates/pcb-diode-api/src/registry/tui/ui.rs
+++ b/crates/pcb-diode-api/src/registry/tui/ui.rs
@@ -1,5 +1,6 @@
 //! UI rendering
 
+use crate::bom::format_price;
 use crate::kicad_symbols::KicadSymbol;
 use crate::{RegistryModule, RegistryModuleDependency, RegistrySymbol, SearchHit};
 use ratatui::{
@@ -458,11 +459,6 @@ fn render_preview_panel(frame: &mut Frame, app: &mut App, area: Rect) {
             frame.render_widget(loading, inner);
         }
     }
-}
-
-/// Format a price value for display (re-export from bom)
-fn format_price(price: f64) -> String {
-    crate::bom::format_price(price)
 }
 
 /// Format availability line: "US:     $3.22 (1,234)" or "US:     ..." while loading

--- a/crates/pcb-layout/Cargo.toml
+++ b/crates/pcb-layout/Cargo.toml
@@ -32,6 +32,5 @@ include_dir = "0.7.4"
 assert_fs = { workspace = true }
 insta = { workspace = true }
 paste = { workspace = true }
-serde_json = { workspace = true }
 pcb-zen = { workspace = true }
 regex = { workspace = true }

--- a/crates/pcb-layout/src/scripts/update_layout_file.py
+++ b/crates/pcb-layout/src/scripts/update_layout_file.py
@@ -435,14 +435,6 @@ def rmv_quotes(s):
     return s
 
 
-def get_group_items(group: pcbnew.PCB_GROUP) -> list[pcbnew.BOARD_ITEM]:
-    return [
-        item.Cast()
-        for item in group.GetItemsDeque()
-        if item.GetClass() not in ["PCB_GENERATOR"]
-    ]
-
-
 def get_footprint_uuid(fp: pcbnew.FOOTPRINT) -> str:
     """Return the UUID of a footprint."""
     path = fp.GetPath().AsString()
@@ -488,7 +480,7 @@ class SyncState:
 
 # Import the lens module (extracted to temp dir by Rust and added to PYTHONPATH)
 from lens import run_lens_sync
-from lens.kicad_adapter import get_footprint_field
+from lens.kicad_adapter import get_footprint_field, get_group_items
 
 
 class ImportNetlist(Step):

--- a/crates/pcbc/Cargo.toml
+++ b/crates/pcbc/Cargo.toml
@@ -92,5 +92,4 @@ zstd = { workspace = true }
 [dev-dependencies]
 httpmock = { workspace = true }
 insta = { workspace = true }
-tempfile = { workspace = true }
 pcb-test-utils = { workspace = true }


### PR DESCRIPTION
This change combines duplicate search availability code and uses the existing pricing and KiCad group helpers. It also removes duplicate test dependencies and an unused CI variable to reduce maintenance without removing supported features.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1173" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->