### PR TITLE
Add minimum slot-width checks to IPC profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Apply Diode's 5 mil copper-spacing baseline to all nine IPC-informed profiles.
 - Add nominal via/PTH annular-ring checks to all nine IPC-informed PDK profiles using Diode baseline limits.
 - Check minimum via, PTH, and NPTH hole diameters in all nine IPC DFM profiles.
+- Check minimum plated and nonplated slot widths in all nine IPC DFM profiles using Diode baseline limits.
 
 ### Fixed
 

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -378,6 +378,7 @@ requirements or qualified capabilities for every technology or copper weight.
 | Copper spacing | Required minimum 5 mil (0.127 mm) | Distinct final conductors on every copper layer; fabrication spacing, not voltage-dependent insulation clearance |
 | Annular ring | Required minimum 0.125 mm for vias, 7 mil (0.1778 mm) for PTHs | Nominal circular-hole enclosure on applicable copper layers, not tolerance-aware finished-board acceptance |
 | Hole diameter | Required minimum 0.20 mm for vias/NPTHs, 15 mil (0.381 mm) for PTHs | Source-declared circular hole diameter, interpreted as finished size |
+| Slot width | Required minimum 0.5 mm plated, 31 mil (0.7874 mm) nonplated | IPC primitive width or PCB IR outline minimum width; excludes the optional 0.6 mm plated preferred tier |
 
 Hole-diameter checks do not model a separate drill-tool diameter, plating
 allowance, or manufacturing tolerance, and cannot verify the exporter's

--- a/crates/pcb-ipc2581-tools/pdks/ipc.toml
+++ b/crates/pcb-ipc2581-tools/pdks/ipc.toml
@@ -25,7 +25,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
 source = "ipc-design-topics"
 
 [profiles.1a.defaults]
@@ -37,7 +37,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
 source = "ipc-design-topics"
 
 [profiles.1b.defaults]
@@ -49,7 +49,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
 source = "ipc-design-topics"
 
 [profiles.1c.defaults]
@@ -61,7 +61,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
 source = "ipc-design-topics"
 
 [profiles.2a.defaults]
@@ -73,7 +73,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
 source = "ipc-design-topics"
 
 [profiles.2b.defaults]
@@ -85,7 +85,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
 source = "ipc-design-topics"
 
 [profiles.2c.defaults]
@@ -97,7 +97,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
 source = "ipc-design-topics"
 
 [profiles.3a.defaults]
@@ -109,7 +109,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
 source = "ipc-design-topics"
 
 [profiles.3b.defaults]
@@ -121,7 +121,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
 source = "ipc-design-topics"
 
 [profiles.3c.defaults]
@@ -165,6 +165,18 @@ source = "diode-standard"
 id = "diode.ipc_baseline.drilling.minimum_npth_hole_diameter"
 select = { hole = "npth" }
 limit = { minimum = "0.2 mm" }
+source = "diode-standard"
+
+[[rules.drilling.slot_width]]
+id = "diode.ipc_baseline.drilling.minimum_plated_slot_width"
+select = { plating = "plated" }
+limit = { minimum = "0.5 mm" }
+source = "diode-standard"
+
+[[rules.drilling.slot_width]]
+id = "diode.ipc_baseline.drilling.minimum_nonplated_slot_width"
+select = { plating = "nonplated" }
+limit = { minimum = "31 mil" }
 source = "diode-standard"
 
 [[rules.drilling.hole_aspect_ratio]]


### PR DESCRIPTION
Apply Diode standard minimum slot widths of 0.5 mm plated and 31 mil nonplated to all nine IPC profiles. Reuse the existing evaluator and shared source citation to extend partial baseline coverage without changing standard or JLC profiles.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1189" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->