### PR TITLE
Support opaque service-account client IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Place generated schematic content outside the page when it cannot fit, instead of failing schematic apply, and reserve space for existing text and graphics.
+- Support opaque service-account client IDs and proper OAuth Basic encoding.
+- Allow off-page schematic placement and avoid existing text and graphics.
 
 ## [0.4.49] - 2026-09-04
 

--- a/crates/pcb-diode-api/src/auth/service_account.rs
+++ b/crates/pcb-diode-api/src/auth/service_account.rs
@@ -12,10 +12,25 @@ use uuid::Uuid;
 
 #[derive(Clone, Serialize, Deserialize)]
 struct Credentials {
-    client_id: Uuid,
+    client_id: String,
     client_secret: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     service_account_name: Option<String>,
+}
+
+impl Credentials {
+    fn authenticate(
+        &self,
+        request: reqwest::blocking::RequestBuilder,
+    ) -> reqwest::blocking::RequestBuilder {
+        // OAuth client_secret_basic encodes each component before Basic joins them
+        // with a colon (RFC 6749 section 2.3.1).
+        let client_id: String =
+            url::form_urlencoded::byte_serialize(self.client_id.as_bytes()).collect();
+        let client_secret: String =
+            url::form_urlencoded::byte_serialize(self.client_secret.as_bytes()).collect();
+        request.basic_auth(client_id, Some(client_secret))
+    }
 }
 
 #[derive(Clone, Serialize, Deserialize)]
