### PR TITLE
Add nominal annular-ring baselines to IPC profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Check all IPC DFM profiles against Diode's 5 mil copper-width baseline.
 - Apply Diode's 5 mil copper-spacing baseline to all nine IPC-informed profiles.
+- Add nominal via/PTH annular-ring checks to all nine IPC-informed PDK profiles using Diode baseline limits.
 
 ### Fixed
 

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -268,9 +268,13 @@ when fewer than two exist.
   board never measures against another board or its panel outline. A feature
   crossing or outside its board material has zero clearance.
 - Annular ring measures the radial copper enclosure of each via or PTH hole
-  on every applicable layer. A genuine intermediate plane anti-pad with no
-  matching source land has no ring to measure. Both terminal layers, and any
-  layer with a matching source land, must retain copper at the hole center;
+  from its nominal circular geometry on every applicable layer. It is not
+  tolerance-aware finished-board acceptance: drill size/position, registration,
+  and plating tolerances are not modeled. Geometric flattening uncertainty is
+  not a fabrication tolerance. Plated-slot enclosure is outside this check.
+  A genuine intermediate plane anti-pad with no matching source land has no
+  ring to measure. Both terminal layers, and any layer with a matching source
+  land, must retain copper at the hole center;
   missing copper there is a zero-enclosure failure. One finding per hole
   reports the worst layer.
 - Hole-to-copper clearance measures the edge-to-edge distance from each
@@ -372,6 +376,7 @@ requirements or qualified capabilities for every technology or copper weight.
 | --- | --- | --- |
 | Copper feature width | Required minimum 5 mil (0.127 mm) | Local widths of final composed copper on every copper layer, not just nominal trace widths |
 | Copper spacing | Required minimum 5 mil (0.127 mm) | Distinct final conductors on every copper layer; fabrication spacing, not voltage-dependent insulation clearance |
+| Annular ring | Required minimum 0.125 mm for vias, 7 mil (0.1778 mm) for PTHs | Nominal circular-hole enclosure on applicable copper layers, not tolerance-aware finished-board acceptance |
 
 Output is UTF-8 JSON on stdout unless `-o` / `--output` is supplied. The
 recommended suffix is `.dfm.json`. Every complete report includes the native

--- a/crates/pcb-ipc2581-tools/pdks/ipc.toml
+++ b/crates/pcb-ipc2581-tools/pdks/ipc.toml
@@ -25,7 +25,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil"]
 source = "ipc-design-topics"
 
 [profiles.1a.defaults]
@@ -37,7 +37,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil"]
 source = "ipc-design-topics"
 
 [profiles.1b.defaults]
@@ -49,7 +49,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil"]
 source = "ipc-design-topics"
 
 [profiles.1c.defaults]
@@ -61,7 +61,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil"]
 source = "ipc-design-topics"
 
 [profiles.2a.defaults]
@@ -73,7 +73,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil"]
 source = "ipc-design-topics"
 
 [profiles.2b.defaults]
@@ -85,7 +85,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil"]
 source = "ipc-design-topics"
 
 [profiles.2c.defaults]
@@ -97,7 +97,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil"]
 source = "ipc-design-topics"
 
 [profiles.3a.defaults]
@@ -109,7 +109,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil"]
 source = "ipc-design-topics"
 
 [profiles.3b.defaults]
@@ -121,7 +121,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil"]
 source = "ipc-design-topics"
 
 [profiles.3c.defaults]
@@ -135,6 +135,18 @@ source = "diode-standard"
 [[rules.copper.clearance]]
 id = "diode.ipc_baseline.copper.minimum_clearance"
 limit = { minimum = "5 mil" }
+source = "diode-standard"
+
+[[rules.copper.annular_ring]]
+id = "diode.ipc_baseline.copper.minimum_via_annular_ring"
+select = { hole = "via" }
+limit = { minimum = "0.125 mm" }
+source = "diode-standard"
+
+[[rules.copper.annular_ring]]
+id = "diode.ipc_baseline.copper.minimum_pth_annular_ring"
+select = { hole = "pth" }
+limit = { minimum = "7 mil" }
 source = "diode-standard"
 
 [[rules.drilling.hole_aspect_ratio]]


### PR DESCRIPTION
Apply Diode's standard via and PTH annular-ring limits to all nine IPC profiles to check nominal circular-hole enclosure. Reuse the shared source citation and document that these checks do not account for manufacturing tolerances or prove finished-board acceptance.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->