### PR TITLE
Trim agent guidance and consolidate setup documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,55 +1,21 @@
 # AGENTS.md
 
-## PCB CLI Subcommands
+## Commands
 
-- `cargo run -p pcbc -- build [PATHS...]` — build and validate Zener designs.
-- `cargo run -p pcbc -- test [PATHS...]` — run tests declared in `.zen` files.
-- `cargo run -p pcbc -- fmt [PATHS...]` — format `.zen` files.
-- `cargo run -p pcbc -- layout --no-open [PATHS...]` — generate/update KiCad layout files without opening KiCad.
+- `cargo run -p pcbc -- <command>` runs the compiler CLI; `pcb` is the shim/version manager.
+- `cargo nextest run -p <crate>` runs crate tests; `cargo test --doc -p <crate>` runs doctests separately.
+- `uv run pytest crates/pcb-layout/src/scripts/lens/tests/ -v` runs layout-lens tests.
 
-## Development Workflow
+Keep checks scoped to the change. Report changed snapshots; do not accept them without user approval.
 
-- `cargo nextest run -p <crate>` — run tests for one crate.
-- `cargo test --doc -p <crate>` — run doctests, which nextest does not run.
-- `cargo fmt` — format Rust code.
-- `uv run pytest crates/pcb-layout/src/scripts/lens/tests/ -v` — run the Python layout-lens tests when changing `crates/pcb-layout/src/scripts/lens/`.
+## Non-obvious constraints
 
-Never run `cargo insta accept` without explicit user approval.
+- Language semantics live in `pcb-zen-core` and the pinned `diodeinc/starlark-rust` fork; workspace/package resolution lives in `pcb-zen`.
+- For layout sync changes, see `crates/pcb-layout/README.md`; for import changes, see `crates/pcbc/src/import/README.md`.
+- Use `anstream` for incidental CLI output. Structured/binary stdout renderers must remain fallible over `std::io::Write`, called through `pcb_ui::write_stdout`. Do not catch `BrokenPipe` process-wide. Gate CLI dependencies/imports in non-CLI or WASM builds.
+- Before pushing, fetch and rebase onto `origin/main`, then fast-forward push; no merge commits.
 
-## Where to Look
+## Documentation
 
-- Start with `README.md` for product context and user-facing CLI behavior.
-- `crates/pcb/src/main.rs` is the shim/version manager; `crates/pcbc/src/main.rs` declares compiler CLI subcommands, with matching files in `crates/pcbc/src/` (`build.rs`, `layout.rs`, `fmt.rs`, `test.rs`, etc.).
-- `crates/pcb-zen-core/src/lang/` contains Zener built-ins, core values, type conversion, validation, and evaluation semantics. Check `docs/pages/spec.mdx` when changing user-visible language behavior.
-- `crates/pcb-zen/src/` provides higher-level workspace/dependency resolution, package cache, diagnostics plumbing, and LSP integration around `pcb-zen-core`.
-- `crates/pcb-sch/src/` is the schematic/netlist data model, BOM helpers, KiCad netlist export, and `# pcb:sch` comment handling.
-- `crates/pcb-layout/src/` generates and synchronizes KiCad layouts. The Python lens implementation is in `crates/pcb-layout/src/scripts/lens/`; read `crates/pcb-layout/README.md` before changing sync behavior.
-- `crates/pcb-kicad/src/` wraps KiCad tooling and KiCad-specific checks; `crates/pcb-sexpr/src/` handles low-level S-expression parsing/rewriting for KiCad files.
-- `crates/pcbc/src/import/` implements `pcb import`; start with `crates/pcbc/src/import/README.md` and `flow.rs` before changing the import pipeline.
-- `crates/pcb-eda/` and `crates/pcb-component-gen/` handle external EDA artifacts and generated Zener component modules.
-- `crates/pcb-diode-api/` contains API/auth/search/BOM-matching client logic.
-- `lib/std/` contains the Zener standard library; `examples/` and `test-workspaces/` are useful runnable designs.
-- Use `docs/pages/packages.mdx` for workspace, dependency, and package behavior.
-
-## Working Rules
-
-- Prefer the smallest correct change and match existing crate/module boundaries.
-- Avoid adding cross-crate abstractions until a boundary is already shared in the existing code.
-- Keep Git history linear: before pushing, fetch and rebase local commits onto `origin/main`, then fast-forward push; never create merge commits.
-- In `.zen` files, remember Zener is Starlark-based, not Python: do not use f-strings.
-- Language behavior may come from the pinned `diodeinc/starlark-rust` fork in `Cargo.toml`; check that fork when local code does not explain Starlark behavior.
-- Use `anstream` macros for incidental CLI output; for primary structured or binary stdout, keep renderers fallible over `std::io::Write` and call them through `pcb_ui::write_stdout` so only `BrokenPipe` is ignored.
-- Do not catch `BrokenPipe` process-wide, and gate CLI output dependencies and imports in crates that also support non-CLI or WASM builds.
-
-## Documentation Rules
-
-- For user-visible changes, add one succinct `CHANGELOG.md` entry under `Unreleased` per logical change.
-- If you change Zener syntax, built-ins, core types, imports/modules, or type rules, update `docs/pages/spec.mdx`.
-- If you change workspace manifests, dependency resolution, or package behavior, update the relevant docs in `docs/pages/`, especially `docs/pages/packages.mdx`.
-- If you change stdlib APIs or examples, prefer a focused docs/example update over broad documentation churn.
-
-## Verification
-
-- Run the narrowest relevant check first: usually `cargo nextest run -p <crate>`, a focused `cargo run -p pcbc -- ...` command, or the layout-lens pytest command above.
-- Do not run full-workspace checks after every small edit.
-- If snapshot tests change, call that out and leave snapshot acceptance to the user.
+- Add one succinct `CHANGELOG.md` entry under `Unreleased` per user-visible change.
+- Update `docs/pages/spec.mdx` for language changes and `docs/pages/packages.mdx` for workspace/dependency/package changes.

