### PR TITLE
Preserve hierarchical sheet ownership when placements are deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Preserve deleted hierarchical sheet instances as restorable project metadata while keeping child schematic content loaded.
 - Use physical stackup order for PCBIR slot cutouts and hole-to-land associations when layer declarations are shuffled.
 - Preserve PCBIR hole-to-land associations after routing or copper clears remove land copper.
 - Fix IPC-2581 tools tests failing to compile without default features.

--- a/crates/pcb-kicad-sch/src/analysis.rs
+++ b/crates/pcb-kicad-sch/src/analysis.rs
@@ -45,6 +45,10 @@ impl NetAnalysis {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SchematicIssue {
+    MissingSheet {
+        page_id: String,
+        sheet_id: String,
+    },
     MissingSymbol {
         slot: SymbolSlotKey,
     },
@@ -96,6 +100,7 @@ impl SchematicIssue {
     /// suppression patterns.
     pub fn kind(&self) -> &'static str {
         match self {
+            SchematicIssue::MissingSheet { .. } => "missing_sheet",
             SchematicIssue::MissingSymbol { .. } => "missing_symbol",
             SchematicIssue::DuplicateSymbol { .. } => "duplicate_symbol",
             SchematicIssue::MismatchedSymbolId { .. } => "mismatched_symbol_id",
@@ -112,6 +117,9 @@ impl SchematicIssue {
     /// One-line human summary, for error messages and logs.
     pub fn summary(&self) -> String {
         match self {
+            SchematicIssue::MissingSheet { page_id, sheet_id } => {
+                format!("sheet '{sheet_id}' is not placed on page '{page_id}'")
+            }
             SchematicIssue::MissingSymbol { slot } => {
                 format!(
                     "component '{}' unit {} is not placed",
@@ -188,6 +196,10 @@ impl SchematicIssue {
 /// retaining UI selection across repeated analysis.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum SchematicIssueKey {
+    MissingSheet {
+        page_id: String,
+        sheet_id: String,
+    },
     MissingSymbol(SymbolSlotKey),
     DuplicateSymbol(SymbolSlotKey),
     MismatchedSymbolId {
@@ -259,7 +271,19 @@ pub fn inspect_schematic(
     let mut expected = expected_reconcilable_connectivity(document, netlist)?;
     apply_symbol_or_label_endpoint_requirements(document, netlist, &mut expected)?;
     let physical = observed_reconcilable_connectivity(document, netlist)?;
-    let analysis = analyze_connectivity(&expected, &physical.graph);
+    let mut analysis = analyze_connectivity(&expected, &physical.graph);
+    analysis.issues.splice(
+        0..0,
+        document.pages.iter().flat_map(|page| {
+            page.items.iter().filter_map(|item| match item {
+                SchItem::Sheet(sheet) if !sheet.placed => Some(SchematicIssue::MissingSheet {
+                    page_id: page.id.clone(),
+                    sheet_id: sheet.id.clone(),
+                }),
+                _ => None,
+            })
+        }),
+    );
     let issues = analysis
         .issues()
         .iter()
@@ -330,6 +354,13 @@ pub(crate) fn issue_context(
             .collect::<BTreeSet<_>>()
     };
     let (key, items) = match &issue {
+        SchematicIssue::MissingSheet { page_id, sheet_id } => (
+            SchematicIssueKey::MissingSheet {
+                page_id: page_id.clone(),
+                sheet_id: sheet_id.clone(),
+            },
+            BTreeSet::new(),
+        ),
         SchematicIssue::MissingSymbol { slot } => (
             SchematicIssueKey::MissingSymbol(slot.clone()),
             BTreeSet::new(),
@@ -420,7 +451,8 @@ pub(crate) fn coarse_key(key: &SchematicIssueKey) -> SchematicIssueKey {
         SchematicIssueKey::UnexpectedNet { items, .. }
         | SchematicIssueKey::UnexpectedConnection { items, .. }
         | SchematicIssueKey::Shorted { items, .. } => items.clear(),
-        SchematicIssueKey::MissingSymbol(_)
+        SchematicIssueKey::MissingSheet { .. }
+        | SchematicIssueKey::MissingSymbol(_)
         | SchematicIssueKey::DuplicateSymbol(_)
         | SchematicIssueKey::MismatchedSymbolId { .. }
         | SchematicIssueKey::UnexpectedSymbol(_)

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -90,6 +90,7 @@ pub(crate) fn reconcile_document(
         remove_locations,
         connectivity: selected_connectivity,
     } = repair_targets(issue_selection, inspection_before, &expected_slots)?;
+    let restores_missing_sheets = !missing_sheets.is_empty();
     for (page_id, sheet_id) in missing_sheets {
         let sheet = document
             .pages
@@ -261,8 +262,10 @@ pub(crate) fn reconcile_document(
         // Any selected mutation (projection or removal) shifts issue keys, so
         // connectivity issues that appear only after the mutation belong to
         // this repair's scope.
-        let document_mutated =
-            !project_slots.is_empty() || !remove_slots.is_empty() || !remove_locations.is_empty();
+        let document_mutated = restores_missing_sheets
+            || !project_slots.is_empty()
+            || !remove_slots.is_empty()
+            || !remove_locations.is_empty();
         current
             .issues
             .iter()

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -84,11 +84,26 @@ pub(crate) fn reconcile_document(
         .into_iter()
         .collect::<BTreeSet<_>>();
     let RepairTargets {
+        missing_sheets,
         project_slots,
         remove_slots,
         remove_locations,
         connectivity: selected_connectivity,
     } = repair_targets(issue_selection, inspection_before, &expected_slots)?;
+    for (page_id, sheet_id) in missing_sheets {
+        let sheet = document
+            .pages
+            .iter_mut()
+            .find(|page| page.id == page_id)
+            .and_then(|page| {
+                page.items.iter_mut().find_map(|item| match item {
+                    SchItem::Sheet(sheet) if sheet.id == sheet_id => Some(sheet),
+                    _ => None,
+                })
+            })
+            .with_context(|| format!("missing sheet {sheet_id} on page {page_id} is absent"))?;
+        sheet.placed = true;
+    }
     let instances = component_slots::component_instances(netlist)?;
     let mut selected_existing = BTreeMap::new();
     for slot in &project_slots {
@@ -303,6 +318,7 @@ fn is_connectivity_issue(issue: &SchematicIssue) -> bool {
 }
 
 struct RepairTargets {
+    missing_sheets: Vec<(String, String)>,
     project_slots: BTreeSet<SymbolSlotKey>,
     remove_slots: BTreeSet<SymbolSlotKey>,
     remove_locations: BTreeSet<SymbolLocation>,
@@ -319,6 +335,7 @@ fn repair_targets(
     } else {
         BTreeSet::new()
     };
+    let mut missing_sheets = Vec::new();
     let mut remove_slots = BTreeSet::new();
     let mut remove_locations = BTreeSet::new();
     let mut selected_connectivity = BTreeSet::new();
@@ -338,6 +355,9 @@ fn repair_targets(
         };
         for context in selected {
             match &context.issue {
+                SchematicIssue::MissingSheet { page_id, sheet_id } => {
+                    missing_sheets.push((page_id.clone(), sheet_id.clone()));
+                }
                 SchematicIssue::MissingSymbol { slot }
                 | SchematicIssue::DuplicateSymbol { slot, .. }
                 | SchematicIssue::MismatchedSymbolId { slot, .. } => {
@@ -362,6 +382,7 @@ fn repair_targets(
         bail!("repairing selected issues requires a valid inspection");
     }
     Ok(RepairTargets {
+        missing_sheets,
         project_slots,
         remove_slots,
         remove_locations,
@@ -835,6 +856,7 @@ fn materialize_hierarchy(
         };
         let sheet = Sheet {
             id: hierarchy::sheet_id(&sheet_plan.module_path),
+            placed: true,
             at: Some(at),
             size: Some(size),
             name: Some(name_field),
@@ -3718,6 +3740,7 @@ mod tests {
         let mut page = SchPage::new(id);
         page.items.push(SchItem::Sheet(Box::new(Sheet {
             id: format!("{id}-sheet"),
+            placed: true,
             at: Some(Point::new(10.0, 10.0)),
             size: Some(Point::new(200.0, 180.0)),
             name: None,

--- a/crates/pcb-kicad-sch/src/connectivity/kicad.rs
+++ b/crates/pcb-kicad-sch/src/connectivity/kicad.rs
@@ -382,6 +382,9 @@ fn collect_page_connectables(
                 }),
             }),
             SchItem::Sheet(sheet) => {
+                if !sheet.placed {
+                    continue;
+                }
                 let child_id = instance.child_ids.get(&sheet.id).with_context(|| {
                     format!(
                         "sheet {} on page {} has no hierarchy instance",

--- a/crates/pcb-kicad-sch/src/kicad.rs
+++ b/crates/pcb-kicad-sch/src/kicad.rs
@@ -220,7 +220,12 @@ fn format_kicad_sch_page(page: &SchPage) -> String {
         library_to_sexpr(&page.library),
     ];
 
-    root.extend(page.items.iter().map(|item| item_to_sexpr(item, page)));
+    root.extend(
+        page.items
+            .iter()
+            .filter(|item| !matches!(item, SchItem::Sheet(sheet) if !sheet.placed))
+            .map(|item| item_to_sexpr(item, page)),
+    );
 
     format!(
         "{}\n",
@@ -479,6 +484,15 @@ fn parse_no_connect(items: SexprList<'_>) -> Result<NoConnect> {
     })
 }
 
+pub(crate) fn parse_sheet_source(source: &str) -> Result<Sheet> {
+    let root = parse(source)?;
+    let list = SexprList::from_sexpr(&root).context("expected sheet expression")?;
+    if list.tag() != Some("sheet") {
+        bail!("expected sheet expression");
+    }
+    parse_sheet(list)
+}
+
 fn parse_sheet(items: SexprList<'_>) -> Result<Sheet> {
     let mut id = None;
     let mut at = None;
@@ -512,6 +526,7 @@ fn parse_sheet(items: SexprList<'_>) -> Result<Sheet> {
 
     Ok(Sheet {
         id: id.context("sheet missing uuid")?,
+        placed: true,
         at,
         size,
         name,
@@ -913,7 +928,7 @@ fn no_connect_to_sexpr(no_connect: &NoConnect) -> Sexpr {
     Sexpr::list(items)
 }
 
-fn sheet_to_sexpr(sheet: &Sheet) -> Sexpr {
+pub(crate) fn sheet_to_sexpr(sheet: &Sheet) -> Sexpr {
     let mut items = vec![Sexpr::symbol("sheet")];
     if let Some(at) = sheet.at {
         items.push(Sexpr::list(vec![

--- a/crates/pcb-kicad-sch/src/lib.rs
+++ b/crates/pcb-kicad-sch/src/lib.rs
@@ -22,6 +22,7 @@ mod placement;
 pub mod reconcile;
 mod repair;
 mod root_interface;
+mod sheet_placements;
 mod source;
 mod symbol;
 
@@ -44,5 +45,6 @@ pub use net_symbols::NetSymbolSpec;
 pub use repair::{
     ConnectivityRepairIntent, NetDriverKind, plan_connectivity_repair, verify_connectivity_repair,
 };
+pub use sheet_placements::{restore_sheet_placements, sync_sheet_placements};
 pub use source::patch_page_source;
 pub use symbol::PlacedPin;

--- a/crates/pcb-kicad-sch/src/model.rs
+++ b/crates/pcb-kicad-sch/src/model.rs
@@ -100,6 +100,9 @@ impl SchItem {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Sheet {
     pub id: Id,
+    /// Whether this logical sheet instance is physically present in its parent source.
+    #[serde(default = "default_true")]
+    pub placed: bool,
     pub at: Option<Point>,
     pub size: Option<Point>,
     pub name: Option<SymbolField>,

--- a/crates/pcb-kicad-sch/src/repair.rs
+++ b/crates/pcb-kicad-sch/src/repair.rs
@@ -212,7 +212,8 @@ pub(crate) fn plan_connectivity_repair_core(
                     }
                 }
             }
-            SchematicIssue::UnboundSymbol { .. }
+            SchematicIssue::MissingSheet { .. }
+            | SchematicIssue::UnboundSymbol { .. }
             | SchematicIssue::MissingSymbol { .. }
             | SchematicIssue::DuplicateSymbol { .. }
             | SchematicIssue::MismatchedSymbolId { .. }
@@ -877,7 +878,8 @@ fn repair_problems(issue: &SchematicIssue) -> BTreeSet<RepairProblem> {
             .cloned()
             .map(RepairProblem::UnexpectedConnection)
             .collect(),
-        SchematicIssue::DisconnectedNet { .. }
+        SchematicIssue::MissingSheet { .. }
+        | SchematicIssue::DisconnectedNet { .. }
         | SchematicIssue::MissingPort { .. }
         | SchematicIssue::UnboundSymbol { .. }
         | SchematicIssue::MissingSymbol { .. }
@@ -1369,6 +1371,7 @@ mod tests {
         });
         let sheet = SchItem::Sheet(Box::new(Sheet {
             id: "sheet".to_string(),
+            placed: true,
             at: Some(Point::new(10.0, 0.0)),
             size: Some(Point::new(20.0, 20.0)),
             name: None,

--- a/crates/pcb-kicad-sch/src/sheet_placements.rs
+++ b/crates/pcb-kicad-sch/src/sheet_placements.rs
@@ -8,6 +8,9 @@ use crate::{SchDocument, SchItem, SchPage};
 
 #[derive(Serialize, Deserialize)]
 struct Entry {
+    // Legacy entries are matched by filename until the next metadata sync.
+    #[serde(default)]
+    parent_id: Option<String>,
     parent_file: String,
     /// Native sheet syntax avoids persisting parser spans or Rust model details.
     sheet: String,
@@ -65,7 +68,10 @@ pub fn restore_sheet_placements(page: &mut SchPage, project: &Value) -> Result<(
         .filter_map(SchItem::id)
         .map(str::to_owned)
         .collect::<std::collections::BTreeSet<_>>();
-    for entry in entries.into_iter().filter(|e| e.parent_file == parent_file) {
+    for entry in entries.into_iter().filter(|e| match &e.parent_id {
+        Some(id) => id == &page.id,
+        None => e.parent_file == parent_file,
+    }) {
         let mut sheet = crate::kicad::parse_sheet_source(&entry.sheet)?;
         normalized(parent_file, sheet.file_name())?;
         if !existing_ids.insert(sheet.id.clone()) {
@@ -88,6 +94,7 @@ pub fn sync_sheet_placements(project: &mut Value, document: &SchDocument) -> Res
         for item in &page.items {
             if let SchItem::Sheet(sheet) = item {
                 next.push(Entry {
+                    parent_id: Some(page.id.clone()),
                     parent_file: parent_file.clone(),
                     sheet: pcb_sexpr::formatter::format_tree(
                         &crate::kicad::sheet_to_sexpr(sheet),

--- a/crates/pcb-kicad-sch/src/sheet_placements.rs
+++ b/crates/pcb-kicad-sch/src/sheet_placements.rs
@@ -1,0 +1,119 @@
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{SchDocument, SchItem, SchPage};
+
+#[derive(Serialize, Deserialize)]
+struct Entry {
+    parent_file: String,
+    /// Native sheet syntax avoids persisting parser spans or Rust model details.
+    sheet: String,
+}
+
+fn entries(project: &Value) -> Result<Option<Vec<Entry>>> {
+    let Some(value) = project.get("diode").and_then(|v| v.get("schematic_sheets")) else {
+        return Ok(None);
+    };
+    serde_json::from_value(value.clone())
+        .context("diode.schematic_sheets must be an array of valid sheet relationships")
+        .map(Some)
+}
+
+fn normalized(base: &str, child: &str) -> Result<PathBuf> {
+    let child = Path::new(child);
+    if child.as_os_str().is_empty() || child.is_absolute() {
+        bail!(
+            "schematic sheet path '{child}' must be relative",
+            child = child.display()
+        );
+    }
+    let mut out = PathBuf::new();
+    if let Some(parent) = Path::new(base).parent() {
+        out.push(parent);
+    }
+    out.push(child);
+    let mut clean = PathBuf::new();
+    for component in out.components() {
+        match component {
+            Component::Normal(value) => clean.push(value),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !clean.pop() {
+                    bail!("schematic sheet path escapes project directory");
+                }
+            }
+            _ => bail!("schematic sheet path escapes project directory"),
+        }
+    }
+    Ok(clean)
+}
+
+/// Restore logical relationships retained in project metadata for one parent page.
+pub fn restore_sheet_placements(page: &mut SchPage, project: &Value) -> Result<()> {
+    let Some(parent_file) = page.file_name.as_deref() else {
+        return Ok(());
+    };
+    let Some(entries) = entries(project)? else {
+        return Ok(());
+    };
+    let mut existing_ids = page
+        .items
+        .iter()
+        .filter_map(SchItem::id)
+        .map(str::to_owned)
+        .collect::<std::collections::BTreeSet<_>>();
+    for entry in entries.into_iter().filter(|e| e.parent_file == parent_file) {
+        let mut sheet = crate::kicad::parse_sheet_source(&entry.sheet)?;
+        normalized(parent_file, sheet.file_name())?;
+        if !existing_ids.insert(sheet.id.clone()) {
+            continue;
+        }
+        sheet.placed = false;
+        page.items.push(SchItem::Sheet(Box::new(sheet)));
+    }
+    Ok(())
+}
+
+/// Replace Diode's relationship metadata from the complete logical document.
+pub fn sync_sheet_placements(project: &mut Value, document: &SchDocument) -> Result<bool> {
+    let mut next = Vec::new();
+    for page in &document.pages {
+        let parent_file = page
+            .file_name
+            .clone()
+            .with_context(|| format!("schematic page '{}' has no filename", page.id))?;
+        for item in &page.items {
+            if let SchItem::Sheet(sheet) = item {
+                next.push(Entry {
+                    parent_file: parent_file.clone(),
+                    sheet: pcb_sexpr::formatter::format_tree(
+                        &crate::kicad::sheet_to_sexpr(sheet),
+                        pcb_sexpr::formatter::FormatMode::Normal,
+                    ),
+                });
+            }
+        }
+    }
+    next.sort_by(|a, b| (&a.parent_file, &a.sheet).cmp(&(&b.parent_file, &b.sheet)));
+    let current = entries(project)?;
+    if next.is_empty() && current.is_none() {
+        return Ok(false);
+    }
+    let value = serde_json::to_value(next)?;
+    if project.pointer("/diode/schematic_sheets") == Some(&value) {
+        return Ok(false);
+    }
+    let root = project
+        .as_object_mut()
+        .context("KiCad project root must be an object")?;
+    let diode = root
+        .entry("diode")
+        .or_insert_with(|| Value::Object(Default::default()))
+        .as_object_mut()
+        .context("KiCad project diode section must be an object")?;
+    diode.insert("schematic_sheets".into(), value);
+    Ok(true)
+}

--- a/crates/pcb-kicad-sch/src/source.rs
+++ b/crates/pcb-kicad-sch/src/source.rs
@@ -89,6 +89,9 @@ fn managed_values(page: &SchPage) -> BTreeMap<String, ManagedValue<'_>> {
         ManagedValue::Library(&page.library),
     )]);
     for item in &page.items {
+        if matches!(item, SchItem::Sheet(sheet) if !sheet.placed) {
+            continue;
+        }
         let Some(id) = item.id() else {
             continue;
         };

--- a/crates/pcb-kicad-sch/tests/common/kicad_builder.rs
+++ b/crates/pcb-kicad-sch/tests/common/kicad_builder.rs
@@ -126,6 +126,7 @@ impl KicadBuilder {
             .collect();
         self.push(SchItem::Sheet(Box::new(Sheet {
             id,
+            placed: true,
             at: None,
             size: None,
             name: None,

--- a/crates/pcb-kicad-sch/tests/issue_repair.rs
+++ b/crates/pcb-kicad-sch/tests/issue_repair.rs
@@ -65,6 +65,7 @@ fn singleton_primary_issue_and_complete_issue_set_produce_the_same_repair() {
 
 fn issue_kind(issue: &SchematicIssue) -> &'static str {
     match issue {
+        SchematicIssue::MissingSheet { .. } => "missing-sheet",
         SchematicIssue::MissingSymbol { .. } => "missing",
         SchematicIssue::DuplicateSymbol { .. } => "duplicate",
         SchematicIssue::MismatchedSymbolId { .. } => "mismatched-id",
@@ -862,6 +863,7 @@ fn nets_split_into_a_user_created_subsheet_are_repairable() {
     };
     let sheet = Sheet {
         id: "sheet-sub".to_string(),
+        placed: true,
         at: Some(Point::new(0.0, 0.0)),
         size: Some(Point::new(25.4, 25.4)),
         name: Some(SymbolField::new("Sheetname", "sub", Point::new(0.0, 0.0))),

--- a/crates/pcb-kicad-sch/tests/reorganized_pages.rs
+++ b/crates/pcb-kicad-sch/tests/reorganized_pages.rs
@@ -29,6 +29,7 @@ fn user_reorganized_page_stays_reconcilable() {
     document.pages.push(user_page);
     document.pages[0].items.push(SchItem::Sheet(Box::new(Sheet {
         id: "user-sheet".to_string(),
+        placed: true,
         at: Some(Point::new(200.0, 100.0)),
         size: Some(Point::new(40.0, 20.0)),
         name: Some(SymbolField::new(
@@ -106,6 +107,7 @@ fn cross_page_net_with_stale_page_scoped_drivers_repairs_to_global() {
     document.pages.push(user_page);
     document.pages[0].items.push(SchItem::Sheet(Box::new(Sheet {
         id: "user-sheet".to_string(),
+        placed: true,
         at: Some(Point::new(200.0, 100.0)),
         size: Some(Point::new(40.0, 20.0)),
         name: Some(SymbolField::new(

--- a/crates/pcb-kicad-sch/tests/sheet_placements.rs
+++ b/crates/pcb-kicad-sch/tests/sheet_placements.rs
@@ -221,3 +221,32 @@ fn invalid_metadata_and_escaping_paths_are_rejected() {
             .contains("escapes project directory")
     );
 }
+
+#[test]
+fn legacy_parent_filenames_migrate_to_stable_ids() {
+    let mut builder = KicadBuilder::new();
+    builder.sheet("child.kicad_sch", &[]);
+    let mut document = builder.build();
+    let mut metadata = json!({});
+    sync_sheet_placements(&mut metadata, &document).unwrap();
+    metadata["diode"]["schematic_sheets"][0]
+        .as_object_mut()
+        .unwrap()
+        .remove("parent_id");
+    document.pages[0].items.clear();
+    restore_sheet_placements(&mut document.pages[0], &metadata).unwrap();
+    assert_eq!(sheets(&document).count(), 1);
+    sync_sheet_placements(&mut metadata, &document).unwrap();
+    assert_eq!(
+        metadata["diode"]["schematic_sheets"][0]["parent_id"],
+        document.pages[0].id
+    );
+    let mut unrelated = document.pages[0].clone();
+    unrelated.id = "replacement-page-at-same-path".into();
+    unrelated.items.clear();
+    restore_sheet_placements(&mut unrelated, &metadata).unwrap();
+    assert!(
+        unrelated.items.is_empty(),
+        "UUID takes precedence over a reused filename"
+    );
+}

--- a/crates/pcb-kicad-sch/tests/sheet_placements.rs
+++ b/crates/pcb-kicad-sch/tests/sheet_placements.rs
@@ -1,0 +1,223 @@
+mod common;
+
+use common::kicad_builder::KicadBuilder;
+use pcb_kicad_sch::{
+    SchDocument, SchItem, Sheet,
+    analysis::{SchematicIssue, inspect_schematic},
+    parse_kicad_sch_page, patch_page_source,
+    reconcile::plan_reconciliation,
+    restore_sheet_placements, sync_sheet_placements,
+};
+use serde_json::json;
+
+fn sheets(document: &SchDocument) -> impl Iterator<Item = &Sheet> {
+    document
+        .pages
+        .iter()
+        .flat_map(|page| page.items.iter())
+        .filter_map(|item| match item {
+            SchItem::Sheet(sheet) => Some(sheet.as_ref()),
+            _ => None,
+        })
+}
+
+#[test]
+fn deleted_source_sheet_restores_as_unplaced_and_reconciles_without_losing_child() {
+    let netlist = common::compile_fixture("hierarchy", "root.zen");
+    let baseline = plan_reconciliation(None, &netlist, "root.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    let root_index = baseline
+        .pages
+        .iter()
+        .position(|page| {
+            page.file_name.as_deref() == Some("root.kicad_sch")
+                && page.items.iter().any(|i| matches!(i, SchItem::Sheet(_)))
+        })
+        .expect("fixture root has a child sheet");
+    let original_sheet = baseline.pages[root_index]
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SchItem::Sheet(sheet) => Some((**sheet).clone()),
+            _ => None,
+        })
+        .unwrap();
+    let mut project = json!({"unrelated":{"keep":true}, "diode":{"other":"value"}});
+    assert!(sync_sheet_placements(&mut project, &baseline).unwrap());
+    assert_eq!(project["unrelated"]["keep"], true);
+    assert_eq!(project["diode"]["other"], "value");
+
+    let source = SchDocument {
+        pages: vec![baseline.pages[root_index].clone()],
+        root_page_ids: vec![baseline.pages[root_index].id.clone()],
+    }
+    .to_kicad_sch()
+    .unwrap();
+    let mut source_without_sheet = baseline.pages[root_index].clone();
+    source_without_sheet
+        .items
+        .retain(|item| !matches!(item, SchItem::Sheet(sheet) if sheet.id == original_sheet.id));
+    let patched = patch_page_source(&source, &source_without_sheet)
+        .unwrap()
+        .expect("sheet deletion changes source");
+    let mut reopened_root = parse_kicad_sch_page(Some("root.kicad_sch"), &patched).unwrap();
+    assert!(
+        !reopened_root
+            .items
+            .iter()
+            .any(|item| matches!(item, SchItem::Sheet(sheet) if sheet.id == original_sheet.id))
+    );
+    restore_sheet_placements(&mut reopened_root, &project).unwrap();
+    let restored = reopened_root
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SchItem::Sheet(sheet) if sheet.id == original_sheet.id => Some(sheet.as_ref()),
+            _ => None,
+        })
+        .expect("metadata restores relationship");
+    assert_eq!(restored.id, original_sheet.id);
+    assert_eq!(restored.pins, original_sheet.pins);
+    assert_eq!(restored.at, original_sheet.at);
+    assert_eq!(restored.size, original_sheet.size);
+    assert!(!restored.placed);
+
+    let mut reopened = baseline.clone();
+    reopened.pages[root_index] = reopened_root;
+    assert_eq!(
+        reopened.pages.len(),
+        baseline.pages.len(),
+        "child page is retained"
+    );
+    let inspection = inspect_schematic(&reopened, &netlist).unwrap();
+    assert!(
+        inspection
+            .issues
+            .iter()
+            .any(|i| matches!(i.issue, SchematicIssue::MissingSheet { .. }))
+    );
+    assert!(
+        !inspection
+            .issues
+            .iter()
+            .any(|i| matches!(i.issue, SchematicIssue::MissingSymbol { .. })),
+        "child symbols remain present: {:#?}",
+        inspection.issues
+    );
+
+    let repaired = plan_reconciliation(Some(&reopened), &netlist, "root.kicad_sch")
+        .unwrap()
+        .apply(Some(&reopened))
+        .unwrap();
+    let repaired_sheet = sheets(&repaired)
+        .find(|sheet| sheet.id == original_sheet.id)
+        .unwrap();
+    assert!(repaired_sheet.placed);
+    assert_eq!(repaired_sheet.pins, original_sheet.pins);
+    assert_eq!(repaired_sheet.at, original_sheet.at);
+    assert_eq!(repaired_sheet.size, original_sheet.size);
+    assert_eq!(
+        repaired
+            .pages
+            .iter()
+            .find(|p| p.id != baseline.pages[root_index].id),
+        baseline
+            .pages
+            .iter()
+            .find(|p| p.id != baseline.pages[root_index].id),
+        "existing child content is preserved"
+    );
+    let second = plan_reconciliation(Some(&repaired), &netlist, "root.kicad_sch")
+        .unwrap()
+        .apply(Some(&repaired))
+        .unwrap();
+    assert_eq!(second, repaired, "second reconciliation is a no-op");
+}
+
+#[test]
+fn restore_is_scoped_to_exact_parent_and_exact_sheet_uuid() {
+    let mut builder = KicadBuilder::new();
+    builder
+        .sheet("shared.kicad_sch", &[])
+        .sheet("shared.kicad_sch", &[])
+        .add_root_page("other", "other.kicad_sch");
+    let original = builder.build();
+    let ids = sheets(&original).map(|s| s.id.clone()).collect::<Vec<_>>();
+    let mut metadata = json!({});
+    sync_sheet_placements(&mut metadata, &original).unwrap();
+    let mut root = original.pages[0].clone();
+    root.items
+        .retain(|item| !matches!(item, SchItem::Sheet(sheet) if sheet.id == ids[0]));
+    restore_sheet_placements(&mut root, &metadata).unwrap();
+    assert!(
+        root.items.iter().any(
+            |item| matches!(item, SchItem::Sheet(sheet) if sheet.id == ids[0] && !sheet.placed)
+        ),
+        "missing UUID must restore even when another instance of the same child file exists"
+    );
+    assert_eq!(
+        root.items
+            .iter()
+            .filter(|i| matches!(i, SchItem::Sheet(_)))
+            .count(),
+        2
+    );
+
+    let mut other = original.pages[1].clone();
+    restore_sheet_placements(&mut other, &metadata).unwrap();
+    assert!(
+        !other
+            .items
+            .iter()
+            .any(|item| matches!(item, SchItem::Sheet(_))),
+        "relationship must not ghost into another parent"
+    );
+}
+
+#[test]
+fn sync_records_deliberate_relationship_removal() {
+    let mut builder = KicadBuilder::new();
+    builder.sheet("child.kicad_sch", &[]);
+    let mut document = builder.build();
+    let mut project = json!({"diode":{"other":17}, "outside":"preserved"});
+    sync_sheet_placements(&mut project, &document).unwrap();
+    document.pages[0]
+        .items
+        .retain(|item| !matches!(item, SchItem::Sheet(_)));
+    assert!(sync_sheet_placements(&mut project, &document).unwrap());
+    restore_sheet_placements(&mut document.pages[0], &project).unwrap();
+    assert!(
+        !document.pages[0]
+            .items
+            .iter()
+            .any(|item| matches!(item, SchItem::Sheet(_))),
+        "dissolved relationship must not resurrect"
+    );
+    assert_eq!(project["diode"]["other"], 17);
+    assert_eq!(project["outside"], "preserved");
+}
+
+#[test]
+fn invalid_metadata_and_escaping_paths_are_rejected() {
+    let mut page = KicadBuilder::new().build().pages.remove(0);
+    let malformed = json!({"diode":{"schematic_sheets":{"not":"an array"}}});
+    assert!(
+        restore_sheet_placements(&mut page, &malformed)
+            .unwrap_err()
+            .to_string()
+            .contains("must be an array")
+    );
+
+    let mut builder = KicadBuilder::new();
+    builder.sheet("../outside.kicad_sch", &[]);
+    let mut project = json!({});
+    sync_sheet_placements(&mut project, &builder.build()).unwrap();
+    assert!(
+        restore_sheet_placements(&mut page, &project)
+            .unwrap_err()
+            .to_string()
+            .contains("escapes project directory")
+    );
+}

--- a/crates/pcb-kicad-sch/tests/sheet_restore_collision.rs
+++ b/crates/pcb-kicad-sch/tests/sheet_restore_collision.rs
@@ -1,0 +1,98 @@
+mod common;
+
+use std::collections::BTreeSet;
+
+use pcb_kicad_sch::{
+    Point, SchItem, Wire,
+    analysis::{SchematicIssue, inspect_schematic},
+    reconcile::{plan_reconciliation, plan_repairs},
+};
+
+#[test]
+fn restoring_a_sheet_repairs_connectivity_introduced_at_its_pin() {
+    let netlist = common::compile_fixture("hierarchy", "root.zen");
+    let mut document = plan_reconciliation(None, &netlist, "root.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+
+    let root = document
+        .pages
+        .iter_mut()
+        .find(|page| page.file_name.as_deref() == Some("root.kicad_sch"))
+        .expect("fixture has a root page");
+    let source_pin = root
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SchItem::Sheet(sheet) if sheet.file.value == "FILTER_A.kicad_sch" => {
+                sheet.placed = false;
+                sheet
+                    .pins
+                    .iter()
+                    .find(|pin| pin.name == "INPUT")
+                    .map(|pin| pin.at)
+            }
+            _ => None,
+        })
+        .expect("FILTER_A has an INPUT sheet pin");
+    let sink = root
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SchItem::Label(label) if label.text == "SINK" => Some(label.at),
+            _ => None,
+        })
+        .expect("fixture drives SINK on the root page");
+
+    // Model user wiring added while the restored sheet was absent. Without
+    // its pin, this merely extends SINK; placing the sheet makes the wire
+    // incorrectly join FILTER_A.INPUT (SOURCE) to SINK.
+    root.items.retain(|item| {
+        !matches!(item, SchItem::Label(label) if label.text == "SOURCE" && label.at == source_pin)
+    });
+    let elbow = Point::new(sink.x + 25.4, source_pin.y);
+    root.items.extend([
+        SchItem::Wire(Wire {
+            id: "wire-at-unplaced-sheet-pin".to_string(),
+            a: source_pin,
+            b: elbow,
+            unsupported: Vec::new(),
+        }),
+        SchItem::Wire(Wire {
+            id: "wire-from-sheet-pin-to-sink".to_string(),
+            a: elbow,
+            b: sink,
+            unsupported: Vec::new(),
+        }),
+    ]);
+
+    let inspection = inspect_schematic(&document, &netlist).unwrap();
+    let missing_sheet = inspection
+        .issues
+        .iter()
+        .find(|issue| matches!(issue.issue, SchematicIssue::MissingSheet { .. }))
+        .expect("unplaced hierarchy is reported")
+        .key
+        .clone();
+    assert!(
+        !inspection.issues.iter().any(|issue| matches!(
+            issue.issue,
+            SchematicIssue::Shorted { .. } | SchematicIssue::UnexpectedConnection { .. }
+        )),
+        "the collision is latent until the sheet pin is restored: {:#?}",
+        inspection.issues
+    );
+
+    let repaired = plan_repairs(
+        &document,
+        &netlist,
+        &inspection,
+        BTreeSet::from([missing_sheet]),
+    )
+    .expect("restoring the selected sheet also repairs its newly exposed collision")
+    .apply(Some(&document))
+    .unwrap();
+    let after = inspect_schematic(&repaired, &netlist).unwrap();
+    assert!(after.analysis.is_equivalent(), "{:#?}", after.issues);
+}

--- a/crates/pcbc/src/kicad_schematic/mod.rs
+++ b/crates/pcbc/src/kicad_schematic/mod.rs
@@ -15,6 +15,7 @@ use serde_json::{Value, json};
 
 use pcb_kicad_sch::{
     SchDocument, analysis::inspect_schematic, patch_page_source, reconcile::plan_reconciliation,
+    sync_sheet_placements,
 };
 
 mod project;
@@ -89,7 +90,7 @@ fn project_state(path: &Path) -> Result<ProjectState> {
     }
 }
 
-fn apply_existing(project: KicadProject, netlist: &Schematic) -> Result<SchematicApplyResult> {
+fn apply_existing(mut project: KicadProject, netlist: &Schematic) -> Result<SchematicApplyResult> {
     let root_schematic = project
         .root_schematics
         .first()
@@ -104,9 +105,6 @@ fn apply_existing(project: KicadProject, netlist: &Schematic) -> Result<Schemati
     // Semantic equality is the no-op boundary. Do not run a parsed KiCad file
     // through our serializer merely because its valid item ordering or
     // formatting differs from generated output.
-    if plan.is_empty() {
-        return Ok(unchanged(project, root_schematic));
-    }
     let desired = plan.apply(Some(&project.document))?;
 
     let mut writes = Vec::new();
@@ -150,6 +148,17 @@ fn apply_existing(project: KicadProject, netlist: &Schematic) -> Result<Schemati
                 next,
             });
         }
+    }
+    if sync_sheet_placements(&mut project.project, &desired)? {
+        let source = fs::read_to_string(&project.project_file)
+            .with_context(|| format!("failed to read {}", project.project_file.display()))?;
+        let mut next = serde_json::to_string_pretty(&project.project)?;
+        next.push('\n');
+        writes.push(PendingWrite {
+            path: project.project_file.clone(),
+            source: Some(source),
+            next,
+        });
     }
     if writes.is_empty() {
         return Ok(unchanged(project, root_schematic));
@@ -267,6 +276,9 @@ fn initialize_project(project_file: PathBuf, netlist: &Schematic) -> Result<Sche
         &schematic_name,
         file_name,
     )?;
+    let mut project: Value = serde_json::from_str(&project_source)?;
+    sync_sheet_placements(&mut project, &document)?;
+    let project_source = format!("{}\n", serde_json::to_string_pretty(&project)?);
 
     fs::create_dir_all(&directory)
         .with_context(|| format!("failed to create {}", directory.display()))?;

--- a/crates/pcbc/src/kicad_schematic/project.rs
+++ b/crates/pcbc/src/kicad_schematic/project.rs
@@ -9,7 +9,9 @@ use pcb_sch::{AttributeValue, Schematic};
 use serde_json::Value;
 use uuid::Uuid;
 
-use pcb_kicad_sch::{SchDocument, SchItem, normalize_schematic_path, parse_kicad_sch_page};
+use pcb_kicad_sch::{
+    SchDocument, SchItem, normalize_schematic_path, parse_kicad_sch_page, restore_sheet_placements,
+};
 
 /// A KiCad schematic project loaded from one project directory.
 #[derive(Debug, Clone)]
@@ -19,6 +21,7 @@ pub struct KicadProject {
     pub root_schematics: Vec<PathBuf>,
     pub schematic_files: Vec<PathBuf>,
     pub document: SchDocument,
+    pub project: Value,
 }
 
 impl KicadProject {
@@ -46,15 +49,19 @@ impl KicadProject {
                 }
                 (requested.to_path_buf(), project_files.remove(0))
             };
+        let project: Value = serde_json::from_str(&fs::read_to_string(&project_file)?)
+            .with_context(|| format!("failed to parse {}", project_file.display()))?;
         let project_roots = project_root_schematics(&directory, &project_file)?;
         let root_schematics = project_roots.iter().map(|root| root.path.clone()).collect();
-        let (schematic_files, document) = load_schematic_hierarchy(&directory, &project_roots)?;
+        let (schematic_files, document) =
+            load_schematic_hierarchy(&directory, &project_roots, &project)?;
         Ok(Self {
             directory,
             project_file,
             root_schematics,
             schematic_files,
             document,
+            project,
         })
     }
 }
@@ -67,6 +74,7 @@ struct ProjectRoot {
 fn load_schematic_hierarchy(
     directory: &Path,
     roots: &[ProjectRoot],
+    project: &Value,
 ) -> Result<(Vec<PathBuf>, SchDocument)> {
     let mut schematic_files = Vec::new();
     let mut root_by_path = std::collections::BTreeMap::new();
@@ -94,6 +102,8 @@ fn load_schematic_hierarchy(
         let relative = relative.to_string_lossy().replace('\\', "/");
         let mut page = parse_kicad_sch_page(Some(&relative), &content)
             .with_context(|| format!("failed to parse {}", path.display()))?;
+        restore_sheet_placements(&mut page, project)
+            .with_context(|| format!("failed to restore sheet metadata for {}", path.display()))?;
         if let Some(root_id) = root_by_path.get(&normalize_schematic_path(&path)) {
             if let Some(root_id) = root_id {
                 page.id = (*root_id).to_string();
@@ -279,6 +289,8 @@ pub(crate) fn files_with_extension(directory: &Path, extension: &str) -> Result<
 mod tests {
     use std::fs;
 
+    use pcb_kicad_sch::sync_sheet_placements;
+
     use super::*;
 
     #[test]
@@ -383,6 +395,49 @@ mod tests {
         let error = KicadProject::load(&directory).unwrap_err();
 
         assert!(error.to_string().contains("escapes project directory"));
+    }
+
+    #[test]
+    fn loads_metadata_only_child_when_parent_source_no_longer_has_sheet() {
+        let directory = tempfile::tempdir().unwrap();
+        let parent = parse_kicad_sch_page(
+            Some("demo.kicad_sch"),
+            &schematic_with_child("root", "child.kicad_sch"),
+        )
+        .unwrap();
+        let mut metadata = serde_json::json!({});
+        sync_sheet_placements(
+            &mut metadata,
+            &SchDocument {
+                pages: vec![parent],
+                root_page_ids: vec!["root".into()],
+            },
+        )
+        .unwrap();
+        fs::write(
+            directory.path().join("demo.kicad_pro"),
+            serde_json::to_string(&metadata).unwrap(),
+        )
+        .unwrap();
+        fs::write(directory.path().join("demo.kicad_sch"), schematic("root")).unwrap();
+        fs::write(directory.path().join("child.kicad_sch"), schematic("child")).unwrap();
+
+        let project = KicadProject::load(directory.path()).unwrap();
+
+        assert_eq!(
+            project.document.pages.len(),
+            2,
+            "restored metadata relationship keeps its child loadable"
+        );
+        assert!(
+            project
+                .schematic_files
+                .iter()
+                .any(|path| path.ends_with("child.kicad_sch"))
+        );
+        assert!(project.document.pages[0].items.iter().any(
+            |item| matches!(item, SchItem::Sheet(sheet) if sheet.id == "sheet-1" && !sheet.placed)
+        ));
     }
 
     #[cfg(unix)]

--- a/crates/pcbc/src/kicad_schematic/project.rs
+++ b/crates/pcbc/src/kicad_schematic/project.rs
@@ -102,20 +102,28 @@ fn load_schematic_hierarchy(
         let relative = relative.to_string_lossy().replace('\\', "/");
         let mut page = parse_kicad_sch_page(Some(&relative), &content)
             .with_context(|| format!("failed to parse {}", path.display()))?;
-        restore_sheet_placements(&mut page, project)
-            .with_context(|| format!("failed to restore sheet metadata for {}", path.display()))?;
         if let Some(root_id) = root_by_path.get(&normalize_schematic_path(&path)) {
             if let Some(root_id) = root_id {
                 page.id = (*root_id).to_string();
             }
             root_page_ids.push(page.id.clone());
         }
+        restore_sheet_placements(&mut page, project)
+            .with_context(|| format!("failed to restore sheet metadata for {}", path.display()))?;
         let parent = path.parent().unwrap_or(directory);
+        let mut removed_sheets = BTreeSet::new();
         for sheet in page.items.iter().filter_map(|item| match item {
             SchItem::Sheet(sheet) => Some(sheet),
             _ => None,
         }) {
             let child = project_schematic_path(directory, parent, sheet.file_name())?;
+            // Files are authoritative: a removed child invalidates retained
+            // placement metadata. Reconciliation can recreate netlist content.
+            // Keep errors for live placements and unreadable/non-file paths.
+            if !sheet.placed && !child.try_exists()? {
+                removed_sheets.insert(sheet.id.clone());
+                continue;
+            }
             if !child.is_file() {
                 bail!(
                     "sheet {} references missing schematic {}",
@@ -127,6 +135,9 @@ fn load_schematic_hierarchy(
                 schematic_files.push(child);
             }
         }
+        page.items.retain(
+            |item| !matches!(item, SchItem::Sheet(sheet) if removed_sheets.contains(&sheet.id)),
+        );
         pages.push(page);
     }
     Ok((
@@ -438,6 +449,64 @@ mod tests {
         assert!(project.document.pages[0].items.iter().any(
             |item| matches!(item, SchItem::Sheet(sheet) if sheet.id == "sheet-1" && !sheet.placed)
         ));
+    }
+
+    #[test]
+    fn root_and_nested_parent_renames_preserve_metadata_only_children() {
+        for nested in [false, true] {
+            let directory = tempfile::tempdir().unwrap();
+            let parent = parse_kicad_sch_page(
+                Some("old.kicad_sch"),
+                &schematic_with_child("parent", "child.kicad_sch"),
+            )
+            .unwrap();
+            let mut metadata = serde_json::json!({
+                "schematic": {"top_level_sheets": [{
+                    "filename": if nested { "root.kicad_sch" } else { "renamed.kicad_sch" }
+                }]}
+            });
+            sync_sheet_placements(
+                &mut metadata,
+                &SchDocument {
+                    pages: vec![parent],
+                    root_page_ids: vec!["parent".into()],
+                },
+            )
+            .unwrap();
+            fs::write(
+                directory.path().join("demo.kicad_pro"),
+                serde_json::to_string(&metadata).unwrap(),
+            )
+            .unwrap();
+            fs::write(
+                directory.path().join("renamed.kicad_sch"),
+                schematic("parent"),
+            )
+            .unwrap();
+            fs::write(directory.path().join("child.kicad_sch"), schematic("child")).unwrap();
+            if nested {
+                fs::write(
+                    directory.path().join("root.kicad_sch"),
+                    schematic_with_child("root", "renamed.kicad_sch"),
+                )
+                .unwrap();
+            }
+            let project = KicadProject::load(directory.path()).unwrap();
+            assert!(project.document.pages.iter().any(|page| page.id == "child"));
+            let parent = project
+                .document
+                .pages
+                .iter()
+                .find(|page| page.id == "parent")
+                .unwrap();
+            assert!(
+                parent
+                    .items
+                    .iter()
+                    .any(|item| matches!(item, SchItem::Sheet(sheet) if !sheet.placed))
+            );
+            assert_eq!(parent.file_name.as_deref(), Some("renamed.kicad_sch"));
+        }
     }
 
     #[cfg(unix)]

--- a/crates/pcbc/tests/schematic_apply_flow.rs
+++ b/crates/pcbc/tests/schematic_apply_flow.rs
@@ -55,6 +55,86 @@ fn linked_hierarchy_fixture(path: &std::path::Path) -> pcb_sch::Schematic {
     netlist
 }
 
+#[test]
+fn apply_restores_deleted_sheet_instance_without_recreating_child_files() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project_dir = workspace.path().join("hardware");
+    let netlist = linked_hierarchy_fixture(&project_dir);
+    let created = apply_linked_schematic(&netlist).unwrap().unwrap();
+    let mut project = KicadProject::load(&project_dir).unwrap();
+    let original = project.document.clone();
+    let parent = project
+        .document
+        .pages
+        .iter_mut()
+        .find(|page| {
+            page.items
+                .iter()
+                .any(|item| matches!(item, SchItem::Sheet(_)))
+        })
+        .unwrap();
+    let parent_file = project_dir.join(parent.file_name.as_ref().unwrap());
+    let originals = created
+        .schematic_files
+        .iter()
+        .map(|path| (path.clone(), fs::read(path).unwrap()))
+        .collect::<Vec<_>>();
+    let SchItem::Sheet(sheet) = parent
+        .items
+        .iter_mut()
+        .find(|item| matches!(item, SchItem::Sheet(_)))
+        .unwrap()
+    else {
+        unreachable!()
+    };
+    sheet.placed = false;
+    let source = fs::read_to_string(&parent_file).unwrap();
+    let deleted = pcb_kicad_sch::patch_page_source(&source, parent)
+        .unwrap()
+        .unwrap();
+    fs::write(&parent_file, deleted).unwrap();
+
+    let reopened = KicadProject::load(&project_dir).unwrap();
+    assert_eq!(reopened.document.pages.len(), original.pages.len());
+    let inspection = inspect_schematic(&reopened.document, &netlist).unwrap();
+    assert!(
+        inspection
+            .issues
+            .iter()
+            .any(|issue| matches!(issue.issue, SchematicIssue::MissingSheet { .. }))
+    );
+    assert!(
+        !inspection
+            .issues
+            .iter()
+            .any(|issue| matches!(issue.issue, SchematicIssue::MissingSymbol { .. }))
+    );
+    assert!(apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    let restored = KicadProject::load(&project_dir).unwrap().document;
+    for page in &original.pages {
+        let actual = restored
+            .pages
+            .iter()
+            .find(|other| other.id == page.id)
+            .unwrap();
+        let mut expected_items = page.items.iter().collect::<Vec<_>>();
+        let mut actual_items = actual.items.iter().collect::<Vec<_>>();
+        expected_items.sort_by_key(|item| item.id());
+        actual_items.sort_by_key(|item| item.id());
+        assert_eq!(actual_items, expected_items);
+    }
+    for (path, contents) in originals {
+        if path != parent_file {
+            assert_eq!(
+                fs::read(path).unwrap(),
+                contents,
+                "child file must be reused unchanged"
+            );
+        }
+    }
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+}
+
 fn expose_root_port(netlist: &mut pcb_sch::Schematic, port_name: &str, net_name: &str) {
     let net_id = netlist
         .nets
@@ -324,7 +404,9 @@ fn initializes_each_linked_module_instance_as_its_own_child_sheet() {
 
     let unchanged = apply_linked_schematic(&netlist).unwrap().unwrap();
 
-    assert!(!unchanged.changed);
+    // Source aliases are preserved; only their recovery metadata is refreshed.
+    assert!(unchanged.changed);
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
     for (path, source) in before {
         assert_eq!(fs::read(path).unwrap(), source);
     }
@@ -355,6 +437,12 @@ fn adds_an_uninitialized_linked_module_to_an_existing_project() {
         )
         .unwrap();
     }
+    pcb_kicad_sch::sync_sheet_placements(&mut incomplete.project, &incomplete.document).unwrap();
+    fs::write(
+        &created.project_file,
+        serde_json::to_string_pretty(&incomplete.project).unwrap(),
+    )
+    .unwrap();
     fs::remove_file(&missing_file).unwrap();
 
     let repaired = apply_linked_schematic(&netlist).unwrap().unwrap();

--- a/crates/pcbc/tests/schematic_apply_flow.rs
+++ b/crates/pcbc/tests/schematic_apply_flow.rs
@@ -135,6 +135,61 @@ fn apply_restores_deleted_sheet_instance_without_recreating_child_files() {
     assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
 }
 
+#[test]
+fn apply_recreates_child_deleted_after_its_sheet_placement() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project_dir = workspace.path().join("hardware");
+    let netlist = linked_hierarchy_fixture(&project_dir);
+    apply_linked_schematic(&netlist).unwrap().unwrap();
+    let mut project = KicadProject::load(&project_dir).unwrap();
+    let parent = project
+        .document
+        .pages
+        .iter_mut()
+        .find(|page| {
+            page.items
+                .iter()
+                .any(|item| matches!(item, SchItem::Sheet(_)))
+        })
+        .unwrap();
+    let parent_file = project_dir.join(parent.file_name.as_ref().unwrap());
+    let child_file = parent
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SchItem::Sheet(sheet) => {
+                sheet.placed = false;
+                Some(parent_file.parent().unwrap().join(sheet.file_name()))
+            }
+            _ => None,
+        })
+        .unwrap();
+    let source = fs::read_to_string(&parent_file).unwrap();
+    fs::write(
+        &parent_file,
+        pcb_kicad_sch::patch_page_source(&source, parent)
+            .unwrap()
+            .unwrap(),
+    )
+    .unwrap();
+    fs::remove_file(&child_file).unwrap();
+
+    KicadProject::load(&project_dir).expect("stale placement metadata must not block loading");
+    assert!(apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    assert!(
+        child_file.is_file(),
+        "netlist content recreates the missing child"
+    );
+    let repaired = KicadProject::load(&project_dir).unwrap();
+    assert!(
+        inspect_schematic(&repaired.document, &netlist)
+            .unwrap()
+            .analysis
+            .is_equivalent()
+    );
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+}
+
 fn expose_root_port(netlist: &mut pcb_sch::Schematic, port_name: &str, net_name: &str) {
     let net_id = netlist
         .nets


### PR DESCRIPTION
## Summary
- Persist parent/child sheet relationships in `.kicad_pro` metadata, independent of canvas placement.
- Load missing placements as unplaced sheets without reclassifying child components as missing.
- Report `missing_sheet` and let `pcb apply` restore the original sheet instance on its original parent.
- Remove relationships from metadata when callers explicitly dissolve/remove them; preserve duplicate instances by UUID.

Supports Lenny’s Quiche sheet-deletion workflow: ordinary canvas deletion produces a parent-only ghost, while explicit dissolution remains a separate operation.

## Validation
- `cargo test -p pcb-kicad-sch`
- `cargo test -p pcbc --lib kicad_schematic::project` (7 passed)
- `cargo test -p pcbc --test integration schematic_apply_flow` (20 passed)
- Regression coverage for reload/repair idempotency, unchanged child files, parent scope, duplicate instances, dissolution, and invalid metadata.

Existing projects record relationship metadata on their next apply/save; arbitrary orphan files are not inferred as child sheets.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes schematic hierarchy loading, reconciliation, and project JSON persistence; incorrect metadata or restore logic could mis-wire nets or drop child pages, but behavior is heavily tested and scoped to Diode metadata.
> 
> **Overview**
> **Hierarchical sheet instances removed from a parent `.kicad_sch` can be kept as logical relationships** instead of treating the whole subtree as missing symbols.
> 
> Sheets gain a **`placed`** flag: unplaced instances stay in the in-memory document (child pages still load) but are omitted from KiCad source output, connectivity, and managed-value patching. Parent/child links are stored under **`diode.schematic_sheets`** in `.kicad_pro` via **`sync_sheet_placements`** / **`restore_sheet_placements`**, keyed by parent page UUID with legacy filename fallback.
> 
> Schematic inspection now reports **`missing_sheet`**; reconciliation/repair can flip **`placed`** back to true and treat that mutation like other document edits (including follow-on connectivity fixes at restored pins). Project load restores metadata-only sheets, prunes stale entries when the child file is gone, and **`pcb apply`** writes updated metadata even when schematic pages are otherwise unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fee8d75eecb8311ece2e1dd7154b52c587b369ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->