### PR TITLE
Upgrade shipped symbols to KiCad 10 and enforce their format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade all remaining bundled standard-library and example symbols to KiCad 10 format.
+
 ## [0.4.51] - 2026-09-05
 
 ### Added

--- a/crates/pcb-eda/tests/test_eda.rs
+++ b/crates/pcb-eda/tests/test_eda.rs
@@ -3,6 +3,53 @@ use std::collections::{BTreeSet, HashMap};
 use std::fs;
 use std::path::Path;
 
+#[test]
+fn test_shipped_symbols_use_kicad10_format() {
+    fn check_directory(directory: &Path) -> usize {
+        let mut checked = 0;
+        for entry in fs::read_dir(directory).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                checked += check_directory(&path);
+            } else if path.extension().is_some_and(|ext| ext == "kicad_sym") {
+                let contents = fs::read_to_string(&path).unwrap();
+                let root = pcb_sexpr::parse(&contents)
+                    .unwrap_or_else(|err| panic!("{}: {err}", path.display()));
+                let items = root.as_list().expect("Expected a symbol library list");
+                assert_eq!(
+                    items.first().and_then(pcb_sexpr::Sexpr::as_sym),
+                    Some("kicad_symbol_lib"),
+                    "{}: expected a KiCad symbol library",
+                    path.display()
+                );
+                let version = pcb_sexpr::find_child_list(items, "version")
+                    .and_then(|items| items.get(1))
+                    .and_then(pcb_sexpr::Sexpr::as_int);
+                assert_eq!(
+                    version,
+                    Some(20251024),
+                    "{}: expected KiCad 10 format; run with KiCad 10: kicad-cli sym upgrade \"{}\"",
+                    path.display(),
+                    path.display()
+                );
+                SymbolLibrary::from_string(&contents, "kicad_sym")
+                    .unwrap_or_else(|err| panic!("{}: {err}", path.display()));
+                checked += 1;
+            }
+        }
+        checked
+    }
+
+    let repository = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    // Only shipped assets: legacy test fixtures must retain compatibility coverage.
+    for directory in ["lib", "examples"] {
+        assert!(
+            check_directory(&repository.join(directory)) > 0,
+            "No symbol libraries found in {directory}"
+        );
+    }
+}
+
 fn setup_symbol(name: &str) -> Symbol {
     let name_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("tests/resources/kicad")

--- a/examples/L6387E/L6387ED.kicad_sym
+++ b/examples/L6387E/L6387ED.kicad_sym
@@ -1,13 +1,17 @@
 (kicad_symbol_lib
-	(version 20241209)
+	(version 20251024)
 	(generator "kicad_symbol_editor")
-	(generator_version "9.0")
+	(generator_version "10.0")
 	(symbol "L6387ED"
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
 		(property "Reference" "IC"
 			(at 24.13 7.62 0)
+			(show_name no)
+			(do_not_autoplace no)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -17,6 +21,8 @@
 		)
 		(property "Value" "L6387ED"
 			(at 24.13 5.08 0)
+			(show_name no)
+			(do_not_autoplace no)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -26,101 +32,121 @@
 		)
 		(property "Footprint" "SOIC127P600X175-8N"
 			(at 24.13 -94.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left top)
-				(hide yes)
 			)
 		)
 		(property "Datasheet" "https://datasheet.datasheetarchive.com/originals/distributors/Datasheets-45/DSA-17132.pdf"
 			(at 24.13 -194.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left top)
-				(hide yes)
 			)
 		)
 		(property "Description" "L6387ED, Dual MOSFET Power Driver 0.65A, Non-Inverting, Maximum of 17V, 8-Pin SOIC"
 			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(hide yes)
 			)
 		)
 		(property "Height" "1.75"
 			(at 24.13 -394.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left top)
-				(hide yes)
 			)
 		)
 		(property "Manufacturer_Name" "STMicroelectronics"
 			(at 24.13 -494.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left top)
-				(hide yes)
 			)
 		)
 		(property "Manufacturer_Part_Number" "L6387ED"
 			(at 24.13 -594.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left top)
-				(hide yes)
 			)
 		)
 		(property "Mouser Part Number" "511-L6387ED"
 			(at 24.13 -694.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left top)
-				(hide yes)
 			)
 		)
 		(property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/STMicroelectronics/L6387ED?qs=qolwYojYp3Smj0WMIYr9rQ%3D%3D"
 			(at 24.13 -794.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left top)
-				(hide yes)
 			)
 		)
 		(property "Arrow Part Number" "L6387ED"
 			(at 24.13 -894.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left top)
-				(hide yes)
 			)
 		)
 		(property "Arrow Price/Stock" "https://www.arrow.com/en/products/l6387ed/stmicroelectronics?region=europe"
 			(at 24.13 -994.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
 				(justify left top)
-				(hide yes)
 			)
 		)
 		(symbol "L6387ED_1_1"
@@ -208,34 +234,16 @@
 				)
 			)
 			(pin passive line
-				(at 27.94 0 180)
+				(at 27.94 -7.62 180)
 				(length 5.08)
-				(name "VBOOT"
+				(name "LVG"
 					(effects
 						(font
 							(size 1.27 1.27)
 						)
 					)
 				)
-				(number "8"
-					(effects
-						(font
-							(size 1.27 1.27)
-						)
-					)
-				)
-			)
-			(pin passive line
-				(at 27.94 -2.54 180)
-				(length 5.08)
-				(name "HVG"
-					(effects
-						(font
-							(size 1.27 1.27)
-						)
-					)
-				)
-				(number "7"
+				(number "5"
 					(effects
 						(font
 							(size 1.27 1.27)
@@ -262,16 +270,34 @@
 				)
 			)
 			(pin passive line
-				(at 27.94 -7.62 180)
+				(at 27.94 -2.54 180)
 				(length 5.08)
-				(name "LVG"
+				(name "HVG"
 					(effects
 						(font
 							(size 1.27 1.27)
 						)
 					)
 				)
-				(number "5"
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 27.94 0 180)
+				(length 5.08)
+				(name "VBOOT"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
 					(effects
 						(font
 							(size 1.27 1.27)

--- a/examples/PhaseDriver/B05100W-TP.kicad_sym
+++ b/examples/PhaseDriver/B05100W-TP.kicad_sym
@@ -1,108 +1,267 @@
-(kicad_symbol_lib (version 20211014) (generator SamacSys_ECAD_Model)
-  (symbol "B05100W-TP" (in_bom yes) (on_board yes) (pin_names hide)
-    (property "Reference" "D" (at 12.7 8.89 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (property "Value" "B05100W-TP" (at 12.7 6.35 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (property "Footprint" "SOD3716X135N" (at 12.7 -93.65 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Datasheet" "https://www.mccsemi.com/pdf/Products/B05100W(SOD-123).pdf" (at 12.7 -193.65 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "ki_description" "SCHOTTKY BARRIER RECTIFIERS 100V 0.5A, SOD-123" (at 12.7 -293.65 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Height" "1.35" (at 12.7 -393.65 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Mouser Part Number" "" (at 12.7 -493.65 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Mouser Price/Stock" "" (at 12.7 -593.65 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Manufacturer_Name" "MCC" (at 12.7 -693.65 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Manufacturer_Part_Number" "B05100W-TP" (at 12.7 -793.65 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (polyline
-      (pts
-        (xy 7.62 2.54)
-        (xy 7.62 -2.54)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 7.62 2.54)
-        (xy 8.636 2.54)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 8.636 1.524)
-        (xy 8.636 2.54)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 7.62 -2.54)
-        (xy 6.604 -2.54)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 6.604 -1.524)
-        (xy 6.604 -2.54)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 5.08 0)
-        (xy 7.62 0)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 12.7 0)
-        (xy 15.24 0)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 7.62 0)
-        (xy 12.7 2.54)
-        (xy 12.7 -2.54)
-        (xy 7.62 0)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type outline))
-    )
-    (pin passive line (at 2.54 0 0) (length 2.54)
-      (name "K" (effects (font (size 1.27 1.27))))
-      (number "1" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 17.78 0 180) (length 2.54)
-      (name "A" (effects (font (size 1.27 1.27))))
-      (number "2" (effects (font (size 1.27 1.27))))
-    )
-  )
+(kicad_symbol_lib
+	(version 20251024)
+	(generator "kicad_symbol_editor")
+	(generator_version "10.0")
+	(symbol "B05100W-TP"
+		(pin_names
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "D"
+			(at 12.7 8.89 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Value" "B05100W-TP"
+			(at 12.7 6.35 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Footprint" "SOD3716X135N"
+			(at 12.7 -93.65 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Datasheet" "https://www.mccsemi.com/pdf/Products/B05100W(SOD-123).pdf"
+			(at 12.7 -193.65 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Description" "SCHOTTKY BARRIER RECTIFIERS 100V 0.5A, SOD-123"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Height" "1.35"
+			(at 12.7 -393.65 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Mouser Part Number" ""
+			(at 12.7 -493.65 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Mouser Price/Stock" ""
+			(at 12.7 -593.65 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Manufacturer_Name" "MCC"
+			(at 12.7 -693.65 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Manufacturer_Part_Number" "B05100W-TP"
+			(at 12.7 -793.65 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(symbol "B05100W-TP_1_1"
+			(polyline
+				(pts
+					(xy 5.08 0) (xy 7.62 0)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 6.604 -1.524) (xy 6.604 -2.54)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 7.62 2.54) (xy 7.62 -2.54)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 7.62 2.54) (xy 8.636 2.54)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 7.62 0) (xy 12.7 2.54) (xy 12.7 -2.54) (xy 7.62 0)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 7.62 -2.54) (xy 6.604 -2.54)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 8.636 1.524) (xy 8.636 2.54)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 12.7 0) (xy 15.24 0)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(pin passive line
+				(at 2.54 0 0)
+				(length 2.54)
+				(name "K"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 17.78 0 180)
+				(length 2.54)
+				(name "A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
 )

--- a/examples/PhaseDriver/BAT30KFILM.kicad_sym
+++ b/examples/PhaseDriver/BAT30KFILM.kicad_sym
@@ -1,82 +1,243 @@
-(kicad_symbol_lib (version 20211014) (generator SamacSys_ECAD_Model)
-  (symbol "BAT30KFILM" (in_bom yes) (on_board yes) (pin_names hide)
-    (property "Reference" "D" (at 11.43 5.08 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (property "Value" "BAT30KFILM" (at 11.43 2.54 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (property "Footprint" "SODFL1608X70N" (at 11.43 -97.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Datasheet" "http://www.st.com/content/ccc/resource/technical/document/datasheet/b5/44/50/dc/a4/84/48/70/CD00126118.pdf/files/CD00126118.pdf/jcr:content/translations/en.CD00126118.pdf" (at 11.43 -197.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "ki_description" "STMicroelectronics BAT30KFILM, SMT Schottky Diode, 30V 300mA, 2-Pin SOD-523" (at 11.43 -297.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Height" "0.7" (at 11.43 -397.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Manufacturer_Name" "STMicroelectronics" (at 11.43 -497.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Manufacturer_Part_Number" "BAT30KFILM" (at 11.43 -597.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Mouser Part Number" "511-BAT30KFILM" (at 11.43 -697.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/STMicroelectronics/BAT30KFILM?qs=jZi1jxfVU97WgdRkbosYSw%3D%3D" (at 11.43 -797.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Arrow Part Number" "BAT30KFILM" (at 11.43 -897.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Arrow Price/Stock" "https://www.arrow.com/en/products/bat30kfilm/stmicroelectronics?utm_currency=USD&region=europe" (at 11.43 -997.46 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (polyline
-      (pts
-        (xy 5.08 2.54)
-        (xy 5.08 -2.54)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 2.54 0)
-        (xy 5.08 0)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 10.16 0)
-        (xy 12.7 0)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type none))
-    )
-    (polyline
-      (pts
-        (xy 5.08 0)
-        (xy 10.16 2.54)
-        (xy 10.16 -2.54)
-        (xy 5.08 0)
-      )
-      (stroke (width 0.254) (type default))
-      (fill (type outline))
-    )
-    (pin passive line (at 0 0 0) (length 2.54)
-      (name "K" (effects (font (size 1.27 1.27))))
-      (number "1" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 15.24 0 180) (length 2.54)
-      (name "A" (effects (font (size 1.27 1.27))))
-      (number "2" (effects (font (size 1.27 1.27))))
-    )
-  )
+(kicad_symbol_lib
+	(version 20251024)
+	(generator "kicad_symbol_editor")
+	(generator_version "10.0")
+	(symbol "BAT30KFILM"
+		(pin_names
+			(hide yes)
+		)
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "D"
+			(at 11.43 5.08 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Value" "BAT30KFILM"
+			(at 11.43 2.54 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Footprint" "SODFL1608X70N"
+			(at 11.43 -97.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Datasheet" "http://www.st.com/content/ccc/resource/technical/document/datasheet/b5/44/50/dc/a4/84/48/70/CD00126118.pdf/files/CD00126118.pdf/jcr:content/translations/en.CD00126118.pdf"
+			(at 11.43 -197.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Description" "STMicroelectronics BAT30KFILM, SMT Schottky Diode, 30V 300mA, 2-Pin SOD-523"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Height" "0.7"
+			(at 11.43 -397.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Manufacturer_Name" "STMicroelectronics"
+			(at 11.43 -497.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Manufacturer_Part_Number" "BAT30KFILM"
+			(at 11.43 -597.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Mouser Part Number" "511-BAT30KFILM"
+			(at 11.43 -697.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/STMicroelectronics/BAT30KFILM?qs=jZi1jxfVU97WgdRkbosYSw%3D%3D"
+			(at 11.43 -797.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Arrow Part Number" "BAT30KFILM"
+			(at 11.43 -897.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Arrow Price/Stock" "https://www.arrow.com/en/products/bat30kfilm/stmicroelectronics?utm_currency=USD&region=europe"
+			(at 11.43 -997.46 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(symbol "BAT30KFILM_1_1"
+			(polyline
+				(pts
+					(xy 2.54 0) (xy 5.08 0)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 5.08 2.54) (xy 5.08 -2.54)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(polyline
+				(pts
+					(xy 5.08 0) (xy 10.16 2.54) (xy 10.16 -2.54) (xy 5.08 0)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(polyline
+				(pts
+					(xy 10.16 0) (xy 12.7 0)
+				)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(pin passive line
+				(at 0 0 0)
+				(length 2.54)
+				(name "K"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 15.24 0 180)
+				(length 2.54)
+				(name "A"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
 )

--- a/examples/PhaseDriver/STL100N8F7.kicad_sym
+++ b/examples/PhaseDriver/STL100N8F7.kicad_sym
@@ -1,82 +1,329 @@
-(kicad_symbol_lib (version 20211014) (generator SamacSys_ECAD_Model)
-  (symbol "STL100N8F7" (in_bom yes) (on_board yes)
-    (property "Reference" "IC" (at 21.59 7.62 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (property "Value" "STL100N8F7" (at 21.59 5.08 0)
-      (effects (font (size 1.27 1.27)) (justify left top))
-    )
-    (property "Footprint" "STL100N8F7" (at 21.59 -94.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Datasheet" "https://www.st.com/resource/en/datasheet/stl100n8f7.pdf" (at 21.59 -194.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "ki_description" "N-channel 80 V, 5.2 mOhm typ., 100 A STripFET F7 Power MOSFET in a PowerFLAT 5x6 package" (at 21.59 -294.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Height" "1.05" (at 21.59 -394.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Manufacturer_Name" "STMicroelectronics" (at 21.59 -494.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Manufacturer_Part_Number" "STL100N8F7" (at 21.59 -594.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Mouser Part Number" "511-STL100N8F7" (at 21.59 -694.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/STMicroelectronics/STL100N8F7?qs=dTJS0cRn7ohTbC8AAiQuWA%3D%3D" (at 21.59 -794.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Arrow Part Number" "STL100N8F7" (at 21.59 -894.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (property "Arrow Price/Stock" "https://www.arrow.com/en/products/stl100n8f7/stmicroelectronics" (at 21.59 -994.92 0)
-      (effects (font (size 1.27 1.27)) (justify left top) hide)
-    )
-    (rectangle
-      (start 5.08 2.54)
-      (end 20.32 -12.7)
-      (stroke (width 0.254) (type default))
-      (fill (type background))
-    )
-    (pin passive line (at 0 0 0) (length 5.08)
-      (name "S_1" (effects (font (size 1.27 1.27))))
-      (number "1" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 0 -2.54 0) (length 5.08)
-      (name "S_2" (effects (font (size 1.27 1.27))))
-      (number "2" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 0 -5.08 0) (length 5.08)
-      (name "S_3" (effects (font (size 1.27 1.27))))
-      (number "3" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 0 -7.62 0) (length 5.08)
-      (name "G" (effects (font (size 1.27 1.27))))
-      (number "4" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 0 -10.16 0) (length 5.08)
-      (name "D_1" (effects (font (size 1.27 1.27))))
-      (number "5" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 25.4 0 180) (length 5.08)
-      (name "D_2" (effects (font (size 1.27 1.27))))
-      (number "6" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 25.4 -2.54 180) (length 5.08)
-      (name "D_3" (effects (font (size 1.27 1.27))))
-      (number "7" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 25.4 -5.08 180) (length 5.08)
-      (name "D_4" (effects (font (size 1.27 1.27))))
-      (number "8" (effects (font (size 1.27 1.27))))
-    )
-    (pin passive line (at 25.4 -7.62 180) (length 5.08)
-      (name "D_5" (effects (font (size 1.27 1.27))))
-      (number "9" (effects (font (size 1.27 1.27))))
-    )
-  )
+(kicad_symbol_lib
+	(version 20251024)
+	(generator "kicad_symbol_editor")
+	(generator_version "10.0")
+	(symbol "STL100N8F7"
+		(exclude_from_sim no)
+		(in_bom yes)
+		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
+		(property "Reference" "IC"
+			(at 21.59 7.62 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Value" "STL100N8F7"
+			(at 21.59 5.08 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Footprint" "STL100N8F7"
+			(at 21.59 -94.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Datasheet" "https://www.st.com/resource/en/datasheet/stl100n8f7.pdf"
+			(at 21.59 -194.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Description" "N-channel 80 V, 5.2 mOhm typ., 100 A STripFET F7 Power MOSFET in a PowerFLAT 5x6 package"
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Height" "1.05"
+			(at 21.59 -394.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Manufacturer_Name" "STMicroelectronics"
+			(at 21.59 -494.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Manufacturer_Part_Number" "STL100N8F7"
+			(at 21.59 -594.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Mouser Part Number" "511-STL100N8F7"
+			(at 21.59 -694.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Mouser Price/Stock" "https://www.mouser.co.uk/ProductDetail/STMicroelectronics/STL100N8F7?qs=dTJS0cRn7ohTbC8AAiQuWA%3D%3D"
+			(at 21.59 -794.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Arrow Part Number" "STL100N8F7"
+			(at 21.59 -894.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(property "Arrow Price/Stock" "https://www.arrow.com/en/products/stl100n8f7/stmicroelectronics"
+			(at 21.59 -994.92 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+				(justify left top)
+			)
+		)
+		(symbol "STL100N8F7_1_1"
+			(rectangle
+				(start 5.08 2.54)
+				(end 20.32 -12.7)
+				(stroke
+					(width 0.254)
+					(type default)
+				)
+				(fill
+					(type background)
+				)
+			)
+			(pin passive line
+				(at 0 0 0)
+				(length 5.08)
+				(name "S_1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -2.54 0)
+				(length 5.08)
+				(name "S_2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -5.08 0)
+				(length 5.08)
+				(name "S_3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -7.62 0)
+				(length 5.08)
+				(name "G"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 0 -10.16 0)
+				(length 5.08)
+				(name "D_1"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 0 180)
+				(length 5.08)
+				(name "D_2"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "6"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -2.54 180)
+				(length 5.08)
+				(name "D_3"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "7"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -5.08 180)
+				(length 5.08)
+				(name "D_4"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "8"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+			(pin passive line
+				(at 25.4 -7.62 180)
+				(length 5.08)
+				(name "D_5"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+				(number "9"
+					(effects
+						(font
+							(size 1.27 1.27)
+						)
+					)
+				)
+			)
+		)
+		(embedded_fonts no)
+	)
 )

--- a/lib/std/generics/symbols/QR.kicad_sym
+++ b/lib/std/generics/symbols/QR.kicad_sym
@@ -1,22 +1,61 @@
 (kicad_symbol_lib
-	(version 20241209)
+	(version 20251024)
 	(generator "kicad_symbol_editor")
-	(generator_version "9.0")
+	(generator_version "10.0")
 	(symbol "QR"
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
 		(property "Reference" "QR"
 			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(hide yes)
 			)
 		)
 		(property "Value" "QR"
-			(at 0 -12.000 0)
+			(at 0 -12 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Footprint" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Datasheet" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
+			(effects
+				(font
+					(size 1.27 1.27)
+				)
+			)
+		)
+		(property "Description" ""
+			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -24,241 +63,2591 @@
 			)
 		)
 		(symbol "QR_0_1"
-			(rectangle (start -10.500 10.500) (end 10.500 -10.500) (stroke (width 0) (type default)) (fill (type none)))
-			(rectangle (start -10.500 10.500) (end -9.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -9.500 10.500) (end -8.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 10.500) (end -7.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 10.500) (end -6.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 10.500) (end -5.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -5.500 10.500) (end -4.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 10.500) (end -3.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 10.500) (end -1.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 10.500) (end 2.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 10.500) (end 4.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 10.500) (end 5.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 10.500) (end 6.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 10.500) (end 7.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 10.500) (end 8.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 8.500 10.500) (end 9.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 10.500) (end 10.500 9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 9.500) (end -9.500 8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 9.500) (end -3.500 8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 9.500) (end 0.500 8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 9.500) (end 2.500 8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 9.500) (end 4.500 8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 9.500) (end 10.500 8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 8.500) (end -9.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 8.500) (end -7.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 8.500) (end -6.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 8.500) (end -5.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 8.500) (end -3.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 0.500 8.500) (end 1.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 8.500) (end 2.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 8.500) (end 4.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 8.500) (end 6.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 8.500) (end 7.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 8.500) (end 8.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 8.500) (end 10.500 7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 7.500) (end -9.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 7.500) (end -7.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 7.500) (end -6.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 7.500) (end -5.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 7.500) (end -3.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 7.500) (end 0.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 7.500) (end 2.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 7.500) (end 4.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 7.500) (end 6.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 7.500) (end 7.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 7.500) (end 8.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 7.500) (end 10.500 6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 6.500) (end -9.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 6.500) (end -7.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 6.500) (end -6.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 6.500) (end -5.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 6.500) (end -3.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -1.500 6.500) (end -0.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 0.500 6.500) (end 1.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 6.500) (end 2.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 6.500) (end 4.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 6.500) (end 6.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 6.500) (end 7.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 6.500) (end 8.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 6.500) (end 10.500 5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 5.500) (end -9.500 4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 5.500) (end -3.500 4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -1.500 5.500) (end -0.500 4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 5.500) (end 0.500 4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 5.500) (end 4.500 4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 5.500) (end 10.500 4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 4.500) (end -9.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -9.500 4.500) (end -8.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 4.500) (end -7.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 4.500) (end -6.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 4.500) (end -5.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -5.500 4.500) (end -4.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 4.500) (end -3.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 4.500) (end -1.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 4.500) (end 0.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 4.500) (end 2.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 4.500) (end 4.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 4.500) (end 5.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 4.500) (end 6.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 4.500) (end 7.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 4.500) (end 8.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 8.500 4.500) (end 9.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 4.500) (end 10.500 3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 3.500) (end -1.500 2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 2.500) (end -9.500 1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -9.500 2.500) (end -8.500 1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 2.500) (end -6.500 1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 2.500) (end -5.500 1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 2.500) (end -3.500 1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 2.500) (end 0.500 1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 0.500 2.500) (end 1.500 1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 2.500) (end 4.500 1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 2.500) (end 10.500 1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 1.500) (end -9.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 1.500) (end -5.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -3.500 1.500) (end -2.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 1.500) (end -1.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -1.500 1.500) (end -0.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 1.500) (end 0.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 0.500 1.500) (end 1.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 1.500) (end 2.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 2.500 1.500) (end 3.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 1.500) (end 5.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 1.500) (end 6.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 1.500) (end 8.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 8.500 1.500) (end 9.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 1.500) (end 10.500 0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 0.500) (end -9.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 0.500) (end -7.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 0.500) (end -5.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 0.500) (end -3.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 0.500) (end -1.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -1.500 0.500) (end -0.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 0.500 0.500) (end 1.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 0.500) (end 2.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 0.500) (end 5.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 0.500) (end 7.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 0.500) (end 10.500 -0.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 -0.500) (end -9.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -9.500 -0.500) (end -8.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 -0.500) (end -7.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 -0.500) (end -6.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -5.500 -0.500) (end -4.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 -0.500) (end -1.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -1.500 -0.500) (end -0.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 -0.500) (end 2.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 2.500 -0.500) (end 3.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 -0.500) (end 4.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 -0.500) (end 5.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 -0.500) (end 6.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 8.500 -0.500) (end 9.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 -0.500) (end 10.500 -1.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -9.500 -1.500) (end -8.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 -1.500) (end -5.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 -1.500) (end -3.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -3.500 -1.500) (end -2.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -1.500 -1.500) (end -0.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 0.500 -1.500) (end 1.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 -1.500) (end 2.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 2.500 -1.500) (end 3.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 -1.500) (end 4.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 -1.500) (end 5.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 -1.500) (end 6.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 -1.500) (end 7.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 -1.500) (end 8.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 -1.500) (end 10.500 -2.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 -2.500) (end -1.500 -3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 -2.500) (end 0.500 -3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 -2.500) (end 2.500 -3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 2.500 -2.500) (end 3.500 -3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 -2.500) (end 4.500 -3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 -2.500) (end 8.500 -3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 8.500 -2.500) (end 9.500 -3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 -2.500) (end 10.500 -3.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 -3.500) (end -9.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -9.500 -3.500) (end -8.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 -3.500) (end -7.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 -3.500) (end -6.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 -3.500) (end -5.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -5.500 -3.500) (end -4.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 -3.500) (end -3.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 -3.500) (end 0.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 0.500 -3.500) (end 1.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 -3.500) (end 8.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 -3.500) (end 10.500 -4.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 -4.500) (end -9.500 -5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 -4.500) (end -3.500 -5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -1.500 -4.500) (end -0.500 -5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 -4.500) (end 4.500 -5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 -4.500) (end 8.500 -5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 8.500 -4.500) (end 9.500 -5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 -4.500) (end 10.500 -5.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 -5.500) (end -9.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 -5.500) (end -7.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 -5.500) (end -6.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 -5.500) (end -5.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 -5.500) (end -3.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 -5.500) (end -1.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -1.500 -5.500) (end -0.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 -5.500) (end 0.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 2.500 -5.500) (end 3.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 -5.500) (end 4.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 -5.500) (end 6.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 -5.500) (end 7.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 -5.500) (end 8.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 -5.500) (end 10.500 -6.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 -6.500) (end -9.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 -6.500) (end -7.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 -6.500) (end -6.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 -6.500) (end -5.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 -6.500) (end -3.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 -6.500) (end -1.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 -6.500) (end 0.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 -6.500) (end 2.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 2.500 -6.500) (end 3.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 3.500 -6.500) (end 4.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 -6.500) (end 5.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 -6.500) (end 6.500 -7.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 -7.500) (end -9.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 -7.500) (end -7.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 -7.500) (end -6.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 -7.500) (end -5.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 -7.500) (end -3.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -1.500 -7.500) (end -0.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 0.500 -7.500) (end 1.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 -7.500) (end 2.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 2.500 -7.500) (end 3.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 -7.500) (end 5.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 -7.500) (end 6.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 -7.500) (end 7.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 8.500 -7.500) (end 9.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 9.500 -7.500) (end 10.500 -8.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 -8.500) (end -9.500 -9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 -8.500) (end -3.500 -9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 -8.500) (end -1.500 -9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -0.500 -8.500) (end 0.500 -9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 0.500 -8.500) (end 1.500 -9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 -8.500) (end 2.500 -9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 -8.500) (end 5.500 -9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 6.500 -8.500) (end 7.500 -9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 8.500 -8.500) (end 9.500 -9.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -10.500 -9.500) (end -9.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -9.500 -9.500) (end -8.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -8.500 -9.500) (end -7.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -7.500 -9.500) (end -6.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -6.500 -9.500) (end -5.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -5.500 -9.500) (end -4.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -4.500 -9.500) (end -3.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start -2.500 -9.500) (end -1.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 1.500 -9.500) (end 2.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 2.500 -9.500) (end 3.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 4.500 -9.500) (end 5.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 5.500 -9.500) (end 6.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 7.500 -9.500) (end 8.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
-			(rectangle (start 8.500 -9.500) (end 9.500 -10.500) (stroke (width 0) (type default)) (fill (type outline)))
+			(rectangle
+				(start -10.5 10.5)
+				(end -9.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 10.5)
+				(end 10.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type none)
+				)
+			)
+			(rectangle
+				(start -10.5 9.5)
+				(end -9.5 8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 8.5)
+				(end -9.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 7.5)
+				(end -9.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 6.5)
+				(end -9.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 5.5)
+				(end -9.5 4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 4.5)
+				(end -9.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 2.5)
+				(end -9.5 1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 1.5)
+				(end -9.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 0.5)
+				(end -9.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 -0.5)
+				(end -9.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 -3.5)
+				(end -9.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 -4.5)
+				(end -9.5 -5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 -5.5)
+				(end -9.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 -6.5)
+				(end -9.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 -7.5)
+				(end -9.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 -8.5)
+				(end -9.5 -9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -10.5 -9.5)
+				(end -9.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -9.5 10.5)
+				(end -8.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -9.5 4.5)
+				(end -8.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -9.5 2.5)
+				(end -8.5 1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -9.5 -0.5)
+				(end -8.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -9.5 -1.5)
+				(end -8.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -9.5 -3.5)
+				(end -8.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -9.5 -9.5)
+				(end -8.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 10.5)
+				(end -7.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 8.5)
+				(end -7.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 7.5)
+				(end -7.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 6.5)
+				(end -7.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 4.5)
+				(end -7.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 0.5)
+				(end -7.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 -0.5)
+				(end -7.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 -3.5)
+				(end -7.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 -5.5)
+				(end -7.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 -6.5)
+				(end -7.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 -7.5)
+				(end -7.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -8.5 -9.5)
+				(end -7.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 10.5)
+				(end -6.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 8.5)
+				(end -6.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 7.5)
+				(end -6.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 6.5)
+				(end -6.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 4.5)
+				(end -6.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 2.5)
+				(end -6.5 1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 -0.5)
+				(end -6.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 -3.5)
+				(end -6.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 -5.5)
+				(end -6.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 -6.5)
+				(end -6.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 -7.5)
+				(end -6.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -7.5 -9.5)
+				(end -6.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 10.5)
+				(end -5.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 8.5)
+				(end -5.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 7.5)
+				(end -5.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 6.5)
+				(end -5.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 4.5)
+				(end -5.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 2.5)
+				(end -5.5 1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 1.5)
+				(end -5.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 0.5)
+				(end -5.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 -1.5)
+				(end -5.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 -3.5)
+				(end -5.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 -5.5)
+				(end -5.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 -6.5)
+				(end -5.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 -7.5)
+				(end -5.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -6.5 -9.5)
+				(end -5.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -5.5 10.5)
+				(end -4.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -5.5 4.5)
+				(end -4.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -5.5 -0.5)
+				(end -4.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -5.5 -3.5)
+				(end -4.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -5.5 -9.5)
+				(end -4.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 10.5)
+				(end -3.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 9.5)
+				(end -3.5 8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 8.5)
+				(end -3.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 7.5)
+				(end -3.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 6.5)
+				(end -3.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 5.5)
+				(end -3.5 4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 4.5)
+				(end -3.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 2.5)
+				(end -3.5 1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 0.5)
+				(end -3.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 -1.5)
+				(end -3.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 -3.5)
+				(end -3.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 -4.5)
+				(end -3.5 -5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 -5.5)
+				(end -3.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 -6.5)
+				(end -3.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 -7.5)
+				(end -3.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 -8.5)
+				(end -3.5 -9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -4.5 -9.5)
+				(end -3.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -3.5 1.5)
+				(end -2.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -3.5 -1.5)
+				(end -2.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 10.5)
+				(end -1.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 4.5)
+				(end -1.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 3.5)
+				(end -1.5 2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 1.5)
+				(end -1.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 0.5)
+				(end -1.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 -0.5)
+				(end -1.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 -2.5)
+				(end -1.5 -3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 -5.5)
+				(end -1.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 -6.5)
+				(end -1.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 -8.5)
+				(end -1.5 -9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -2.5 -9.5)
+				(end -1.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -1.5 6.5)
+				(end -0.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -1.5 5.5)
+				(end -0.5 4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -1.5 1.5)
+				(end -0.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -1.5 0.5)
+				(end -0.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -1.5 -0.5)
+				(end -0.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -1.5 -1.5)
+				(end -0.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -1.5 -4.5)
+				(end -0.5 -5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -1.5 -5.5)
+				(end -0.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -1.5 -7.5)
+				(end -0.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 9.5)
+				(end 0.5 8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 7.5)
+				(end 0.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 5.5)
+				(end 0.5 4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 4.5)
+				(end 0.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 2.5)
+				(end 0.5 1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 1.5)
+				(end 0.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 -2.5)
+				(end 0.5 -3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 -3.5)
+				(end 0.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 -5.5)
+				(end 0.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 -6.5)
+				(end 0.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start -0.5 -8.5)
+				(end 0.5 -9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 0.5 8.5)
+				(end 1.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 0.5 6.5)
+				(end 1.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 0.5 2.5)
+				(end 1.5 1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 0.5 1.5)
+				(end 1.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 0.5 0.5)
+				(end 1.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 0.5 -1.5)
+				(end 1.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 0.5 -3.5)
+				(end 1.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 0.5 -7.5)
+				(end 1.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 0.5 -8.5)
+				(end 1.5 -9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 10.5)
+				(end 2.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 9.5)
+				(end 2.5 8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 8.5)
+				(end 2.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 7.5)
+				(end 2.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 6.5)
+				(end 2.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 4.5)
+				(end 2.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 1.5)
+				(end 2.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 0.5)
+				(end 2.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 -0.5)
+				(end 2.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 -1.5)
+				(end 2.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 -2.5)
+				(end 2.5 -3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 -6.5)
+				(end 2.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 -7.5)
+				(end 2.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 -8.5)
+				(end 2.5 -9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 1.5 -9.5)
+				(end 2.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 2.5 1.5)
+				(end 3.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 2.5 -0.5)
+				(end 3.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 2.5 -1.5)
+				(end 3.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 2.5 -2.5)
+				(end 3.5 -3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 2.5 -5.5)
+				(end 3.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 2.5 -6.5)
+				(end 3.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 2.5 -7.5)
+				(end 3.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 2.5 -9.5)
+				(end 3.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 10.5)
+				(end 4.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 9.5)
+				(end 4.5 8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 8.5)
+				(end 4.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 7.5)
+				(end 4.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 6.5)
+				(end 4.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 5.5)
+				(end 4.5 4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 4.5)
+				(end 4.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 2.5)
+				(end 4.5 1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 -0.5)
+				(end 4.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 -1.5)
+				(end 4.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 -2.5)
+				(end 4.5 -3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 -4.5)
+				(end 4.5 -5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 -5.5)
+				(end 4.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 3.5 -6.5)
+				(end 4.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 10.5)
+				(end 5.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 4.5)
+				(end 5.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 1.5)
+				(end 5.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 0.5)
+				(end 5.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 -0.5)
+				(end 5.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 -1.5)
+				(end 5.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 -6.5)
+				(end 5.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 -7.5)
+				(end 5.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 -8.5)
+				(end 5.5 -9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 4.5 -9.5)
+				(end 5.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 10.5)
+				(end 6.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 8.5)
+				(end 6.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 7.5)
+				(end 6.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 6.5)
+				(end 6.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 4.5)
+				(end 6.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 1.5)
+				(end 6.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 -0.5)
+				(end 6.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 -1.5)
+				(end 6.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 -5.5)
+				(end 6.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 -6.5)
+				(end 6.5 -7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 -7.5)
+				(end 6.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 5.5 -9.5)
+				(end 6.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 10.5)
+				(end 7.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 8.5)
+				(end 7.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 7.5)
+				(end 7.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 6.5)
+				(end 7.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 4.5)
+				(end 7.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 0.5)
+				(end 7.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 -1.5)
+				(end 7.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 -5.5)
+				(end 7.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 -7.5)
+				(end 7.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 6.5 -8.5)
+				(end 7.5 -9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 10.5)
+				(end 8.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 8.5)
+				(end 8.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 7.5)
+				(end 8.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 6.5)
+				(end 8.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 4.5)
+				(end 8.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 1.5)
+				(end 8.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 -1.5)
+				(end 8.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 -2.5)
+				(end 8.5 -3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 -3.5)
+				(end 8.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 -4.5)
+				(end 8.5 -5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 -5.5)
+				(end 8.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 7.5 -9.5)
+				(end 8.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 8.5 10.5)
+				(end 9.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 8.5 4.5)
+				(end 9.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 8.5 1.5)
+				(end 9.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 8.5 -0.5)
+				(end 9.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 8.5 -2.5)
+				(end 9.5 -3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 8.5 -4.5)
+				(end 9.5 -5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 8.5 -7.5)
+				(end 9.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 8.5 -8.5)
+				(end 9.5 -9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 8.5 -9.5)
+				(end 9.5 -10.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 10.5)
+				(end 10.5 9.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 9.5)
+				(end 10.5 8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 8.5)
+				(end 10.5 7.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 7.5)
+				(end 10.5 6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 6.5)
+				(end 10.5 5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 5.5)
+				(end 10.5 4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 4.5)
+				(end 10.5 3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 2.5)
+				(end 10.5 1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 1.5)
+				(end 10.5 0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 0.5)
+				(end 10.5 -0.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 -0.5)
+				(end 10.5 -1.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 -1.5)
+				(end 10.5 -2.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 -2.5)
+				(end 10.5 -3.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 -3.5)
+				(end 10.5 -4.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 -4.5)
+				(end 10.5 -5.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 -5.5)
+				(end 10.5 -6.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
+			(rectangle
+				(start 9.5 -7.5)
+				(end 10.5 -8.5)
+				(stroke
+					(width 0)
+					(type default)
+				)
+				(fill
+					(type outline)
+				)
+			)
 		)
 		(embedded_fonts no)
 	)

--- a/lib/std/generics/symbols/VERSION.kicad_sym
+++ b/lib/std/generics/symbols/VERSION.kicad_sym
@@ -1,22 +1,28 @@
 (kicad_symbol_lib
-	(version 20241209)
+	(version 20251024)
 	(generator "kicad_symbol_editor")
-	(generator_version "9.0")
+	(generator_version "10.0")
 	(symbol "Version"
 		(exclude_from_sim no)
 		(in_bom yes)
 		(on_board yes)
+		(in_pos_files yes)
+		(duplicate_pin_numbers_are_jumpers no)
 		(property "Reference" "Version"
 			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(hide yes)
 			)
 		)
 		(property "Value" ""
 			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
 			(effects
 				(font
 					(size 1.27 1.27)
@@ -25,29 +31,35 @@
 		)
 		(property "Footprint" ""
 			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(hide yes)
 			)
 		)
 		(property "Datasheet" ""
 			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(hide yes)
 			)
 		)
 		(property "Description" ""
 			(at 0 0 0)
+			(show_name no)
+			(do_not_autoplace no)
+			(hide yes)
 			(effects
 				(font
 					(size 1.27 1.27)
 				)
-				(hide yes)
 			)
 		)
 		(symbol "Version_0_1"


### PR DESCRIPTION
## Summary
- Upgrade the remaining six standard-library and example symbol libraries using KiCad 10 native conversion.
- Add a recursive integration test requiring format 20251024 and successful loading through the importer for every shipped symbol library.
- Preserve legacy test fixtures for compatibility coverage and document the migration in the changelog.

Fixes https://linear.app/diodeinc/issue/ENG-1357/stdlib-versionqr-symbols-are-kicad-9-pcb-apply-schematic-rejects-them

## Verification
- `cargo nextest run -p pcb-eda`: 72 tests passed after rebasing onto origin/main.
- `cargo fmt --all -- --check` and diff whitespace checks passed.
- All 157 shipped libraries exported successfully with KiCad 10.
- Before/after SVG output for all six converted libraries is identical excluding timestamp metadata.
- Temporarily adding a legacy symbol in a nested example directory caused the new guard to fail with the offending path and upgrade command; removing it restored the passing result.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Asset and format migration with a repo-wide guard test; schematic pin connectivity should be unchanged, though symbol graphics may differ slightly after KiCad’s upgrade (e.g. pin placement on `L6387ED`).
> 
> **Overview**
> **Upgrades remaining bundled KiCad symbol libraries under `lib/` and `examples/` to KiCad 10** (`version 20251024`, `generator_version 10.0`), including stdlib generics like `QR` and `VERSION` and example parts (e.g. PhaseDriver, L6387E). Files are rewritten in the KiCad 10 symbol schema (property `show_name` / `do_not_autoplace` / `hide`, `in_pos_files`, nested unit symbols, `Description` instead of legacy `ki_description` where applicable).
> 
> **Adds `test_shipped_symbols_use_kicad10_format`** in `pcb-eda`, which recursively scans only `lib` and `examples`, requires `version 20251024`, and checks each library loads via `SymbolLibrary::from_string`—legacy fixtures under `tests/resources` stay on older formats for compatibility tests.
> 
> **Documents the change** in the Unreleased changelog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e45c0b4856e2a7cea50ab094a4227e946b2bffa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->