--- a/README.md
+++ b/README.md
@@ -20,61 +20,9 @@ For native Windows, run this command in PowerShell:
 powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/diodeinc/pcb/main/install.ps1 | iex"
 ```
 
-The launcher downloads and runs the `pcbc` toolchain requested by each project.
-The Unix installer writes `pcb` to `$HOME/.local/bin` by default. The Windows
-installer writes `pcb.exe` to `%USERPROFILE%\.pcb\bin` by default. Set
-`PCB_INSTALL_DIR` to choose a different directory.
-
-The installer also registers the `diode://` URL scheme for the current user.
-The Diode registry can use these links to open sandbox layouts in KiCad
-without a terminal. `pcb self update` updates and re-registers the launcher together with
-the `pcb` shim. If a browser-launched open fails, the launcher displays the
-error and records command output in `~/.pcb/pcb-launcher.log` (or
-`%USERPROFILE%\.pcb\pcb-launcher.log` on Windows).
-
-KiCad 10.x is required only for generating and editing layouts. Building and
-validating Zener files does not require KiCad.
-
-Native Windows support is experimental. Use WSL2 if a command does not work in
-the native environment.
-
-### Toolchain management
-
-`pcb` manages `pcbc`, the standard library, and bundled sidecars such as
-`pcb-rectify` as one versioned toolchain.
-
-Workspace commands use the toolchain selected by `pcb-version`. `pcb auth`
-instead uses the latest stable toolchain; an explicit `+<toolchain>` override
-still wins. `pcb self` and `pcb toolchain` run directly in the launcher.
-
-```bash
-pcb toolchain show                 # Show the active and latest matching versions
-pcb toolchain show --offline       # Use installed and cached data only
-pcb toolchain install latest       # Install the latest stable toolchain
-pcb toolchain prune --dry-run      # Preview removable downloads and old patches
-pcb toolchain prune                # Remove them
-pcb toolchain repair latest        # Validate and restore a toolchain
-```
-
-Install and repair accept `latest`, `nightly`, a lane such as `0.4`, or an exact
-version such as `0.4.9`. Pruning preserves the newest patch in each lane, the
-active version, prereleases, nightly, and local toolchains. `pcb self update`
-updates the shim and managed channels and fails if any requested update fails.
-
-### Developing from source
-
-```bash
-git clone https://github.com/diodeinc/pcb.git
-cd pcb
-cargo build -p pcb -p pcbc
-./install.sh --local
-```
-
-Local installation registers `diode://` links against the local toolchain.
-Installing or self-updating a release registers them against `latest` again.
-
-Repository maintenance scripts are run by their explicit path, such as
-`./bin/embed-readme --check README.md`; no shell environment activation is needed.
+The launcher downloads the toolchain selected by each project. KiCad 10.x is
+required for layouts, but not for building Zener designs. Native Windows support
+is experimental; use WSL2 if needed.
 
 ## Quick start
 
