### PR TITLE
Create a starter spec.md for new boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Upgrade all remaining bundled standard-library and example symbols to KiCad 10 format.
+- Create a starter `spec.md` when scaffolding a new board repository.
 
 ## [0.4.51] - 2026-09-05
 

--- a/crates/pcbc/src/new.rs
+++ b/crates/pcbc/src/new.rs
@@ -13,6 +13,7 @@ const GITIGNORE_TEMPLATE: &str = include_str!("templates/gitignore");
 const BOARD_PCB_TOML: &str = include_str!("templates/board_pcb_toml.jinja");
 const BOARD_ZEN: &str = include_str!("templates/board_zen.jinja");
 const BOARD_README: &str = include_str!("templates/board_readme.jinja");
+const BOARD_SPEC: &str = include_str!("templates/board_spec.jinja");
 const PACKAGE_ZEN: &str = include_str!("templates/package_zen.jinja");
 const PACKAGE_README: &str = include_str!("templates/package_readme.jinja");
 
@@ -21,6 +22,7 @@ fn create_template_env() -> Environment<'static> {
     env.add_template("board_pcb_toml", BOARD_PCB_TOML).unwrap();
     env.add_template("board_zen", BOARD_ZEN).unwrap();
     env.add_template("board_readme", BOARD_README).unwrap();
+    env.add_template("board_spec", BOARD_SPEC).unwrap();
     env.add_template("package_zen", PACKAGE_ZEN).unwrap();
     env.add_template("package_readme", PACKAGE_README).unwrap();
     env
@@ -346,6 +348,13 @@ pub(crate) fn init_board_repo(dir: &Path, board: &str, repository: &str) -> Resu
         .render(&ctx)
         .context("Failed to render README.md template")?;
     std::fs::write(dir.join("README.md"), readme_content).context("Failed to write README.md")?;
+
+    let spec_content = env
+        .get_template("board_spec")
+        .unwrap()
+        .render(&ctx)
+        .context("Failed to render spec.md template")?;
+    std::fs::write(dir.join("spec.md"), spec_content).context("Failed to write spec.md")?;
 
     std::fs::write(dir.join(".gitignore"), GITIGNORE_TEMPLATE)
         .context("Failed to write .gitignore")?;

--- a/crates/pcbc/src/templates/board_spec.jinja
+++ b/crates/pcbc/src/templates/board_spec.jinja
@@ -1,0 +1,19 @@
+# {{ board }} Design Specification
+
+## Purpose
+
+<!-- Describe what this board does, who or what uses it, and how it fits into the larger system. -->
+
+## Requirements
+
+<!-- Capture the important requirements and any known constraints:
+- Power: input sources, voltage ranges, and expected current or power budget.
+- Interfaces: connectors, protocols, and signals to other boards or devices.
+- Functionality: key components, features, and measurable performance targets.
+- Physical: board size, mounting, and environmental constraints.
+Include only what applies; leave undecided details as open questions.
+-->
+
+## Open Questions
+
+<!-- List decisions still to be made, options being considered, and anything blocking implementation. -->


### PR DESCRIPTION
## Summary
- Create `spec.md` in each new board repository using the existing template system.
- Keep the starter lightweight: Purpose, Requirements, and Open Questions, with short guidance comments and no status field.
- Follow the existing spec-builder agent convention of `<board-repo>/spec.md`.

## Verification
- Scaffold test was executed successfully during development, then removed at user request.
- `cargo fmt --check -p pcbc` passed.
- `git diff --check` passed.

## Rollout
Companion registry change adds a Spec tab before Schematic. Registry board creation already copies all files produced by `pcb new board`; the API image must be rebuilt after this change reaches a PCB CLI release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scaffolding-only change that adds an optional markdown file at board creation; no runtime design or auth behavior changes.
> 
> **Overview**
> **`pcb new board`** (and any flow using **`init_board_repo`**, including board import scaffolding) now writes a root **`spec.md`** alongside the existing board templates.
> 
> The file comes from a new **`board_spec.jinja`** template: a lightweight outline with **Purpose**, **Requirements**, and **Open Questions** sections plus HTML comment guidance, aligned with the **`&lt;board-repo&gt;/spec.md`** convention. The unreleased changelog notes the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9340e1e2c68ddfa7263abb459491352cd8d16cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->