### PR TITLE
Fix IPC-2581 tools tests without default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Keep cutout-only copper layers empty in artwork composition and rendering while preserving visible drill artwork.
+- Fix IPC-2581 tools tests failing to compile without default features.
 
 ## [0.4.50] - 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Keep cutout-only copper layers empty in artwork composition and rendering while preserving visible drill artwork.
 - Fix IPC-2581 tools tests failing to compile without default features.
+- Keep cutout-only copper layers empty in artwork composition and rendering while preserving visible drill artwork.
 
 ## [0.4.50] - 2026-09-05
 

--- a/crates/pcb-ipc2581-tools/Cargo.toml
+++ b/crates/pcb-ipc2581-tools/Cargo.toml
@@ -56,6 +56,7 @@ rayon = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+zstd = { workspace = true }
 
 [[example]]
 name = "board_array_balancing_region"


### PR DESCRIPTION
Add zstd as a test dependency so IPC-2581 assembly and placement tests compile without default features. Keep production dependencies unchanged and retain both regression tests in non-CLI builds. Fixes ENG-1374.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1179" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->