@@ -99,108 +47,26 @@ Led(name="D1", package="0402", color="red", A=LED_ANODE, K=GND)
 Board(name="blinky", layers=4, layout_path="layout/blinky")
 ```
 
-Build the design:
+Build the design and generate a KiCad layout:
 
 ```bash
 pcb build blinky.zen
-```
-
-Generate a KiCad layout:
-
-```bash
 pcb layout blinky.zen
 ```
 
-## Repository layouts
+See [Getting Started](https://docs.pcb.new/pages/quickstart) for board setup,
+toolchains, and CI authentication, and [Packages](https://docs.pcb.new/pages/packages)
+for repository structure and dependencies. Run `pcb help` for commands.
 
-Zener projects use one of two repository shapes.
-
-### Board repository
-
-A board repository contains one board plus any local modules and components it
-owns:
-
-```text
-MyBoard/
-├── pcb.toml              # Workspace and board manifest
-├── MyBoard.zen           # Board schematic
-├── layout/               # KiCad layout files
-├── modules/              # Reusable circuit modules
-│   └── PowerSupply/
-│       ├── PowerSupply.zen
-│       └── pcb.toml
-├── components/           # Custom component definitions
-│   └── Manufacturer/
-│       └── MPN/
-│           ├── MPN.zen
-│           └── pcb.toml
-└── vendor/               # Vendored dependencies
-```
-
-Create one with:
+## Developing from source
 
 ```bash
-pcb new board MyBoard https://github.com/myorg/MyBoard
+git clone https://github.com/diodeinc/pcb.git
+cd pcb
+./install.sh --local
 ```
 
-Board repository `pcb.toml`:
-
-```toml
-[workspace]
-repository = "github.com/myorg/MyBoard"
-pcb-version = "0.4"
-
-[board]
-name = "MyBoard"
-path = "MyBoard.zen"
-description = "Replace with concise board description."
-```
-
-### Registry repository
-
-A registry repository contains reusable packages and no board:
-
-```text
-registry/
-├── pcb.toml              # Workspace manifest
-├── components/           # Component packages
-│   └── TPS54331/
-│       ├── TPS54331.zen
-│       ├── TPS54331.kicad_sym
-│       ├── TPS54331.kicad_mod
-│       └── pcb.toml
-└── modules/              # Reusable module packages
-    └── UsbCSink/
-        ├── UsbCSink.zen
-        └── pcb.toml
-```
-
-Registry `pcb.toml`:
-
-```toml
-[workspace]
-repository = "github.com/myorg/registry"
-pcb-version = "0.4"
-```
-
-## Common commands
-
-```bash
-pcb new board <NAME> <REPO_URL>              # Create a board repository
-pcb build [PATHS...]                         # Build and validate designs
-pcb sync                                     # Reconcile imports and dependency manifests
-pcb layout <FILE>                            # Generate layout files
-pcb dfm <FILE>                               # Check a .zen board for manufacturability
-pcb import <KICAD_SCH|KICAD_PRO> <OUTPUT_DIR> # Import a KiCad schematic or project
-```
-
-Run `pcb help` or `pcb help <command>` for the full command reference.
-
-Authenticate a machine with `pcb auth login --service-account`, or import
-JSON (`client_id`, `client_secret`) with
-`pcb auth login --service-account --stdin < credentials.json`.
-For CI, set `DIODE_API_URL`, `DIODE_CLIENT_ID`, and `DIODE_CLIENT_SECRET`.
-PCB renews access tokens automatically.
+Requires Rust. See [AGENTS.md](AGENTS.md) for test commands and repository conventions.
 
 ## License
 

--- a/docs/pages/packages.mdx
+++ b/docs/pages/packages.mdx
@@ -7,6 +7,17 @@ Package versions identify immutable source snapshots. A dependency on
 `component-lib@0.3.2` selects the same source for every build until the manifest
 changes.
 
+## Repository structure
+
+A board repository has a root `pcb.toml` with `[workspace]` and `[board]`
+metadata, a board `.zen` entrypoint, and generated KiCad files under `layout/`.
+Create one with `pcb new board <NAME> <REPO_URL>`.
+
+A registry repository has a root `[workspace]` but no `[board]`. Both repository
+types can own reusable packages under `components/` and `modules/`. Each package
+has its own `pcb.toml` and `.zen` entrypoints; component packages also carry
+their symbols and footprints. `vendor/` holds vendored dependencies.
+
 ## Version policy
 
 PCB packages use semantic versions with hardware-specific compatibility rules:

--- a/docs/pages/quickstart.mdx
+++ b/docs/pages/quickstart.mdx
@@ -16,8 +16,7 @@ source, and generate a KiCad layout.
 
 ## 1. Install `pcb`
 
-The `pcb` launcher downloads and runs the `pcbc` toolchain selected by each
-project. Run the installer for your platform:
+Run the installer for your platform:
 
 <CodeGroup>
 
@@ -31,25 +30,16 @@ powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/dio
 
 </CodeGroup>
 
-The installer adds `pcb` to your user `PATH` when necessary. Restart the shell
-if the command is not available, then verify the installation:
+Default install directories are `$HOME/.local/bin` on Unix and
+`%USERPROFILE%\.pcb\bin` on Windows; override with `PCB_INSTALL_DIR`.
+
+The installer adds `pcb` to your user `PATH` when necessary. Verify installation:
 
 ```bash
 pcb --version
 ```
 
-<Accordion title="Install from source">
-
-Install Rust, then clone the [repository](https://github.com/diodeinc/pcb) and
-run the local installer:
-
-```bash
-git clone https://github.com/diodeinc/pcb
-cd pcb
-./install.sh --local
-```
-
-</Accordion>
+For source builds, see the [repository README](https://github.com/diodeinc/pcb#developing-from-source).
 
 ## 2. Create a board repository
 
@@ -60,8 +50,8 @@ pcb new board Blinky github.com/your-org/blinky
 cd Blinky
 ```
 
