### PR TITLE
Refactor DFM land indices and drill-span predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,27 +10,19 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Check all IPC DFM profiles against Diode's 5 mil copper-width baseline.
-- Apply Diode's 5 mil copper-spacing baseline to all nine IPC-informed profiles.
-- Add nominal via/PTH annular-ring checks to all nine IPC-informed PDK profiles using Diode baseline limits.
-- Check minimum via, PTH, and NPTH hole diameters in all nine IPC DFM profiles.
-- Check minimum plated and nonplated slot widths in all nine IPC DFM profiles using Diode baseline limits.
-- Add circular hole-to-hole clearance to all nine IPC-informed DFM profiles using Diode's standard 10 mil baseline.
-- Check copper-to-board-edge and cutout clearance at 15 mil in all nine IPC-informed DFM profiles.
-- Warn about soldermask webs below 4 mil in all nine IPC-informed DFM profiles.
-- Check plated and nonplated slot-to-copper clearance, with Diode guidance warnings in standard and IPC profiles.
-- Warn on plated-slot copper enclosure below 0.25 mm in Standard and IPC profiles.
+- Expand all nine IPC-informed DFM profiles with Diode baseline checks.
+- Warn about soldermask webs below 4 mil in IPC profiles.
+- Warn about slot clearance and plated-slot enclosure in standard and IPC profiles.
 
 ### Fixed
 
