### PR TITLE
Add circular hole-pair clearance to IPC profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Add nominal via/PTH annular-ring checks to all nine IPC-informed PDK profiles using Diode baseline limits.
 - Check minimum via, PTH, and NPTH hole diameters in all nine IPC DFM profiles.
 - Check minimum plated and nonplated slot widths in all nine IPC DFM profiles using Diode baseline limits.
+- Add circular hole-to-hole clearance to all nine IPC-informed DFM profiles using Diode's standard 10 mil baseline.
 
 ### Fixed
 

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -379,6 +379,7 @@ requirements or qualified capabilities for every technology or copper weight.
 | Annular ring | Required minimum 0.125 mm for vias, 7 mil (0.1778 mm) for PTHs | Nominal circular-hole enclosure on applicable copper layers, not tolerance-aware finished-board acceptance |
 | Hole diameter | Required minimum 0.20 mm for vias/NPTHs, 15 mil (0.381 mm) for PTHs | Source-declared circular hole diameter, interpreted as finished size |
 | Slot width | Required minimum 0.5 mm plated, 31 mil (0.7874 mm) nonplated | IPC primitive width or PCB IR outline minimum width; excludes the optional 0.6 mm plated preferred tier |
+| Hole-to-hole clearance | Required minimum 10 mil (0.254 mm) | All six unordered circular via/PTH/NPTH pair classes with overlapping physical drill spans; excludes routed-slot pairs |
 
 Hole-diameter checks do not model a separate drill-tool diameter, plating
 allowance, or manufacturing tolerance, and cannot verify the exporter's

--- a/crates/pcb-ipc2581-tools/pdks/ipc.toml
+++ b/crates/pcb-ipc2581-tools/pdks/ipc.toml
@@ -25,7 +25,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance"]
 source = "ipc-design-topics"
 
 [profiles.1a.defaults]
@@ -37,7 +37,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance"]
 source = "ipc-design-topics"
 
 [profiles.1b.defaults]
@@ -49,7 +49,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance"]
 source = "ipc-design-topics"
 
 [profiles.1c.defaults]
@@ -61,7 +61,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance"]
 source = "ipc-design-topics"
 
 [profiles.2a.defaults]
@@ -73,7 +73,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance"]
 source = "ipc-design-topics"
 
 [profiles.2b.defaults]
@@ -85,7 +85,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance"]
 source = "ipc-design-topics"
 
 [profiles.2c.defaults]
@@ -97,7 +97,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance"]
 source = "ipc-design-topics"
 
 [profiles.3a.defaults]
@@ -109,7 +109,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance"]
 source = "ipc-design-topics"
 
 [profiles.3b.defaults]
@@ -121,7 +121,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance"]
 source = "ipc-design-topics"
 
 [profiles.3c.defaults]
@@ -177,6 +177,42 @@ source = "diode-standard"
 id = "diode.ipc_baseline.drilling.minimum_nonplated_slot_width"
 select = { plating = "nonplated" }
 limit = { minimum = "31 mil" }
+source = "diode-standard"
+
+[[rules.drilling.hole_to_hole_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_hole_to_hole_clearance.via_via"
+select = { first_hole = "via", second_hole = "via" }
+limit = { minimum = "10 mil" }
+source = "diode-standard"
+
+[[rules.drilling.hole_to_hole_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_hole_to_hole_clearance.via_pth"
+select = { first_hole = "via", second_hole = "pth" }
+limit = { minimum = "10 mil" }
+source = "diode-standard"
+
+[[rules.drilling.hole_to_hole_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_hole_to_hole_clearance.via_npth"
+select = { first_hole = "via", second_hole = "npth" }
+limit = { minimum = "10 mil" }
+source = "diode-standard"
+
+[[rules.drilling.hole_to_hole_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_hole_to_hole_clearance.pth_pth"
+select = { first_hole = "pth", second_hole = "pth" }
+limit = { minimum = "10 mil" }
+source = "diode-standard"
+
+[[rules.drilling.hole_to_hole_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_hole_to_hole_clearance.pth_npth"
+select = { first_hole = "pth", second_hole = "npth" }
+limit = { minimum = "10 mil" }
+source = "diode-standard"
+
+[[rules.drilling.hole_to_hole_clearance]]
+id = "diode.ipc_baseline.drilling.minimum_hole_to_hole_clearance.npth_npth"
+select = { first_hole = "npth", second_hole = "npth" }
+limit = { minimum = "10 mil" }
 source = "diode-standard"
 
 [[rules.drilling.hole_aspect_ratio]]


### PR DESCRIPTION
Apply the Diode standard 10 mil minimum to all six circular via/PTH/NPTH hole-pair classes in all nine IPC profiles. Reuse the existing physical-span check and shared baseline source to close this coverage gap without changing standard or JLC profiles.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->