-`pcb new board` creates `pcb.toml`, `Blinky.zen`, and a Git repository. The
-generated design is empty but valid.
+The generated design is empty but valid. See [Packages](/pages/packages#repository-structure)
+for repository structure.
 
 ## 3. Build the board
 
@@ -70,8 +60,6 @@ Validate the board source and generate its netlist:
 ```bash
 pcb build Blinky.zen
 ```
-
-A successful build exits without validation errors.
 
 ## 4. Generate the layout
 
@@ -83,6 +71,35 @@ pcb layout --no-open Blinky.zen
 
 This command writes the generated board under `layout/`.
 
+## Toolchains
+
+`pcb` manages the compiler, stdlib, and sidecars as one toolchain. Workspace
+commands use `pcb-version`; `pcb auth` uses latest stable instead. An explicit
+`pcb +<version> <command>` overrides either selection.
+
+```bash
+pcb toolchain show              # Active and available versions; --offline avoids network
+pcb toolchain install latest    # Also accepts nightly, a lane (0.4), or an exact version
+pcb toolchain repair latest     # Validate and restore a toolchain
+pcb toolchain prune --dry-run   # Preview cleanup; omit --dry-run to remove files
+pcb self update                # Update the shim and managed channels
+```
+
+Pruning removes downloads and superseded patches, preserving the newest patch
+per lane, the active version, prereleases, nightly, and local toolchains.
+
+## Service accounts and CI
+
+Run `pcb auth login --service-account` interactively, or import JSON containing
+`client_id` and `client_secret`:
+
+```bash
+pcb auth login --service-account --stdin < credentials.json
+```
+
+For CI, supply `DIODE_API_URL`, `DIODE_CLIENT_ID`, and `DIODE_CLIENT_SECRET`
+through the CI secret store. PCB renews access tokens automatically.
+
 ## Troubleshooting
 
 - If the shell cannot find `pcb` after installation, restart the shell or
@@ -90,4 +107,8 @@ This command writes the generated board under `layout/`.
 - If `pcb layout` cannot find KiCad, install `kicad-cli` and `pcbnew`. Set
   `KICAD_CLI` or `KICAD_PCBNEW` if either executable is outside its default
   platform path.
+- Installers register `diode://` links for opening registry layouts in KiCad.
+  If opening fails, check `~/.pcb/pcb-launcher.log` (Windows:
+  `%USERPROFILE%\.pcb\pcb-launcher.log`). `./install.sh --local` registers the
+  local toolchain; release installation or `pcb self update` restores `latest`.
 - Run `pcb help` or `pcb help <command>` for the complete CLI reference.


### PR DESCRIPTION
This change removes repeated instructions from AGENTS.md and keeps the README focused on installation and a working example. It moves useful setup, toolchain, and authentication details into the existing guides so readers can find them without duplicate instructions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1174" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->