-- Keep LSP schematic evaluation responsive by using cached BOM matches without supplier API requests; dependency resolution is unchanged.
-- Preserve deleted hierarchical sheet instances as restorable project metadata while keeping child schematic content loaded.
-- Use physical stackup order for PCBIR slot cutouts and hole-to-land associations when layer declarations are shuffled.
-- Preserve PCBIR hole-to-land associations after routing or copper clears remove land copper.
-- Fix IPC-2581 tools tests failing to compile without default features.
-- Keep cutout-only copper layers empty in artwork composition and rendering while preserving visible drill artwork.
-- Report hole-to-copper clearance violations when unrelated copper reuses a land's source indices.
-- Use physical stackup order for circular-hole DFM clearance and annular-ring checks when copper layer declarations are shuffled.
+- Avoid supplier API requests during LSP evaluation.
+- Keep deleted sheet instances restorable and child schematics loaded.
+- Respect physical stackup order in slot cutouts, land links, and DFM checks.
+- Preserve hole-to-land links after routing or copper clears.
+- Fix IPC-2581 tools test compilation without default features.
+- Remove phantom copper on cutout-only layers without hiding drill artwork.
+- Fix false hole-clearance exemptions from shared source indices.
 
 ## [0.4.50] - 2026-09-05
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -105,7 +105,7 @@ pub(super) fn evaluate(
             let enclosures = copper_layers
                 .iter()
                 .enumerate()
-                .filter(|(copper_index, _)| hole.spans_copper(*copper_index))
+                .filter(|(copper_index, _)| hole.drill_span.contains_copper(*copper_index))
                 .filter(|(_, copper)| conditions.applies_to_layer(copper))
                 .filter_map(|(copper_index, copper)| {
                     let land = hole_lands[hole_index]
@@ -113,7 +113,7 @@ pub(super) fn evaluate(
                         .find(|link| link.copper_index as usize == copper_index)
                         .map(|link: &HoleLand| &copper.lands[link.land_index as usize]);
                     let in_copper = contains[copper_index][position];
-                    let required = land.is_some() || hole.terminates_on(copper_index);
+                    let required = land.is_some() || hole.drill_span.terminates_on(copper_index);
                     (in_copper || required).then_some((
                         copper_index,
                         RingSubject {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -34,7 +34,9 @@ pub(super) fn evaluate(
     for (hole_index, hole) in holes_of_class(design, class) {
         let radius_mm = hole.diameter_mm / 2.0;
         for (copper_index, copper) in design.copper_layers.iter().enumerate() {
-            if !hole.spans_copper(copper_index) || !conditions.applies_to_layer(copper) {
+            if !hole.drill_span.contains_copper(copper_index)
+                || !conditions.applies_to_layer(copper)
+            {
                 continue;
             }
             checked += 1;
@@ -566,7 +568,7 @@ limit = {{ minimum = "0.20 mm" }}
                     .copper_layers
                     .iter()
                     .enumerate()
-                    .filter(|(index, _)| design.holes[0].spans_copper(*index))
+                    .filter(|(index, _)| design.holes[0].drill_span.contains_copper(*index))
                     .map(|(_, layer)| layer.layer.name.as_str())
                     .collect::<Vec<_>>();
                 included.sort_unstable();

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
@@ -53,7 +53,7 @@ pub(super) fn evaluate(
                     let y_gap = (second.bbox.min.y - first.bbox.max.y)
                         .max(first.bbox.min.y - second.bbox.max.y)
                         .max(0.0);
-                    classes_match && y_gap < reach && first.span_overlaps(second)
+                    classes_match && y_gap < reach && first.drill_span.overlaps(&second.drill_span)
                 })
                 .map(move |second| {
                     let distance = disk_clearance(

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/plated_slot_enclosure.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/plated_slot_enclosure.rs
@@ -25,19 +25,16 @@ pub(super) fn evaluate(limit_mm: f64, conditions: &Conditions, design: &Design) 
         .enumerate()
         .filter(|(_, slot)| slot_matches(slot.plating, SlotPlating::Plated))
     {
-        let first = usize::from(slot.drill_span.first_copper_index);
-        let last = usize::from(slot.drill_span.last_copper_index);
         let mut sites = Vec::new();
         for (index, copper) in design
             .copper_layers
             .iter()
             .enumerate()
             .filter(|(index, copper)| {
-                (first..=last).contains(index) && conditions.applies_to_layer(copper)
+                slot.drill_span.contains_copper(*index) && conditions.applies_to_layer(copper)
             })
         {
-            let required = index == first
-                || index == last
+            let required = slot.drill_span.terminates_on(index)
                 || design.slot_lands[slot_index]
                     .iter()
                     .any(|land| land.copper_index as usize == index);

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
@@ -36,9 +36,9 @@ pub(super) fn evaluate(
         for (copper_index, copper) in design.copper_layers.iter().enumerate() {
             // Extraction orders copper layers and drill spans by the same
             // validated physical stackup.
-            let span = usize::from(slot.drill_span.first_copper_index)
-                ..=usize::from(slot.drill_span.last_copper_index);
-            if !span.contains(&copper_index) || !conditions.applies_to_layer(copper) {
+            if !slot.drill_span.contains_copper(copper_index)
+                || !conditions.applies_to_layer(copper)
+            {
                 continue;
             }
             checked += 1;

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -94,8 +94,32 @@ impl<'a> Design<'a> {
         let copper_layers = when(pools.copper, || {
             collect_copper_layers(imported, scope, pools.conductor_ownership, stackup.as_ref())
         })?;
-        let physical_holes = when(pools.hole_lands || pools.slot_lands, || {
-            imported.physical_holes(scope)
+        let (physical_holes, land_indices) = when(pools.hole_lands || pools.slot_lands, || {
+            let physical_holes = imported
+                .physical_holes(scope)?
+                .into_iter()
+                .map(|hole| (hole.id.0, hole))
+                .collect();
+            let land_indices = copper_layers
+                .iter()
+                .enumerate()
+                .flat_map(|(copper_index, layer)| {
+                    layer
+                        .lands
+                        .iter()
+                        .enumerate()
+                        .map(move |(land_index, land)| {
+                            (
+                                land.id,
+                                HoleLand {
+                                    copper_index: copper_index as u32,
+                                    land_index: land_index as u32,
+                                },
+                            )
+                        })
+                })
+                .collect();
+            Ok((physical_holes, land_indices))
         })?;
         let layout = when(pools.board_outlines || pools.board_arrays, || {
             Ok(Some(&imported.geometry))
@@ -129,14 +153,14 @@ impl<'a> Design<'a> {
             hole_lands: when(pools.hole_lands, || {
                 link_lands(
                     holes.iter().map(|hole| hole.id),
-                    &copper_layers,
+                    &land_indices,
                     &physical_holes,
                 )
             })?,
             slot_lands: when(pools.slot_lands, || {
                 link_lands(
                     slots.iter().map(|slot| slot.id),
-                    &copper_layers,
+                    &land_indices,
                     &physical_holes,
                 )
             })?,
@@ -157,7 +181,7 @@ impl<'a> Design<'a> {
             copper_layers,
         };
         if pools.resolved_drill_spans {
-            validate_hole_clearance_spans(&design, rules)?;
+            validate_drill_spans(&design, rules)?;
         }
         Ok(design)
     }
@@ -237,7 +261,7 @@ impl<'a> Design<'a> {
     }
 }
 
-fn validate_hole_clearance_spans(design: &Design, rules: &[Rule]) -> Result<()> {
+fn validate_drill_spans(design: &Design, rules: &[Rule]) -> Result<()> {
     for slot in &design.slots {
         let selected = rules.iter().any(|rule| {
             (matches!(rule.kind, rules::RuleKind::SlotToCopperClearance(plating)
@@ -270,7 +294,8 @@ fn validate_hole_clearance_spans(design: &Design, rules: &[Rule]) -> Result<()> 
                     .iter()
                     .enumerate()
                     .any(|(index, layer)| {
-                        hole.spans_copper(index) && rule.conditions.applies_to_layer(layer)
+                        hole.drill_span.contains_copper(index)
+                            && rule.conditions.applies_to_layer(layer)
                     })
         });
         if selected
@@ -572,32 +597,6 @@ pub(super) struct Hole {
     pub net: Option<Symbol>,
     pub source_set_index: u32,
     pub source_feature_index: u32,
-}
-
-impl Hole {
-    pub fn spans_copper(&self, copper_index: usize) -> bool {
-        let (low, high) = (
-            self.drill_span.first_copper_index,
-            self.drill_span.last_copper_index,
-        );
-        (usize::from(low)..=usize::from(high)).contains(&copper_index)
-    }
-
-    /// Whether two drill spans coexist at some board depth.
-    pub fn span_overlaps(&self, other: &Hole) -> bool {
-        self.drill_span.first_copper_index <= other.drill_span.last_copper_index
-            && other.drill_span.first_copper_index <= self.drill_span.last_copper_index
-    }
-
-    /// Whether `copper_index` is an end of the drill span: a layer the
-    /// plating barrel must land on.
-    pub fn terminates_on(&self, copper_index: usize) -> bool {
-        let (low, high) = (
-            self.drill_span.first_copper_index,
-            self.drill_span.last_copper_index,
-        );
-        copper_index == usize::from(low) || copper_index == usize::from(high)
-    }
 }
 
 /// One hole's land on one copper layer, by pool indices.
@@ -1440,32 +1439,9 @@ fn collect_mask_layers(imported: &ImportedDesign, scope: ArtworkScope) -> Result
 /// nearest candidate.
 fn link_lands(
     holes: impl ExactSizeIterator<Item = FeatureOccurrenceId>,
-    copper_layers: &[CopperLayer],
-    physical_holes: &[PhysicalHole],
+    land_indices: &HashMap<LandId, HoleLand>,
+    physical_holes: &HashMap<FeatureOccurrenceId, PhysicalHole>,
 ) -> Result<Vec<Vec<HoleLand>>> {
-    let physical_holes = physical_holes
-        .iter()
-        .map(|hole| (hole.id.0, hole))
-        .collect::<HashMap<_, _>>();
-    let land_indices = copper_layers
-        .iter()
-        .enumerate()
-        .flat_map(|(copper_index, layer)| {
-            layer
-                .lands
-                .iter()
-                .enumerate()
-                .map(move |(land_index, land)| {
-                    (
-                        land.id,
-                        HoleLand {
-                            copper_index: copper_index as u32,
-                            land_index: land_index as u32,
-                        },
-                    )
-                })
-        })
-        .collect::<HashMap<_, _>>();
     let mut hole_lands = vec![Vec::new(); holes.len()];
     for (hole_index, hole) in holes.enumerate() {
         let physical_hole = physical_holes

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/report.rs
@@ -612,6 +612,25 @@ pub struct DrillSpan {
     pub interpretation: &'static str,
 }
 
+impl DrillSpan {
+    pub(super) fn contains_copper(&self, copper_index: usize) -> bool {
+        (usize::from(self.first_copper_index)..=usize::from(self.last_copper_index))
+            .contains(&copper_index)
+    }
+
+    /// Whether two drill spans coexist at some board depth.
+    pub(super) fn overlaps(&self, other: &Self) -> bool {
+        self.first_copper_index <= other.last_copper_index
+            && other.first_copper_index <= self.last_copper_index
+    }
+
+    /// Whether this is an end of the span, where the plating must land.
+    pub(super) fn terminates_on(&self, copper_index: usize) -> bool {
+        copper_index == usize::from(self.first_copper_index)
+            || copper_index == usize::from(self.last_copper_index)
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct SourceLocator {
     pub step: Option<String>,


### PR DESCRIPTION
Build physical-hole and land lookup maps once for both hole and slot checks, and share range predicates on DrillSpan. Rename the span validator to reflect its scope without changing extraction, ownership, errors, or report output. Scoped DFM tests pass with default and no-default features, and Clippy and formatting checks pass.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->