### PR TITLE
Check slot-to-copper clearance with Diode guidance warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Add circular hole-to-hole clearance to all nine IPC-informed DFM profiles using Diode's standard 10 mil baseline.
 - Check copper-to-board-edge and cutout clearance at 15 mil in all nine IPC-informed DFM profiles.
 - Warn about soldermask webs below 4 mil in all nine IPC-informed DFM profiles.
-- Check plated and nonplated slot clearance to unrelated copper, with Diode baseline limits in IPC profiles.
+- Check plated and nonplated slot-to-copper clearance, with Diode guidance warnings in standard and IPC profiles.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Add circular hole-to-hole clearance to all nine IPC-informed DFM profiles using Diode's standard 10 mil baseline.
 - Check copper-to-board-edge and cutout clearance at 15 mil in all nine IPC-informed DFM profiles.
 - Warn about soldermask webs below 4 mil in all nine IPC-informed DFM profiles.
+- Check plated and nonplated slot clearance to unrelated copper, with Diode baseline limits in IPC profiles.
 
 ### Fixed
 

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -86,6 +86,11 @@ id = "copper.via_hole_clearance"
 select = { hole = "via" }
 limit = { minimum = "0.20 mm", preferred = "0.25 mm" }
 
+[[rules.copper.slot_clearance]]
+id = "copper.plated_slot_clearance"
+select = { plating = "plated" }
+limit = { minimum = "0.40 mm", preferred = "0.50 mm" }
+
 [[rules.copper.feature_width]]
 id = "copper.feature_width"
 cases = [
@@ -178,6 +183,7 @@ high-level pass is never allowed to suppress a later authoritative failure.
 | Slot-to-board-edge clearance | Materialized filled route outline against its enclosing physical board profile, including cutouts | Indexed profile boundaries |
 | Annular ring | Drill circle and final composed copper image on each applicable layer | Batched containment and an indexed copper boundary |
 | Hole-to-copper clearance | Analytic drill circle and attributed final composed copper on each layer in its drill span | Indexed attributed-copper boundaries |
+| Slot-to-copper clearance | Materialized filled route outline and attributed final composed copper on each layer in its physical span | Indexed region boundaries |
 | Copper width | Final composed copper image, medial-axis width of each residue | Guarded opening localizes candidates |
 | Copper clearance | Final composed copper attributed to occurrence-scoped electrical conductors | Sorted bounds prune conductor components already proven clear |
 | Soldermask web | Final composed mask-opening image, medial-axis width of each residue | Guarded closing localizes candidates |
@@ -282,6 +288,16 @@ when fewer than two exist.
   layer in its declared span. Via and PTH copper is exempt only when net or
   physical-land identity proves that it belongs to the hole. NPTH copper is
   never exempt. Missing drill-span identity makes the check incomplete.
+- Slot-to-copper clearance (`rules.copper.slot_clearance`) measures the true
+  materialized filled slot outline, including its ends, against unrelated
+  final copper on its physical span. Touching or overlapping copper has zero
+  clearance. Select `plated` or `nonplated` with `select.plating`. Plated slots
+  exempt only occurrence-scoped own-net copper or resolved physical lands
+  with matching stated padstack identity and no contradictory stated net;
+  netless functional and foreign copper remain offenders. Nonplated slots
+  exempt nothing. The rule requires one unambiguous physical stackup and a
+  declared through or resolvable layer span; missing data fails extraction.
+  Copper layer declaration order does not determine the physical span.
 - Copper feature-width rules report narrow copper piece by piece after final
   polarity composition. Copper-clearance rules measure the shortest
   boundary distance between distinct final conductor images. Same-net
@@ -359,8 +375,10 @@ ratio at 6.0 for Level A, 8.0 for Level B, and 10.0 for Level C. They also
 check via, PTH, and NPTH hole-to-copper clearance at 0.25 mm for Level A,
 0.20 mm for Level B, and 0.15 mm for Level C. They check via, PTH, NPTH,
 plated-slot, and nonplated-slot clearance to the board edge at 0.50 mm for
-Level A, 0.40 mm for Level B, and 0.30 mm for Level C. These values apply
-across all three performance classes. Each profile assumes 1.6 mm board
+Level A, 0.40 mm for Level B, and 0.30 mm for Level C. Plated and nonplated
+slot-to-copper clearance uses the same 0.50 / 0.40 / 0.30 mm A/B/C limits:
+Diode deliberately allows more routing margin than for circular drills.
+These values apply across all three performance classes. Each profile assumes 1.6 mm board
 thickness for the through-hole aspect-ratio fallback described above. Diode
 chose these opinionated values using IPC design topics as context; they are not
 licensed IPC numeric matrices, do not prove full IPC compliance, and do not

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -297,6 +297,8 @@ when fewer than two exist.
   netless functional and foreign copper remain offenders. Nonplated slots
   exempt nothing. The rule requires one unambiguous physical stackup and a
   declared through or resolvable layer span; missing data fails extraction.
+  This eligibility requirement also applies to preferred warning tiers: missing
+  data is an incomplete check, not a geometric shortfall or a valid pass.
   Copper layer declaration order does not determine the physical span.
 - Copper feature-width rules report narrow copper piece by piece after final
   polarity composition. Copper-clearance rules measure the shortest
@@ -360,6 +362,12 @@ and checks. `--layout-target` accepts
 `board` or `board-array` and defaults to `board-array`. Add
 `--waivers waivers.toml` to apply a [waiver file](#waivers).
 
+The `standard` PDK prefers 0.40 mm plated and nonplated slot-to-copper
+clearance. Shortfalls produce warnings, not a failed manufacturing verdict.
+This is conservative Diode routing guidance, not a manufacturer capability
+or an IPC requirement. Slot clearance is not enabled in `jlcpcb-1oz` without
+a manufacturer source.
+
 The `jlcpcb-1oz` PDK, also available as `jlc`, executes the public rigid FR-4
 capability table for 2-32 copper layers and 1 oz outer copper. It deliberately
 omits the one-layer NPTH-only service, 2 oz rules, local 3 mil BGA exceptions,
@@ -376,8 +384,9 @@ check via, PTH, and NPTH hole-to-copper clearance at 0.25 mm for Level A,
 0.20 mm for Level B, and 0.15 mm for Level C. They check via, PTH, NPTH,
 plated-slot, and nonplated-slot clearance to the board edge at 0.50 mm for
 Level A, 0.40 mm for Level B, and 0.30 mm for Level C. Plated and nonplated
-slot-to-copper clearance uses the same 0.50 / 0.40 / 0.30 mm A/B/C limits:
-Diode deliberately allows more routing margin than for circular drills.
+slot-to-copper clearance prefers 0.50 / 0.40 / 0.30 mm for A/B/C and warns
+on shortfalls. Diode deliberately allows more routing margin than for circular
+drills; these are opinionated guidance, not IPC requirements.
 These values apply across all three performance classes. Each profile assumes 1.6 mm board
 thickness for the through-hole aspect-ratio fallback described above. Diode
 chose these opinionated values using IPC design topics as context; they are not

--- a/crates/pcb-ipc2581-tools/pdks/ipc.toml
+++ b/crates/pcb-ipc2581-tools/pdks/ipc.toml
@@ -25,7 +25,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only", "Diode guidance: preferred plated/nonplated slot-to-copper clearance at 0.50 mm, warning only"]
 source = "ipc-design-topics"
 
 [profiles.1a.defaults]
@@ -37,7 +37,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only", "Diode guidance: preferred plated/nonplated slot-to-copper clearance at 0.40 mm, warning only"]
 source = "ipc-design-topics"
 
 [profiles.1b.defaults]
@@ -49,7 +49,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 1
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only", "Diode guidance: preferred plated/nonplated slot-to-copper clearance at 0.30 mm, warning only"]
 source = "ipc-design-topics"
 
 [profiles.1c.defaults]
@@ -61,7 +61,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only", "Diode guidance: preferred plated/nonplated slot-to-copper clearance at 0.50 mm, warning only"]
 source = "ipc-design-topics"
 
 [profiles.2a.defaults]
@@ -73,7 +73,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only", "Diode guidance: preferred plated/nonplated slot-to-copper clearance at 0.40 mm, warning only"]
 source = "ipc-design-topics"
 
 [profiles.2b.defaults]
@@ -85,7 +85,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 2
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only", "Diode guidance: preferred plated/nonplated slot-to-copper clearance at 0.30 mm, warning only"]
 source = "ipc-design-topics"
 
 [profiles.2c.defaults]
@@ -97,7 +97,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "A"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.25 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.50 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only", "Diode guidance: preferred plated/nonplated slot-to-copper clearance at 0.50 mm, warning only"]
 source = "ipc-design-topics"
 
 [profiles.3a.defaults]
@@ -109,7 +109,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "B"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.20 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.40 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only", "Diode guidance: preferred plated/nonplated slot-to-copper clearance at 0.40 mm, warning only"]
 source = "ipc-design-topics"
 
 [profiles.3b.defaults]
@@ -121,7 +121,7 @@ description = "Diode's opinionated partial baseline informed by IPC design topic
 performance_class = 3
 producibility_level = "C"
 technologies = ["rigid", "flex", "rigid_flex", "hdi"]
-coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only"]
+coverage = ["Diode baseline: maximum via aspect ratio", "Diode baseline: maximum PTH aspect ratio", "Diode baseline: via, PTH, and NPTH hole-to-copper clearance at 0.15 mm", "Diode baseline: via, PTH, NPTH, plated-slot, and nonplated-slot board-edge clearance at 0.30 mm", "Diode standard baseline: minimum final copper feature width at 5 mil (0.127 mm) on every copper layer", "Diode standard baseline: distinct-conductor copper spacing at 5 mil (0.127 mm)", "Diode standard baseline: nominal circular via/PTH annular ring at 0.125 mm / 7 mil", "Diode standard baseline: minimum hole diameter, via/NPTH 0.20 mm and PTH 15 mil (0.381 mm)", "Diode standard baseline: minimum plated/nonplated slot width at 0.5 mm / 31 mil (0.7874 mm)", "Diode standard baseline: all six unordered circular via/PTH/NPTH hole pairs at 10 mil (0.254 mm) clearance", "Diode standard baseline: copper-to-board-edge and cutout clearance at 15 mil (0.381 mm)", "Diode standard baseline: preferred soldermask web at 4 mil (0.1016 mm), warning only", "Diode guidance: preferred plated/nonplated slot-to-copper clearance at 0.30 mm, warning only"]
 source = "ipc-design-topics"
 
 [profiles.3c.defaults]
@@ -434,3 +434,47 @@ source = "ipc-design-topics"
 id = "diode.ipc_baseline.soldermask.minimum_web"
 limit = { preferred = "4 mil" }
 source = "diode-standard"
+
+# Diode routing margin, deliberately larger than circular-hole copper clearance.
+# These are conservative baseline choices, not IPC-specified numeric limits.
+[[rules.copper.slot_clearance]]
+id = "diode.ipc_baseline.copper.plated_slot_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { plating = "plated" }
+limit = { minimum = "0.50 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.slot_clearance]]
+id = "diode.ipc_baseline.copper.nonplated_slot_clearance.level_a"
+profiles = ["1a", "2a", "3a"]
+select = { plating = "nonplated" }
+limit = { minimum = "0.50 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.slot_clearance]]
+id = "diode.ipc_baseline.copper.plated_slot_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { plating = "plated" }
+limit = { minimum = "0.40 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.slot_clearance]]
+id = "diode.ipc_baseline.copper.nonplated_slot_clearance.level_b"
+profiles = ["1b", "2b", "3b"]
+select = { plating = "nonplated" }
+limit = { minimum = "0.40 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.slot_clearance]]
+id = "diode.ipc_baseline.copper.plated_slot_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { plating = "plated" }
+limit = { minimum = "0.30 mm" }
+source = "ipc-design-topics"
+
+[[rules.copper.slot_clearance]]
+id = "diode.ipc_baseline.copper.nonplated_slot_clearance.level_c"
+profiles = ["1c", "2c", "3c"]
+select = { plating = "nonplated" }
+limit = { minimum = "0.30 mm" }
+source = "ipc-design-topics"

--- a/crates/pcb-ipc2581-tools/pdks/ipc.toml
+++ b/crates/pcb-ipc2581-tools/pdks/ipc.toml
@@ -435,46 +435,47 @@ id = "diode.ipc_baseline.soldermask.minimum_web"
 limit = { preferred = "4 mil" }
 source = "diode-standard"
 
-# Diode routing margin, deliberately larger than circular-hole copper clearance.
-# These are conservative baseline choices, not IPC-specified numeric limits.
+# Diode preferred routing margin, larger than circular-hole copper clearance.
+# Shortfalls warn: these are opinionated guidance, not IPC requirements.
+# A physical stackup and declared/resolved slot span are still required inputs.
 [[rules.copper.slot_clearance]]
 id = "diode.ipc_baseline.copper.plated_slot_clearance.level_a"
 profiles = ["1a", "2a", "3a"]
 select = { plating = "plated" }
-limit = { minimum = "0.50 mm" }
+limit = { preferred = "0.50 mm" }
 source = "ipc-design-topics"
 
 [[rules.copper.slot_clearance]]
 id = "diode.ipc_baseline.copper.nonplated_slot_clearance.level_a"
 profiles = ["1a", "2a", "3a"]
 select = { plating = "nonplated" }
-limit = { minimum = "0.50 mm" }
+limit = { preferred = "0.50 mm" }
 source = "ipc-design-topics"
 
 [[rules.copper.slot_clearance]]
 id = "diode.ipc_baseline.copper.plated_slot_clearance.level_b"
 profiles = ["1b", "2b", "3b"]
 select = { plating = "plated" }
-limit = { minimum = "0.40 mm" }
+limit = { preferred = "0.40 mm" }
 source = "ipc-design-topics"
 
 [[rules.copper.slot_clearance]]
 id = "diode.ipc_baseline.copper.nonplated_slot_clearance.level_b"
 profiles = ["1b", "2b", "3b"]
 select = { plating = "nonplated" }
-limit = { minimum = "0.40 mm" }
+limit = { preferred = "0.40 mm" }
 source = "ipc-design-topics"
 
 [[rules.copper.slot_clearance]]
 id = "diode.ipc_baseline.copper.plated_slot_clearance.level_c"
 profiles = ["1c", "2c", "3c"]
 select = { plating = "plated" }
-limit = { minimum = "0.30 mm" }
+limit = { preferred = "0.30 mm" }
 source = "ipc-design-topics"
 
 [[rules.copper.slot_clearance]]
 id = "diode.ipc_baseline.copper.nonplated_slot_clearance.level_c"
 profiles = ["1c", "2c", "3c"]
 select = { plating = "nonplated" }
-limit = { minimum = "0.30 mm" }
+limit = { preferred = "0.30 mm" }
 source = "ipc-design-topics"

--- a/crates/pcb-ipc2581-tools/pdks/standard.toml
+++ b/crates/pcb-ipc2581-tools/pdks/standard.toml
@@ -8,6 +8,11 @@ revision = "draft-2026-09-03"
 manufacturer = "Diode"
 process = "Standard"
 
+[sources.diode-slot-guidance]
+title = "Diode slot-to-copper routing guidance"
+url = "https://github.com/diodeinc/pcb/blob/main/crates/pcb-ipc2581-tools/docs/dfm.md"
+note = "Diode prefers 0.40 mm clearance for plated and nonplated slots as conservative routing guidance, not a manufacturer capability or IPC requirement. Shortfalls warn; missing physical stackup or declared slot span remains an input error."
+
 [profiles.standard]
 name = "Diode standard"
 description = "General-purpose defaults retained from the original Diode DFM PDK."
@@ -88,6 +93,18 @@ limit = { minimum = "5 mil" }
 [[rules.copper.clearance]]
 id = "copper.minimum_copper_clearance"
 limit = { minimum = "5 mil" }
+
+[[rules.copper.slot_clearance]]
+id = "diode.standard.copper.plated_slot_clearance"
+select = { plating = "plated" }
+limit = { preferred = "0.40 mm" }
+source = "diode-slot-guidance"
+
+[[rules.copper.slot_clearance]]
+id = "diode.standard.copper.nonplated_slot_clearance"
+select = { plating = "nonplated" }
+limit = { preferred = "0.40 mm" }
+source = "diode-slot-guidance"
 
 [[rules.copper.board_edge_clearance]]
 id = "copper.minimum_board_edge_clearance"

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -177,7 +177,7 @@ fn owned_by_hole(
     })
 }
 
-fn land_owns_conductor(land: &Land, conductor: ConductorId) -> bool {
+pub(super) fn land_owns_conductor(land: &Land, conductor: ConductorId) -> bool {
     match conductor {
         ConductorId::Net {
             step,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -653,7 +653,9 @@ fn slot_subject(design: &Design, slot: &Slot, role: &'static str) -> Subject {
         slot.source_feature_index,
     );
     subject.provenance = Some(slot.provenance.clone());
-    subject.drill_span = Some(slot.drill_span.clone());
+    // Width and board-edge checks need not resolve the physical stackup.
+    // Do not present their declaration-order fallback as a physical span.
+    subject.drill_span = design.stackup.as_ref().map(|_| slot.drill_span.clone());
     subject
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/mod.rs
@@ -18,6 +18,7 @@ mod hole_diameter;
 mod hole_pair_clearance;
 mod layer_count;
 mod linework_clearance;
+mod slot_clearance;
 mod slot_width;
 mod thin_regions;
 
@@ -312,7 +313,7 @@ fn skip_reason(rule: &Rule, design: &Design) -> Option<String> {
             .iter()
             .all(|hole| hole.class != class)
             .then(|| format!("{} holes", class.label())),
-        RuleKind::SlotWidth(plating) => design
+        RuleKind::SlotWidth(plating) | RuleKind::SlotToCopperClearance(plating) => design
             .slots
             .iter()
             .all(|slot| !slot_matches(slot.plating, plating))
@@ -371,6 +372,9 @@ fn evaluate(rule: &Rule, design: &Design) -> RuleEvaluation {
         RuleKind::HoleToCopperClearance(class) => {
             hole_clearance::evaluate(limit(), class, &rule.conditions, design).into()
         }
+        RuleKind::SlotToCopperClearance(plating) => {
+            slot_clearance::evaluate(limit(), plating, &rule.conditions, design).into()
+        }
         RuleKind::LineworkToCopperClearance(linework) => {
             linework_clearance::evaluate(limit(), linework, &rule.conditions, design).into()
         }
@@ -385,7 +389,10 @@ fn evaluate(rule: &Rule, design: &Design) -> RuleEvaluation {
     }
 }
 
-fn slot_matches(actual: pcb_ir::dialects::ipc::PlatingKind, expected: SlotPlating) -> bool {
+pub(super) fn slot_matches(
+    actual: pcb_ir::dialects::ipc::PlatingKind,
+    expected: SlotPlating,
+) -> bool {
     matches!(
         (actual, expected),
         (
@@ -646,6 +653,7 @@ fn slot_subject(design: &Design, slot: &Slot, role: &'static str) -> Subject {
         slot.source_feature_index,
     );
     subject.provenance = Some(slot.provenance.clone());
+    subject.drill_span = Some(slot.drill_span.clone());
     subject
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
@@ -1,0 +1,346 @@
+//! Filled materialized slot to attributed final copper, on its declared span.
+//! Nonplated slots exempt nothing. Plated slots exempt only occurrence-scoped
+//! net ownership or canonical physical lands; proximity never implies ownership.
+
+use pcb_ir::geom::dfm::{region_clearance_sites_with_index, region_clearance_within};
+
+use crate::commands::dfm::design::{ConductorId, Design};
+use crate::commands::dfm::pdk::SlotPlating;
+use crate::commands::dfm::report::Evidence;
+use crate::commands::dfm::rules::Conditions;
+
+use super::copper_clearance::conductor_subject;
+use super::hole_clearance::land_owns_conductor;
+use super::{Evaluation, Measured, layers, linework_clearance, slot_matches, slot_subject};
+
+pub(super) fn evaluate(
+    limit_mm: f64,
+    plating: SlotPlating,
+    conditions: &Conditions,
+    design: &Design,
+) -> Evaluation {
+    let mut checked = 0;
+    let mut measured = Vec::new();
+    let stackup = design
+        .stackup
+        .as_ref()
+        .expect("slot clearance requires a physical stackup");
+    for (slot_index, slot) in design
+        .slots
+        .iter()
+        .enumerate()
+        .filter(|(_, slot)| slot_matches(slot.plating, plating))
+    {
+        let boundary = slot.outline.prepare_query();
+        let owner = slot.net.map(|net| ConductorId::Net {
+            step: slot.step,
+            instance: slot.provenance.instance_index,
+            net,
+        });
+        for (copper_index, copper) in design.copper_layers.iter().enumerate() {
+            let span_layers = &stackup.copper_layers[usize::from(slot.drill_span.first_copper_index)
+                ..=usize::from(slot.drill_span.last_copper_index)];
+            if !span_layers
+                .iter()
+                .any(|layer| layer.name == copper.layer.name)
+                || !conditions.applies_to_layer(copper)
+            {
+                continue;
+            }
+            checked += 1;
+            // A canonical link can mean unique overlap, not identity. Exempt
+            // a land only with stated padstack identity and no conflicting net.
+            let own_lands = design.slot_lands[slot_index]
+                .iter()
+                .filter(|link| link.copper_index as usize == copper_index)
+                .map(|link| &copper.lands[link.land_index as usize])
+                .filter(|land| slot.padstack == Some(land.padstack))
+                .filter(|land| {
+                    slot.net
+                        .zip(land.net)
+                        .is_none_or(|(slot_net, land_net)| slot_net == land_net)
+                })
+                .collect::<Vec<_>>();
+            let nearest = copper
+                .conductors
+                .iter()
+                .zip(&design.conductor_boundaries[copper_index])
+                .filter(|(conductor, _)| {
+                    plating == SlotPlating::Nonplated
+                        || !(owner == Some(conductor.id)
+                            || own_lands
+                                .iter()
+                                .any(|land| land_owns_conductor(land, conductor.id)))
+                })
+                .filter_map(|(conductor, copper_boundary)| {
+                    region_clearance_within(
+                        &slot.outline,
+                        &boundary,
+                        &conductor.image,
+                        copper_boundary,
+                        limit_mm,
+                    )
+                    .map(|distance| (conductor, copper_boundary, distance))
+                })
+                .min_by(|(_, _, left), (_, _, right)| left.mm.total_cmp(&right.mm));
+            let Some((offender, copper_boundary, distance)) = nearest else {
+                continue;
+            };
+            let finding_layers = layers([&slot.layer, &copper.layer]);
+            let subjects = vec![
+                slot_subject(design, slot, "slot"),
+                conductor_subject(design, offender.id, "offender", &copper.layer.name),
+            ];
+            let evidence = vec![
+                Evidence::region("routed_slot", &slot.outline),
+                Evidence::bounds("offending_copper", offender.image.bbox),
+            ];
+            let sites = region_clearance_sites_with_index(
+                &slot.outline,
+                &offender.image,
+                copper_boundary,
+                limit_mm,
+            )
+            .into_iter()
+            .map(|geometry| {
+                let mut site =
+                    linework_clearance::report_site(geometry, finding_layers.clone(), limit_mm);
+                site.subjects = subjects.clone();
+                site.evidence.extend(evidence.clone());
+                site
+            })
+            .collect();
+            measured.push(Measured {
+                distance,
+                bbox: slot
+                    .bbox
+                    .union(pcb_ir::geom::BBox::from_point(distance.second)),
+                layers: finding_layers,
+                subjects,
+                evidence,
+                sites,
+            });
+        }
+    }
+    Evaluation { checked, measured }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::LayoutTarget;
+    use crate::commands::dfm::{self, CheckRequest, PdkSource, TextSource, report};
+    use crate::ipc2581::Ipc2581;
+
+    fn pdk(plating: &str) -> String {
+        format!(
+            r#"schema_version = 2
+default_profile = "test"
+[pdk]
+id = "slot-test"
+name = "Slot test"
+revision = "1"
+[profiles.test]
+name = "Test"
+[[rules.copper.slot_clearance]]
+id = "slot-clearance"
+select = {{ plating = "{plating}" }}
+limit = {{ minimum = "0.20 mm" }}
+"#
+        )
+    }
+
+    // Declaration order deliberately differs from physical copper order.
+    fn board(plating: &str, slot_set: &str, copper: &str) -> String {
+        format!(
+            r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+<Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/>
+<LayerRef name="L0"/><LayerRef name="L1"/><LayerRef name="L2"/><LayerRef name="ROUT"/>
+<DictionaryStandard units="MILLIMETER"><EntryStandard id="land"><Oval width="2.4" height="1"/></EntryStandard></DictionaryStandard>
+</Content><Ecad><CadHeader units="MILLIMETER"/><CadData>
+<Layer name="L0" layerFunction="CONDUCTOR" side="TOP" polarity="POSITIVE"/>
+<Layer name="L2" layerFunction="CONDUCTOR" side="BOTTOM" polarity="POSITIVE"/>
+<Layer name="L1" layerFunction="CONDUCTOR" side="INTERNAL" polarity="POSITIVE"/>
+<Layer name="ROUT" layerFunction="ROUT" side="ALL" polarity="POSITIVE"><Span fromLayer="L0" toLayer="L1"/></Layer>
+<Stackup name="primary" overallThickness="1.6" tolPlus="0" tolMinus="0" whereMeasured="METAL" stackupStatus="PROPOSED">
+<StackupGroup name="group" thickness="1.6" tolPlus="0" tolMinus="0">
+<StackupLayer layerOrGroupRef="L0" thickness="0.035" tolPlus="0" tolMinus="0" sequence="0"/>
+<StackupLayer layerOrGroupRef="L1" thickness="0.035" tolPlus="0" tolMinus="0" sequence="1"/>
+<StackupLayer layerOrGroupRef="L2" thickness="0.035" tolPlus="0" tolMinus="0" sequence="2"/>
+</StackupGroup></Stackup>
+<Step name="board" type="BOARD"><Datum x="0" y="0"/>
+<PadStackDef name="land-stack"><PadstackPadDef layerRef="L0" padUse="REGULAR"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></PadstackPadDef></PadStackDef>
+{copper}
+<LayerFeature layerRef="ROUT"><Set {slot_set}>
+<SlotCavity name="S1" platingStatus="{plating}"><Location x="0" y="0"/><Oval width="2" height="0.6"/></SlotCavity>
+</Set></LayerFeature></Step></CadData></Ecad></IPC-2581>"#
+        )
+    }
+
+    fn copper(net: &str) -> String {
+        format!(
+            r#"<LayerFeature layerRef="L0"><Set {net}><Features><Contour><Polygon>
+<PolyBegin x="1.1" y="-0.5"/><PolyStepSegment x="2" y="-0.5"/>
+<PolyStepSegment x="2" y="0.5"/><PolyStepSegment x="1.1" y="0.5"/><PolyStepSegment x="1.1" y="-0.5"/>
+</Polygon></Contour></Features></Set></LayerFeature>"#
+        )
+    }
+
+    fn check(xml: &str, source: &str, target: LayoutTarget) -> anyhow::Result<report::DfmReport> {
+        let imported = pcb_ir::import::ipc2581::import_design(&Ipc2581::parse(xml)?)?;
+        dfm::check(
+            &imported,
+            CheckRequest {
+                input: report::FileIdentity::new("slot.xml", xml.as_bytes()),
+                pdk: PdkSource::Toml(TextSource {
+                    path: "slot.toml",
+                    source,
+                }),
+                waivers: None,
+                layout_target: target,
+                generated_at: chrono::DateTime::from_timestamp(0, 0).unwrap(),
+            },
+        )
+    }
+
+    #[test]
+    fn plated_ownership_and_nonplated_clearance_use_the_slot_ends_not_its_width() {
+        for (plating, selector, net, fails) in [
+            ("PLATED", "plated", "net=\"N1\"", false),
+            ("PLATED", "plated", "net=\"N2\"", true),
+            ("PLATED", "plated", "", true),
+            ("NONPLATED", "nonplated", "net=\"N1\"", true),
+        ] {
+            let result = check(
+                &board(plating, "net=\"N1\"", &copper(net)),
+                &pdk(selector),
+                LayoutTarget::Board,
+            )
+            .unwrap();
+            assert_eq!(result.rules[0].checked, 2);
+            assert_eq!(result.findings.len(), usize::from(fails), "{result:#?}");
+            if fails {
+                let finding = &result.findings[0];
+                assert!((finding.measurement.actual_mm().unwrap() - 0.1).abs() < 1e-8);
+                assert_eq!(
+                    finding.subjects[0]
+                        .drill_span
+                        .as_ref()
+                        .unwrap()
+                        .last_copper_index,
+                    1
+                );
+                assert!(!finding.sites.is_empty());
+                assert!(
+                    result
+                        .scene
+                        .passes
+                        .iter()
+                        .any(|pass| pass.feature == "drills"
+                            && pass.layer.as_deref() == Some("ROUT"))
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn only_the_proven_physical_land_is_exempt_not_other_netless_copper() {
+        let land = r#"<LayerFeature layerRef="L0"><Set><Pad padstackDefRef="land-stack"><Location x="0" y="0"/><StandardPrimitiveRef id="land"/></Pad></Set></LayerFeature>"#;
+        let own = check(
+            &board("PLATED", "geometry=\"land-stack\"", land),
+            &pdk("plated"),
+            LayoutTarget::Board,
+        )
+        .unwrap();
+        assert!(own.findings.is_empty());
+        for (identity, copper_land) in [
+            ("", land.to_owned()),
+            (
+                "geometry=\"land-stack\" net=\"N1\"",
+                land.replace("<Set>", "<Set net=\"N2\">"),
+            ),
+        ] {
+            let unproven = check(
+                &board("PLATED", identity, &copper_land),
+                &pdk("plated"),
+                LayoutTarget::Board,
+            )
+            .unwrap();
+            assert_eq!(
+                unproven.findings.len(),
+                1,
+                "overlap or conflicting net is not ownership"
+            );
+        }
+        let foreign = check(
+            &board(
+                "PLATED",
+                "geometry=\"land-stack\"",
+                &format!("{land}{}", copper("")),
+            ),
+            &pdk("plated"),
+            LayoutTarget::Board,
+        )
+        .unwrap();
+        assert_eq!(foreign.findings.len(), 1);
+        assert_eq!(foreign.findings[0].subjects[1].kind, "unattributed_copper");
+        let nonplated = check(
+            &board("NONPLATED", "geometry=\"land-stack\"", land),
+            &pdk("nonplated"),
+            LayoutTarget::Board,
+        )
+        .unwrap();
+        assert_eq!(nonplated.findings[0].measurement.actual_mm(), Some(0.0));
+    }
+
+    #[test]
+    fn physical_span_survives_mirrored_repeats_and_missing_span_fails_closed() {
+        let source = pdk("plated");
+        let outside = board(
+            "PLATED",
+            "net=\"N1\"",
+            &copper("net=\"N2\"").replace("layerRef=\"L0\"", "layerRef=\"L2\""),
+        );
+        assert!(
+            check(&outside, &source, LayoutTarget::Board)
+                .unwrap()
+                .findings
+                .is_empty()
+        );
+        let inside = outside.replace("layerRef=\"L2\"", "layerRef=\"L1\"");
+        let panel = inside.replace("<StepRef name=\"board\"/>", "<StepRef name=\"panel\"/>")
+            .replace("</CadData>", r#"<Step name="panel" type="PALLET"><StepRepeat stepRef="board" x="10" y="20" nx="2" ny="1" dx="20" dy="0" mirror="true"/></Step></CadData>"#);
+        let repeated = check(&panel, &source, LayoutTarget::BoardArray).unwrap();
+        assert_eq!(repeated.rules[0].checked, 4);
+        assert_eq!(repeated.findings.len(), 2);
+        for finding in &repeated.findings {
+            assert!((finding.measurement.actual_mm().unwrap() - 0.1).abs() < 1e-8);
+            assert_eq!(
+                finding.subjects[0]
+                    .provenance
+                    .as_ref()
+                    .unwrap()
+                    .instance_index,
+                finding.subjects[1]
+                    .provenance
+                    .as_ref()
+                    .unwrap()
+                    .instance_index
+            );
+        }
+        let missing = inside.replace("<Span fromLayer=\"L0\" toLayer=\"L1\"/>", "");
+        assert!(
+            check(&missing, &source, LayoutTarget::Board)
+                .unwrap_err()
+                .to_string()
+                .contains("no resolvable drill span")
+        );
+        let inactive = source.replace("limit = { minimum = \"0.20 mm\" }", "cases = [{ id = \"two\", when = { copper_layers = { exact = 2 } }, limit = { minimum = \"0.20 mm\" } }]");
+        assert!(matches!(
+            check(&missing, &inactive, LayoutTarget::Board)
+                .unwrap()
+                .rules[0]
+                .status,
+            report::RuleStatus::Skipped
+        ));
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
@@ -197,6 +197,41 @@ limit = {{ minimum = "0.20 mm" }}
     }
 
     #[test]
+    fn standard_slot_clearance_warns_without_failing_but_requires_a_span() {
+        let standard = dfm::builtin_pdks()
+            .iter()
+            .find(|pdk| pdk.name == "standard")
+            .unwrap();
+        for plating in ["PLATED", "NONPLATED"] {
+            let xml = board(plating, "net=\"N1\"", &copper("net=\"N2\""))
+                .replace("height=\"0.6\"", "height=\"0.8\"")
+                .replace(
+                    "<Datum x=\"0\" y=\"0\"/>",
+                    r#"<Datum x="0" y="0"/><Profile><Polygon>
+<PolyBegin x="-10" y="-10"/><PolyStepSegment x="10" y="-10"/>
+<PolyStepSegment x="10" y="10"/><PolyStepSegment x="-10" y="10"/>
+<PolyStepSegment x="-10" y="-10"/></Polygon></Profile>"#,
+                );
+            let result = check(&xml, standard.source, LayoutTarget::Board).unwrap();
+            assert!(matches!(result.verdict, report::Verdict::Pass));
+            assert_eq!(result.summary.errors, 0);
+            assert_eq!(result.summary.warnings, 1);
+            let finding = &result.findings[0];
+            assert_eq!(finding.severity, report::Severity::Warning);
+            assert!((finding.measurement.actual_mm().unwrap() - 0.1).abs() < 1e-8);
+            assert_eq!(finding.subjects[0].kind, "routed_slot");
+
+            let missing = xml.replace("<Span fromLayer=\"L0\" toLayer=\"L1\"/>", "");
+            assert!(
+                check(&missing, standard.source, LayoutTarget::Board)
+                    .unwrap_err()
+                    .to_string()
+                    .contains("no resolvable drill span")
+            );
+        }
+    }
+
+    #[test]
     fn plated_ownership_and_nonplated_clearance_use_the_slot_ends_not_its_width() {
         for (plating, selector, net, fails) in [
             ("PLATED", "plated", "net=\"N1\"", false),

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
@@ -21,10 +21,6 @@ pub(super) fn evaluate(
 ) -> Evaluation {
     let mut checked = 0;
     let mut measured = Vec::new();
-    let stackup = design
-        .stackup
-        .as_ref()
-        .expect("slot clearance requires a physical stackup");
     for (slot_index, slot) in design
         .slots
         .iter()
@@ -38,13 +34,11 @@ pub(super) fn evaluate(
             net,
         });
         for (copper_index, copper) in design.copper_layers.iter().enumerate() {
-            let span_layers = &stackup.copper_layers[usize::from(slot.drill_span.first_copper_index)
-                ..=usize::from(slot.drill_span.last_copper_index)];
-            if !span_layers
-                .iter()
-                .any(|layer| layer.name == copper.layer.name)
-                || !conditions.applies_to_layer(copper)
-            {
+            // Extraction orders copper layers and drill spans by the same
+            // validated physical stackup.
+            let span = usize::from(slot.drill_span.first_copper_index)
+                ..=usize::from(slot.drill_span.last_copper_index);
+            if !span.contains(&copper_index) || !conditions.applies_to_layer(copper) {
                 continue;
             }
             checked += 1;

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
@@ -197,6 +197,17 @@ limit = {{ minimum = "0.20 mm" }}
     }
 
     #[test]
+    fn width_only_report_omits_unproven_span_with_shuffled_layers() {
+        let source = pdk("plated")
+            .replace("rules.copper.slot_clearance", "rules.drilling.slot_width")
+            .replace("0.20 mm", "0.80 mm");
+        let result = check(&board("PLATED", "", ""), &source, LayoutTarget::Board).unwrap();
+        let finding = &result.findings[0];
+        assert!((finding.measurement.actual_mm().unwrap() - 0.6).abs() < 1e-8);
+        assert!(finding.subjects[0].drill_span.is_none());
+    }
+
+    #[test]
     fn standard_slot_clearance_warns_without_failing_but_requires_a_span() {
         let standard = dfm::builtin_pdks()
             .iter()

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -54,6 +54,7 @@ pub(super) struct Design<'a> {
     /// Each hole's lands, one per copper layer it owns a land on, indexed
     /// like `holes`.
     pub hole_lands: Vec<Vec<HoleLand>>,
+    pub slot_lands: Vec<Vec<HoleLand>>,
     pub mask_layers: Vec<MaskLayer>,
     pub scores: Vec<Score>,
     pub board_outlines: Vec<BoardOutline>,
@@ -93,6 +94,9 @@ impl<'a> Design<'a> {
         let copper_layers = when(pools.copper, || {
             collect_copper_layers(imported, scope, pools.conductor_ownership, stackup.as_ref())
         })?;
+        let physical_holes = when(pools.hole_lands || pools.slot_lands, || {
+            imported.physical_holes(scope)
+        })?;
         let layout = when(pools.board_outlines || pools.board_arrays, || {
             Ok(Some(&imported.geometry))
         })?;
@@ -123,8 +127,18 @@ impl<'a> Design<'a> {
                     .collect())
             })?,
             hole_lands: when(pools.hole_lands, || {
-                let physical_holes = imported.physical_holes(scope)?;
-                link_lands(&holes, &copper_layers, &physical_holes)
+                link_lands(
+                    holes.iter().map(|hole| hole.id),
+                    &copper_layers,
+                    &physical_holes,
+                )
+            })?,
+            slot_lands: when(pools.slot_lands, || {
+                link_lands(
+                    slots.iter().map(|slot| slot.id),
+                    &copper_layers,
+                    &physical_holes,
+                )
             })?,
             mask_layers: when(pools.masks, || collect_mask_layers(imported, scope))?,
             scores: when(pools.scores, || collect_scores(imported, scope))?,
@@ -224,6 +238,25 @@ impl<'a> Design<'a> {
 }
 
 fn validate_hole_clearance_spans(design: &Design, rules: &[Rule]) -> Result<()> {
+    for slot in &design.slots {
+        let selected = rules.iter().any(|rule| {
+            matches!(rule.kind, rules::RuleKind::SlotToCopperClearance(plating)
+                if super::checks::slot_matches(slot.plating, plating))
+                && rule.conditions.applies_to_design(design)
+                && design
+                    .copper_layers
+                    .iter()
+                    .any(|layer| rule.conditions.applies_to_layer(layer))
+        });
+        if selected
+            && (!slot.span_declared || slot.drill_span.interpretation == "assumed_whole_stack")
+        {
+            bail!(
+                "routed slot on layer '{}' has no resolvable drill span; slot-to-copper clearance cannot be certified",
+                slot.layer.name
+            );
+        }
+    }
     for hole in &design.holes {
         let selected = rules.iter().any(|rule| {
             matches!(
@@ -578,6 +611,9 @@ pub(super) struct HoleLand {
 /// local width.
 #[derive(Debug, Clone)]
 pub(super) struct Slot {
+    pub id: FeatureOccurrenceId,
+    pub span_declared: bool,
+    pub drill_span: DrillSpan,
     pub plating: PlatingKind,
     pub width: Distance,
     pub width_disk: WidthDisk,
@@ -822,6 +858,15 @@ fn collect_drilled(
                         bail!("{at} has no measurable outline");
                     };
                     slots.push(Slot {
+                        id: feature_occurrence_id(feature)
+                            .context("materialized slot has no occurrence identity")?,
+                        span_declared: source_layer.span.is_some(),
+                        drill_span: drill_span(
+                            feature.intent.span,
+                            &imported.layer_definitions,
+                            whole_stack,
+                            stackup,
+                        ),
                         plating: feature.intent.plating,
                         width: slot_width(feature.outer_diameter, width_disk.width)
                             .with_context(|| at)?,
@@ -836,7 +881,7 @@ fn collect_drilled(
                         layer: layer_ref(layer_name, source_layer.layer_function, None),
                         step: feature.source_step_ref,
                         padstack: feature.padstack_ref,
-                        net: feature.net,
+                        net: source_net(&document, feature),
                         source_set_index: feature.source.set_index,
                         source_feature_index: feature.source.feature_index,
                     });
@@ -1392,7 +1437,7 @@ fn collect_mask_layers(imported: &ImportedDesign, scope: ArtworkScope) -> Result
 /// ambiguous or conflicting relationship fails closed; DFM never chooses the
 /// nearest candidate.
 fn link_lands(
-    holes: &[Hole],
+    holes: impl ExactSizeIterator<Item = FeatureOccurrenceId>,
     copper_layers: &[CopperLayer],
     physical_holes: &[PhysicalHole],
 ) -> Result<Vec<Vec<HoleLand>>> {
@@ -1420,9 +1465,9 @@ fn link_lands(
         })
         .collect::<HashMap<_, _>>();
     let mut hole_lands = vec![Vec::new(); holes.len()];
-    for (hole_index, hole) in holes.iter().enumerate() {
+    for (hole_index, hole) in holes.enumerate() {
         let physical_hole = physical_holes
-            .get(&hole.id)
+            .get(&hole)
             .context("DFM hole is missing from the canonical physical view")?;
         for relationship in &physical_hole.lands {
             match &relationship.land {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/pdk.rs
@@ -348,6 +348,12 @@ impl Rules {
             )
             .chain(
                 self.copper
+                    .slot_clearance
+                    .iter()
+                    .map(RuleDefinition::SlotClearance),
+            )
+            .chain(
+                self.copper
                     .feature_width
                     .iter()
                     .map(RuleDefinition::CopperLength),
@@ -389,6 +395,7 @@ enum RuleDefinition<'a> {
     SlotToBoardEdge(&'a SlotToBoardEdgeClearanceRule),
     AnnularRing(&'a AnnularRingRule),
     HoleClearance(&'a HoleClearanceRule),
+    SlotClearance(&'a SlotClearanceRule),
     CopperLength(&'a LengthRule),
     OtherLength(&'a LengthRule),
 }
@@ -404,6 +411,7 @@ impl RuleDefinition<'_> {
             Self::SlotToBoardEdge(rule) => &rule.metadata,
             Self::AnnularRing(rule) => &rule.metadata,
             Self::HoleClearance(rule) => &rule.metadata,
+            Self::SlotClearance(rule) => &rule.metadata,
             Self::CopperLength(rule) | Self::OtherLength(rule) => &rule.metadata,
         }
     }
@@ -420,6 +428,7 @@ impl RuleDefinition<'_> {
             Self::SlotToBoardEdge(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::AnnularRing(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::HoleClearance(rule) => (rule.limit.as_ref(), &rule.cases),
+            Self::SlotClearance(rule) => (rule.limit.as_ref(), &rule.cases),
             Self::CopperLength(rule) | Self::OtherLength(rule) => {
                 (rule.limit.as_ref(), &rule.cases)
             }
@@ -438,7 +447,10 @@ impl RuleDefinition<'_> {
             cases,
             matches!(
                 self,
-                Self::AnnularRing(_) | Self::HoleClearance(_) | Self::CopperLength(_)
+                Self::AnnularRing(_)
+                    | Self::HoleClearance(_)
+                    | Self::SlotClearance(_)
+                    | Self::CopperLength(_)
             ),
         )
     }
@@ -490,6 +502,8 @@ pub struct CopperRules {
     pub annular_ring: Vec<AnnularRingRule>,
     #[serde(default)]
     pub hole_clearance: Vec<HoleClearanceRule>,
+    #[serde(default)]
+    pub slot_clearance: Vec<SlotClearanceRule>,
     #[serde(default)]
     pub feature_width: Vec<LengthRule>,
     #[serde(default)]
@@ -824,6 +838,18 @@ pub struct HoleClearanceRule {
     #[serde(flatten)]
     pub metadata: RuleMetadata,
     pub select: HoleSelector,
+    #[serde(default)]
+    pub limit: Option<LengthLimit>,
+    #[serde(default)]
+    pub cases: Vec<LengthCase>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SlotClearanceRule {
+    #[serde(flatten)]
+    pub metadata: RuleMetadata,
+    pub select: SlotSelector,
     #[serde(default)]
     pub limit: Option<LengthLimit>,
     #[serde(default)]

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/rules.rs
@@ -151,6 +151,8 @@ pub(super) enum RuleKind {
     AnnularRing(HoleClass),
     /// Clearance: a circular drill stays clear of unrelated final copper.
     HoleToCopperClearance(HoleClass),
+    /// Clearance: a materialized slot stays clear of unrelated final copper.
+    SlotToCopperClearance(SlotPlating),
     /// Clearance: reference linework stays clear of each copper image.
     LineworkToCopperClearance(Linework),
     /// Clearance: sibling board-array outlines keep their spacing.
@@ -194,6 +196,7 @@ pub(super) struct Pools {
     pub copper_boundaries: bool,
     pub conductor_boundaries: bool,
     pub hole_lands: bool,
+    pub slot_lands: bool,
     pub resolved_drill_spans: bool,
     pub masks: bool,
     pub scores: bool,
@@ -213,6 +216,7 @@ impl std::ops::BitOr for Pools {
             copper_boundaries: self.copper_boundaries || other.copper_boundaries,
             conductor_boundaries: self.conductor_boundaries || other.conductor_boundaries,
             hole_lands: self.hole_lands || other.hole_lands,
+            slot_lands: self.slot_lands || other.slot_lands,
             resolved_drill_spans: self.resolved_drill_spans || other.resolved_drill_spans,
             masks: self.masks || other.masks,
             scores: self.scores || other.scores,
@@ -230,6 +234,7 @@ const DRILLED: Pools = Pools {
     copper_boundaries: false,
     conductor_boundaries: false,
     hole_lands: false,
+    slot_lands: false,
     resolved_drill_spans: false,
     masks: false,
     scores: false,
@@ -304,6 +309,12 @@ impl RuleKind {
             Self::HoleToCopperClearance(_) => (
                 "hole_to_copper_clearance",
                 "Hole-to-copper clearance",
+                true,
+                &["copper", "drills", "board_outlines"],
+            ),
+            Self::SlotToCopperClearance(_) => (
+                "slot_to_copper_clearance",
+                "Slot-to-copper clearance",
                 true,
                 &["copper", "drills", "board_outlines"],
             ),
@@ -468,6 +479,27 @@ impl RuleKind {
                 pools: Pools {
                     conductor_boundaries: true,
                     hole_lands: true,
+                    resolved_drill_spans: true,
+                    ..COPPER
+                },
+            },
+            Self::SlotToCopperClearance(plating) => Semantics {
+                subject: "slot_layer_pair",
+                quantity: "slot_edge_to_unrelated_copper_clearance",
+                method: "materialized_slot_to_attributed_composed_copper_distance",
+                finding_title: format!(
+                    "{} slot clearance to unrelated copper is below minimum",
+                    slot_label(plating)
+                ),
+                quantity_label: format!(
+                    "{} slot edge-to-unrelated-copper clearance",
+                    slot_label(plating)
+                ),
+                witness_roles: Some(["routed_slot", "offending_copper"]),
+                pools: Pools {
+                    stackup: true,
+                    conductor_boundaries: true,
+                    slot_lands: true,
                     resolved_drill_spans: true,
                     ..COPPER
                 },
@@ -705,6 +737,20 @@ pub(super) fn lower(pdk: &Pdk, selected_profile: Option<&str>) -> Result<Vec<Rul
             profile,
             format!("Minimum {} hole-to-copper clearance", class.label()),
             RuleKind::HoleToCopperClearance(class),
+        ));
+    }
+    for rule in &pdk.rules.copper.slot_clearance {
+        rules.extend(lower_length_rule(
+            &rule.metadata,
+            rule.limit.as_ref(),
+            &rule.cases,
+            profile_name,
+            profile,
+            format!(
+                "Minimum {} slot-to-copper clearance",
+                slot_label(rule.select.plating)
+            ),
+            RuleKind::SlotToCopperClearance(rule.select.plating),
         ));
     }
     for (ruleset, title, kind) in [


### PR DESCRIPTION
Check plated and nonplated slot clearance against final copper on each physical layer in the declared span. Warn below Diode guidance limits in standard and IPC profiles without changing JLC rules. Reject missing span data and exempt plated copper only when ownership is proven.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1193" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->