### PR TITLE
fix(lsp): keep automatic BOM hydration cache-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Keep LSP schematic evaluation responsive by using cached BOM matches without supplier API requests; dependency resolution is unchanged.
 - Use physical stackup order for PCBIR slot cutouts and hole-to-land associations when layer declarations are shuffled.
 - Preserve PCBIR hole-to-land associations after routing or copper clears remove land copper.
 - Fix IPC-2581 tools tests failing to compile without default features.

--- a/crates/pcbc/src/lsp.rs
+++ b/crates/pcbc/src/lsp.rs
@@ -11,17 +11,18 @@ const RESOLVE_DATASHEET_METHOD: &str = "pcb/resolveDatasheet";
 
 pub fn execute(args: LspArgs) -> anyhow::Result<()> {
     let offline = args.offline;
-    let bom_match_mode = if args.offline {
-        pcb_diode_api::BomMatchMode::Offline
-    } else {
-        pcb_diode_api::BomMatchMode::Online
-    };
     pcb_zen::lsp_with_custom_request_handler(
         false,
         offline,
         move |method, params| handle_custom_request(method, params, offline),
-        move |source_path, schematic| {
-            pcb_diode_api::hydrate_schematic_from_bom(source_path, schematic, bom_match_mode);
+        |source_path, schematic| {
+            // Evaluation and viewer-state requests must not wait for supplier APIs.
+            // Reuse cached BOM matches, even when dependency resolution is online.
+            pcb_diode_api::hydrate_schematic_from_bom(
+                source_path,
+                schematic,
+                pcb_diode_api::BomMatchMode::Offline,
+            );
         },
     )
 }

--- a/crates/pcbc/tests/integration.rs
+++ b/crates/pcbc/tests/integration.rs
@@ -11,6 +11,7 @@ mod import;
 mod info;
 mod ipc2581;
 mod layout;
+mod lsp;
 mod migrate;
 mod moved;
 mod netlist;

--- a/crates/pcbc/tests/lsp.rs
+++ b/crates/pcbc/tests/lsp.rs
@@ -1,0 +1,99 @@
+#![cfg(not(target_os = "windows"))]
+
+use std::io::{BufRead, Read};
+
+use httpmock::MockServer;
+use pcb_test_utils::sandbox::Sandbox;
+use serde_json::{Value, json};
+
+#[test]
+fn schematic_evaluation_does_not_request_bom_matches() {
+    for args in [&["lsp"][..], &["lsp", "--offline"][..]] {
+        let server = MockServer::start();
+        let network = server.mock(|when, then| {
+            when.any_request();
+            then.status(500);
+        });
+        let source = r#"
+Resistor = Module("@stdlib/generics/Resistor.zen")
+Resistor(name = "R1", value = "10kOhm", package = "0603", P1 = Net("A"), P2 = Net("B"))
+"#;
+        let mut sandbox = Sandbox::new().with_workspace();
+        sandbox
+            .env("DIODE_API_URL", server.base_url())
+            .env("DIODE_API_AUTH", "none")
+            .env("NO_PROXY", "127.0.0.1,localhost")
+            .write("main.zen", source)
+            .sync();
+        let uri = format!("file://{}", sandbox.root_path().join("main.zen").display());
+        let root_uri = format!("file://{}", sandbox.root_path().display());
+        let changed_source = source.replace("10kOhm", "22kOhm");
+        let messages = [
+            json!({"id": 1, "method": "initialize", "params": {
+                "capabilities": {}, "rootUri": root_uri
+            }}),
+            json!({"method": "initialized", "params": {}}),
+            // Exercise the uncached viewer-state fallback before didOpen.
+            json!({"id": 2, "method": "viewer/getState", "params": {"uri": uri}}),
+            json!({"method": "textDocument/didOpen", "params": {"textDocument": {
+                "uri": uri, "languageId": "starlark", "version": 1, "text": source
+            }}}),
+            json!({"id": 3, "method": "zener/evaluate", "params": {"uri": uri, "inputs": {}}}),
+            // didOpen populates the cached viewer state, which also hydrates BOMs.
+            json!({"id": 4, "method": "viewer/getState", "params": {"uri": uri}}),
+            json!({"method": "textDocument/didChange", "params": {
+                "textDocument": {"uri": uri, "version": 2},
+                "contentChanges": [{"text": changed_source}]
+            }}),
+            json!({"id": 5, "method": "zener/evaluate", "params": {"uri": uri, "inputs": {}}}),
+            json!({"id": 6, "method": "shutdown", "params": null}),
+            json!({"method": "exit", "params": null}),
+        ];
+        let mut input = String::new();
+        for mut message in messages {
+            message["jsonrpc"] = json!("2.0");
+            let body = message.to_string();
+            input.push_str(&format!("Content-Length: {}\r\n\r\n{body}", body.len()));
+        }
+        let output = sandbox
+            .run("pcbc", args)
+            .stdin_bytes(input)
+            .stdout_capture()
+            .stderr_capture()
+            .run()
+            .expect("LSP session should complete");
+
+        let mut stdout = std::io::BufReader::new(output.stdout.as_slice());
+        let mut responses = Vec::new();
+        loop {
+            let mut header = String::new();
+            if stdout.read_line(&mut header).unwrap() == 0 {
+                break;
+            }
+            let length: usize = header
+                .strip_prefix("Content-Length: ")
+                .expect("LSP frame header")
+                .trim()
+                .parse()
+                .unwrap();
+            let mut separator = [0; 2];
+            stdout.read_exact(&mut separator).unwrap();
+            assert_eq!(&separator, b"\r\n");
+            let mut body = vec![0; length];
+            stdout.read_exact(&mut body).unwrap();
+            responses.push(serde_json::from_slice::<Value>(&body).unwrap());
+        }
+        for id in [2, 3, 4, 5] {
+            let response = responses.iter().find(|r| r["id"] == id).unwrap();
+            assert!(response.get("error").is_none(), "{response}");
+            let schematic = if id == 2 || id == 4 {
+                &response["result"]["state"]
+            } else {
+                assert_eq!(response["result"]["success"], true, "{response}");
+                &response["result"]["schematic"]
+            };
+            assert!(!schematic["instances"].as_object().unwrap().is_empty());
+        }
+        network.assert_calls(0);
+    }
+}


### PR DESCRIPTION
Force LSP to not do online BOM matching as this can cause eval load times to be very slow.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change is scoped to LSP BOM hydration latency; online BOM refresh during edit may be deferred until explicit BOM commands, with no auth or data-path changes.
> 
> **Overview**
> **LSP schematic evaluation and viewer state** no longer trigger online BOM matching when the server runs without `--offline`. Automatic hydration always uses **`BomMatchMode::Offline`** (cached matches only), so `zener/evaluate` and `viewer/getState` stay responsive instead of waiting on supplier APIs.
> 
> **`--offline`** still controls vendored dependency resolution and blocks `pcb/resolveDatasheet`; only the schematic hydration path is decoupled from the online/offline CLI flag.
> 
> Adds a **non-Windows integration test** that drives a full LSP session (including evaluate and viewer state before/after `didOpen`) against a mock API that would fail any request, for both `lsp` and `lsp --offline`, and asserts zero network calls while evaluations still return populated schematics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7669b649908deaee7a2f3a26d3051e7973718224. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->