### PR TITLE
Fix circular drill checks to use physical stackup order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Keep cutout-only copper layers empty in artwork composition and rendering while preserving visible drill artwork.
+- Use physical stackup order for circular-hole DFM clearance and annular-ring checks when copper layer declarations are shuffled.
 
 ## [0.4.50] - 2026-09-05
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -292,6 +292,10 @@ limit = { minimum = "0.2 mm" }
     /// with a 2 mm copper square on each layer named in `copper_on`, and
     /// an optional drill span.
     fn board(layer_count: usize, copper_on: &[usize], span: Option<(usize, usize)>) -> Ipc2581 {
+        Ipc2581::parse(&board_xml(layer_count, copper_on, span)).unwrap()
+    }
+
+    fn board_xml(layer_count: usize, copper_on: &[usize], span: Option<(usize, usize)>) -> String {
         let layer_names = (0..layer_count).map(|index| format!("L{index}"));
         let refs = layer_names
             .clone()
@@ -319,7 +323,7 @@ limit = { minimum = "0.2 mm" }
                 )
             })
             .collect::<String>();
-        Ipc2581::parse(&format!(
+        format!(
             r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="owner">
@@ -345,8 +349,7 @@ limit = { minimum = "0.2 mm" }
     </CadData>
   </Ecad>
 </IPC-2581>"#
-        ))
-        .unwrap()
+        )
     }
 
     fn evaluate_pth(ipc: &Ipc2581) -> Evaluation {
@@ -390,6 +393,37 @@ limit = { minimum = "0.2 mm" }
         let measured = &evaluation.measured[0];
         assert_eq!(measured.layers[1].name, "L1");
         assert_eq!(measured.distance.mm, 0.0);
+    }
+
+    #[test]
+    fn physical_terminals_are_independent_of_copper_declaration_order() {
+        let stackup = [0, 1, 2, 3].map(|i| format!(r#"<StackupLayer layerOrGroupRef="L{i}" thickness="0.035" tolPlus="0" tolMinus="0" sequence="{i}"/>"#)).join("");
+        for span in [None, Some((1, 2))] {
+            let terminals = if span.is_some() { [1, 2] } else { [0, 3] };
+            for copper_on in [&terminals[..], &terminals[..1]] {
+                let xml = board_xml(4, copper_on, span).replace(r#"<Step name="board""#, &format!(r#"
+                    <Stackup name="Primary" overallThickness="0.14" tolPlus="0" tolMinus="0" whereMeasured="METAL" stackupStatus="PROPOSED">
+                      <StackupGroup name="Group" thickness="0.14" tolPlus="0" tolMinus="0">{stackup}</StackupGroup>
+                    </Stackup><Step name="board""#));
+                let shuffled = xml
+                    .replace(r#"<Layer name="L1""#, r#"<Layer name="TEMP""#)
+                    .replace(r#"<Layer name="L3""#, r#"<Layer name="L1""#)
+                    .replace(r#"<Layer name="TEMP""#, r#"<Layer name="L3""#);
+                for xml in [&xml, &shuffled] {
+                    let evaluation = evaluate_pth(&Ipc2581::parse(xml).unwrap());
+                    assert_eq!(evaluation.checked, 2, "span {span:?}");
+                    assert_eq!(
+                        evaluation.measured.len(),
+                        2 - copper_on.len(),
+                        "span {span:?}"
+                    );
+                    if let Some(finding) = evaluation.measured.first() {
+                        assert_eq!(finding.layers[1].name, format!("L{}", terminals[1]));
+                        assert_eq!(finding.distance.mm, 0.0);
+                    }
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -527,6 +527,56 @@ limit = {{ minimum = "0.20 mm" }}
     }
 
     #[test]
+    fn physical_drill_span_is_independent_of_copper_declaration_order() {
+        for order in [
+            [0, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ] {
+            for (offender, expected_findings) in [(1, 1), (2, 0)] {
+                let xml = board("VIA", Some((0, 1)), &[copper(offender, Some("N2"), 0.55)]);
+                let declarations = xml
+                    .lines()
+                    .filter(|line| line.contains("<Layer name=\"L"))
+                    .collect::<Vec<_>>();
+                let xml = xml.replace(
+                    &declarations.join("\n"),
+                    &order.map(|i| declarations[i]).join("\n"),
+                );
+                let ipc = Ipc2581::parse(&xml).unwrap();
+                let pdk = Pdk::parse(&pdk("via")).unwrap();
+                let rules = rules::lower(&pdk, None).unwrap();
+                let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+                let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+                let mut included = design
+                    .copper_layers
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| design.holes[0].spans_copper(*index))
+                    .map(|(_, layer)| layer.layer.name.as_str())
+                    .collect::<Vec<_>>();
+                included.sort_unstable();
+                assert_eq!(included, ["L0", "L1"], "declarations {order:?}");
+                let results = checks::run(
+                    &rules,
+                    &design,
+                    None,
+                    NaiveDate::from_ymd_opt(2026, 9, 1).unwrap(),
+                );
+                assert_eq!(results.rules[0].checked, 2);
+                assert_eq!(
+                    results.findings.len(),
+                    expected_findings,
+                    "declarations {order:?}, copper L{offender}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn does_not_require_a_span_for_a_nonapplicable_named_case() {
         let xml = board("VIA", None, &[copper(0, Some("N2"), 0.55)]);
         let source = pdk("via").replace(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
@@ -139,6 +139,57 @@ mod tests {
     use pcb_ir::dialects::ipc::ArtworkScope;
 
     #[test]
+    fn physical_overlap_is_independent_of_copper_declaration_order() {
+        for order in [[0, 1, 2, 3], [0, 2, 1, 3], [0, 3, 1, 2]] {
+            // Disjoint blind spans must not interact; nested spans must.
+            for (first, second, findings) in [((0, 1), (2, 3), 0), ((0, 3), (1, 2), 1)] {
+                let layers = order.map(|i| format!(r#"<Layer name="L{i}" layerFunction="CONDUCTOR" side="INTERNAL" polarity="POSITIVE"/>"#)).join("");
+                let stackup = [0, 1, 2, 3].map(|i| format!(r#"<StackupLayer layerOrGroupRef="L{i}" thickness="0.035" tolPlus="0" tolMinus="0" sequence="{i}"/>"#)).join("");
+                let ipc = Ipc2581::parse(&format!(r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+                  <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/>
+                    <LayerRef name="L0"/><LayerRef name="L1"/><LayerRef name="L2"/><LayerRef name="L3"/><LayerRef name="D1"/><LayerRef name="D2"/>
+                  </Content><Ecad><CadHeader units="MILLIMETER"/><CadData>{layers}
+                    <Layer name="D1" layerFunction="DRILL" side="ALL" polarity="POSITIVE"><Span fromLayer="L{}" toLayer="L{}"/></Layer>
+                    <Layer name="D2" layerFunction="DRILL" side="ALL" polarity="POSITIVE"><Span fromLayer="L{}" toLayer="L{}"/></Layer>
+                    <Stackup name="Primary" overallThickness="0.14" tolPlus="0" tolMinus="0" whereMeasured="METAL" stackupStatus="PROPOSED">
+                      <StackupGroup name="Group" thickness="0.14" tolPlus="0" tolMinus="0">{stackup}</StackupGroup>
+                    </Stackup>
+                    <Step name="board" type="BOARD">
+                      <LayerFeature layerRef="D1"><Set><Hole name="H1" diameter="1" platingStatus="PLATED" x="0" y="0"/></Set></LayerFeature>
+                      <LayerFeature layerRef="D2"><Set><Hole name="H2" diameter="1" platingStatus="PLATED" x="0.1" y="0"/></Set></LayerFeature>
+                    </Step>
+                  </CadData></Ecad></IPC-2581>"#, first.0, first.1, second.0, second.1)).unwrap();
+                let pdk = Pdk::parse(
+                    r#"schema_version = 2
+                    default_profile = "test"
+                    [pdk]
+                    id = "test"
+                    name = "Test"
+                    revision = "1"
+                    [profiles.test]
+                    name = "Test"
+                    [[rules.drilling.hole_to_hole_clearance]]
+                    id = "hole-clearance"
+                    select = { first_hole = "pth", second_hole = "pth" }
+                    limit = { minimum = "0.2 mm" }
+                "#,
+                )
+                .unwrap();
+                let rules = rules::lower(&pdk, None).unwrap();
+                let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+                let design = Design::extract(&imported, ArtworkScope::Board, &rules).unwrap();
+                let evaluation = evaluate(0.2, HoleClass::Pth, HoleClass::Pth, &design);
+                assert_eq!(evaluation.checked, 2);
+                assert_eq!(
+                    evaluation.measured.len(),
+                    findings,
+                    "declarations {order:?}, spans {first:?}, {second:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn overlapping_drills_retain_exact_circle_intersection_parameters() {
         let ipc = Ipc2581::parse(r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
           <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/><LayerRef name="DRILL"/></Content>

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -2,7 +2,8 @@
 //! one layout target, in plain millimeters.
 //!
 //! Exactly the pools the configured rules read are extracted; the rest stay
-//! empty. Each pool is a flat vector in source order; derived facts that
+//! empty. Pools are flat vectors; copper follows physical stackup order
+//! when available, otherwise declaration order. Derived facts that
 //! relate pools (a hole's lands, a copper layer's boundary index) are side
 //! tables indexed like their primary pool. Extraction fails closed: a
 //! drilled feature whose plating, diameter, or outline the file does not
@@ -71,14 +72,26 @@ impl<'a> Design<'a> {
         rules: &[Rule],
     ) -> Result<Self> {
         let pools = rules::pools(rules);
-        let stackup = when(pools.stackup, || {
-            collect_physical_stackup(imported).map(Some)
-        })?;
+        // Circular drill checks must use the declared physical order even
+        // when no thickness or layer-count rule requests the stackup pool.
+        // Keep the legacy declaration-order fallback for files without one.
+        let span_checks = rules.iter().any(|rule| {
+            matches!(
+                rule.kind,
+                rules::RuleKind::HoleToCopperClearance(_)
+                    | rules::RuleKind::AnnularRing(_)
+                    | rules::RuleKind::HolePairClearance(_, _)
+            )
+        });
+        let stackup = when(
+            pools.stackup || (span_checks && !imported.stackups.is_empty()),
+            || collect_physical_stackup(imported).map(Some),
+        )?;
         let (holes, slots) = when(pools.drilled, || {
             collect_drilled(imported, scope, stackup.as_ref())
         })?;
         let copper_layers = when(pools.copper, || {
-            collect_copper_layers(imported, scope, pools.conductor_ownership)
+            collect_copper_layers(imported, scope, pools.conductor_ownership, stackup.as_ref())
         })?;
         let layout = when(pools.board_outlines || pools.board_arrays, || {
             Ok(Some(&imported.geometry))
@@ -514,10 +527,9 @@ pub(super) struct Hole {
     pub diameter_mm: f64,
     pub bbox: BBox,
     pub layer: LayerRef,
-    /// Inclusive ordinal range over the copper stackup the drill spans. A
-    /// through-board or unstated span covers every copper layer.
-    pub copper_span: (u16, u16),
     pub span_declared: bool,
+    /// Inclusive indices in the same order as `Design::copper_layers`.
+    /// Through-board or unstated spans cover every copper layer.
     pub drill_span: DrillSpan,
     pub provenance: SourceLocator,
     pub step: Option<Symbol>,
@@ -529,21 +541,26 @@ pub(super) struct Hole {
 
 impl Hole {
     pub fn spans_copper(&self, copper_index: usize) -> bool {
-        let (low, high) = self.copper_span;
+        let (low, high) = (
+            self.drill_span.first_copper_index,
+            self.drill_span.last_copper_index,
+        );
         (usize::from(low)..=usize::from(high)).contains(&copper_index)
     }
 
     /// Whether two drill spans coexist at some board depth.
     pub fn span_overlaps(&self, other: &Hole) -> bool {
-        let (self_low, self_high) = self.copper_span;
-        let (other_low, other_high) = other.copper_span;
-        self_low <= other_high && other_low <= self_high
+        self.drill_span.first_copper_index <= other.drill_span.last_copper_index
+            && other.drill_span.first_copper_index <= self.drill_span.last_copper_index
     }
 
     /// Whether `copper_index` is an end of the drill span: a layer the
     /// plating barrel must land on.
     pub fn terminates_on(&self, copper_index: usize) -> bool {
-        let (low, high) = self.copper_span;
+        let (low, high) = (
+            self.drill_span.first_copper_index,
+            self.drill_span.last_copper_index,
+        );
         copper_index == usize::from(low) || copper_index == usize::from(high)
     }
 }
@@ -770,8 +787,6 @@ fn collect_drilled(
                         diameter_mm: feature.outer_diameter,
                         bbox: BBox::from_point(feature.center).expand(feature.outer_diameter / 2.0),
                         layer: layer_ref(layer_name, source_layer.layer_function, None),
-                        copper_span: copper_span(feature.intent.span, &imported.layer_definitions)
-                            .unwrap_or(whole_stack),
                         span_declared: source_layer.span.is_some(),
                         drill_span: drill_span(
                             feature.intent.span,
@@ -1179,13 +1194,23 @@ fn collect_copper_layers(
     imported: &ImportedDesign,
     scope: ArtworkScope,
     require_conductor_ownership: bool,
+    stackup: Option<&PhysicalStackup>,
 ) -> Result<Vec<CopperLayer>> {
-    let copper_layers = imported
+    let mut copper_layers = imported
         .layer_definitions
         .iter()
         .enumerate()
         .filter(|(_, layer)| layers::is_copper(layer.layer_function))
         .collect::<Vec<_>>();
+    if let Some(stackup) = stackup {
+        copper_layers.sort_by_key(|(_, layer)| {
+            stackup
+                .copper_layers
+                .iter()
+                .position(|physical| physical.name == imported.resolve(layer.name))
+                .expect("validated stackup includes every copper layer")
+        });
+    }
     let total = copper_layers.len();
     #[cfg(not(target_family = "wasm"))]
     let copper_layers = copper_layers.into_par_iter();


### PR DESCRIPTION
Use the validated physical stackup and one drill span for circular-hole clearance and annular-ring checks. This prevents shuffled copper declarations from changing layer selection or results and preserves support for files without a stackup (fixes [ENG-1373](https://linear.app/diodeinc/issue/ENG-1373)).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1180" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->