@@ -45,6 +60,9 @@ impl ServiceAccountAuth {
     pub(super) fn validate(&self, ctx: &WorkspaceContext) -> Result<()> {
         if api_url(&self.api_base_url)? != api_url(ctx.api_base_url())? {
             bail!("Service-account credentials belong to a different API endpoint");
+        }
+        if self.credentials.client_id.is_empty() {
+            bail!("Invalid service-account client ID: must not be empty");
         }
         if self.credentials.client_secret.is_empty() {
             bail!("Invalid service-account client secret");
@@ -106,9 +124,7 @@ pub(super) fn from_environment(ctx: &WorkspaceContext) -> Result<Option<ServiceA
         return Ok(None);
     }
     let client_id = std::env::var("DIODE_CLIENT_ID")
-        .ok()
-        .and_then(|id| Uuid::parse_str(&id).ok())
-        .context("Set DIODE_CLIENT_ID to the service-account client UUID")?;
+        .map_err(|_| anyhow::anyhow!("Set DIODE_CLIENT_ID to the service-account client ID"))?;
     let client_secret = std::env::var("DIODE_CLIENT_SECRET")
         .map_err(|_| anyhow::anyhow!("Set DIODE_CLIENT_SECRET with DIODE_CLIENT_ID"))?;
     // An explicit URL keeps repository configuration from redirecting CI secrets.
@@ -196,12 +212,10 @@ struct TokenResponse {
 }
 
 fn exchange(account: &ServiceAccountAuth) -> Result<AccessToken> {
-    let response = oauth_client()?
-        .post(format!("{}/api/auth/token", account.api_base_url))
-        .basic_auth(
-            account.credentials.client_id,
-            Some(&account.credentials.client_secret),
-        )
+    let request = oauth_client()?.post(format!("{}/api/auth/token", account.api_base_url));
+    let response = account
+        .credentials
+        .authenticate(request)
         .header(
             reqwest::header::CONTENT_TYPE,
             "application/x-www-form-urlencoded",
@@ -273,8 +287,7 @@ pub(super) fn login(ctx: &WorkspaceContext, from_stdin: bool) -> Result<()> {
         }
         println!("Endpoint: {}", api_url(ctx.api_base_url())?);
         let client_id = inquire::Text::new("Client ID:").prompt()?;
-        let client_id = Uuid::parse_str(client_id.trim())
-            .map_err(|_| anyhow::anyhow!("Client ID must be a UUID"))?;
+        let client_id = client_id.trim().to_string();
         let client_secret = inquire::Password::new("Client secret:")
             .without_confirmation()
             .prompt()?;
@@ -368,16 +381,11 @@ fn finish_setup(ctx: &WorkspaceContext, account: &mut ServiceAccountAuth) {
         return;
     };
     let confirm = (|| -> Result<()> {
-        let response = oauth_client()?
-            .post(format!(
-                "{}/api/auth/service-account-setup/{setup_id}/confirm",
-                account.api_base_url
-            ))
-            .basic_auth(
-                account.credentials.client_id,
-                Some(&account.credentials.client_secret),
-            )
-            .send()?;
+        let request = oauth_client()?.post(format!(
+            "{}/api/auth/service-account-setup/{setup_id}/confirm",
+            account.api_base_url
+        ));
+        let response = account.credentials.authenticate(request).send()?;
         if response.status() != reqwest::StatusCode::NO_CONTENT {
             bail!("Console confirmation failed: {}", response.status());
         }

--- a/crates/pcb-diode-api/src/auth/service_account/tests.rs
+++ b/crates/pcb-diode-api/src/auth/service_account/tests.rs
@@ -14,7 +14,7 @@ fn account(endpoint: &str) -> ServiceAccountAuth {
     ServiceAccountAuth {
         api_base_url: endpoint.to_string(),
         credentials: Credentials {
-            client_id: CLIENT_ID.parse().unwrap(),
+            client_id: CLIENT_ID.to_string(),
             client_secret: SECRET.to_string(),
             service_account_name: Some("test-runner".to_string()),
         },
@@ -144,4 +144,64 @@ fn mismatched_endpoint_and_malformed_credentials_fail_without_exposing_secrets()
     let error = get_valid_token_with_context(&ctx).unwrap_err();
     assert!(!format!("{error:#}").contains(SECRET));
     assert!(error.to_string().contains("Invalid authentication file"));
+}
+
+#[test]
+fn credential_ids_and_oauth_basic_encoding() {
+    let client = reqwest::blocking::Client::new();
+    for (id, secret, encoded) in [
+        (CLIENT_ID, SECRET, format!("{CLIENT_ID}:{SECRET}")),
+        (
+            "sandbox:test-sandbox",
+            SECRET,
+            format!("sandbox%3Atest-sandbox:{SECRET}"),
+        ),
+        (
+            "sandbox:id%+ café",
+            "dsc_secret:%+ café",
+            "sandbox%3Aid%25%2B+caf%C3%A9:dsc_secret%3A%25%2B+caf%C3%A9".into(),
+        ),
+    ] {
+        let import: CredentialImport = serde_json::from_value(json!({
+            "client_id": id, "client_secret": secret,
+        }))
+        .unwrap();
+        assert_eq!(import.credentials.client_id, id);
+        let request = import
+            .credentials
+            .authenticate(client.post("https://api.example/api/auth/token"))
+            .build()
+            .unwrap();
+        assert_eq!(
+            request.headers()[reqwest::header::AUTHORIZATION],
+            format!(
+                "Basic {}",
+                base64::engine::general_purpose::STANDARD.encode(encoded)
+            )
+        );
+    }
+}
+
+#[test]
+fn credentials_reject_missing_or_empty_ids() {
+    let ctx = WorkspaceContext::from_api_base_url("https://api.example");
+    assert!(
+        serde_json::from_value::<CredentialImport>(json!({
+            "client_secret": SECRET,
+        }))
+        .is_err()
+    );
+    let import: CredentialImport = serde_json::from_value(json!({
+        "client_id": "", "client_secret": SECRET,
+    }))
+    .unwrap();
+    let mut invalid = account(ctx.api_base_url());
+    invalid.credentials = import.credentials;
+    assert!(
+        invalid
+            .validate(&ctx)
+            .unwrap_err()
+            .to_string()
+            .contains("must not be empty")
+    );
 }


### PR DESCRIPTION
Accept non-empty service-account client IDs without UUID parsing so sandbox credentials work. Form-encode both OAuth Basic credentials to preserve colons and other special characters, and keep focused validation and header tests.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1177" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->