### PR TITLE
fix(schematic): emit intentional no-connect markers (ENG-1411)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Emit intentional no-connect markers when creating or reconciling schematics with `pcb apply`.
+
 ### Changed
 
 - Upgrade all remaining bundled standard-library and example symbols to KiCad 10 format.

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -339,6 +339,19 @@ fn reconcile_not_connected_markers(
         targets.extend(resolve_pin_targets(placed, &path, &pin_name, &pin_numbers)?);
     }
     targets.retain(|target| !target.hidden);
+    // Unspecified pins may carry user-authored NC markers too. Preserve those
+    // while the visible endpoint survives; connected endpoints were cleared above.
+    let mut visible_points = BTreeMap::<usize, Vec<Point>>::new();
+    for placed in placed.values() {
+        let parsed = symbol::ParsedSymbolDefinition::parse(&placed.definition)?;
+        visible_points.entry(placed.page_index).or_default().extend(
+            parsed
+                .placed_pins(&placed.symbol)?
+                .into_iter()
+                .filter(|pin| !pin.hidden)
+                .map(|pin| pin.point),
+        );
+    }
     // A marker previously attached to a managed pin must not become an orphan
     // when the component/pin disappears, becomes hidden, or reconnects elsewhere.
     // Use old geometry, not UUID ownership or only the new netlist's terminals.
@@ -373,9 +386,10 @@ fn reconcile_not_connected_markers(
                     !old_points
                         .iter()
                         .any(|point| points_coincide(*point, marker.at))
-                        || targets.iter().any(|target| {
-                            target.page_index == page_index
-                                && points_coincide(target.point, marker.at)
+                        || visible_points.get(&page_index).is_some_and(|points| {
+                            points
+                                .iter()
+                                .any(|point| points_coincide(*point, marker.at))
                         })
                 }
                 _ => true,

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -11,9 +11,9 @@ use crate::{
     analysis::{ConnectivityInspection, SchematicIssue, SchematicIssueKey},
     component_slots,
     connectivity::{
-        ConnectionOrigin, ConnectivityItemRef, IslandRef, PhysicalConnectivity, PhysicalIsland,
-        PhysicalPinRef, PinVisibility, SymbolLocation, named_connected_nets,
-        reduce_with_provenance,
+        ComponentIdentity, ConnectionOrigin, ConnectivityItemRef, IslandRef, PhysicalConnectivity,
+        PhysicalIsland, PhysicalPinRef, PinVisibility, SymbolLocation, Terminal,
+        named_connected_nets, not_connected_terminals, reduce_with_provenance,
     },
     deterministic_uuid, field_autoplace, hierarchy, net_symbols,
     placement::{GridPacker, GridPoint, GridRect, point_rect},
@@ -304,9 +304,61 @@ pub(crate) fn reconcile_document(
     // Library cleanup is a whole-document concern; a scoped repair must not
     // touch pages outside its selection.
     if complete {
+        reconcile_not_connected_markers(&mut document, netlist, &placed)?;
         prune_unused_symbol_definitions(&mut document);
     }
     Ok(document)
+}
+
+fn reconcile_not_connected_markers(
+    document: &mut SchDocument,
+    netlist: &Schematic,
+    placed: &BTreeMap<SymbolSlotKey, PlacedSymbol>,
+) -> Result<()> {
+    let connected_nets = named_connected_nets(netlist)
+        .map(|net| net.name.clone())
+        .collect();
+    for targets in connectivity_targets(netlist, placed, &connected_nets)?.values() {
+        for target in targets {
+            document.pages[target.page_index].items.retain(|item| {
+                !matches!(item, SchItem::NoConnect(marker) if points_coincide(marker.at, target.point))
+            });
+        }
+    }
+    for terminal in not_connected_terminals(netlist) {
+        let Terminal::ComponentPin {
+            component: ComponentIdentity::ManagedPath(path),
+            pin_name,
+            pin_numbers,
+        } = terminal
+        else {
+            continue;
+        };
+        for target in resolve_pin_targets(placed, &path, &pin_name, &pin_numbers)? {
+            if target.hidden {
+                continue;
+            }
+            // A marker belongs to an endpoint, not a pin identity. Preserve
+            // user markers and use one marker for stacked physical pins.
+            if document.pages[target.page_index].items.iter().any(|item| {
+                matches!(item, SchItem::NoConnect(marker) if points_coincide(marker.at, target.point))
+            }) {
+                continue;
+            }
+            let id = available_deterministic_id(
+                document,
+                &format!("zener:no-connect:{}:{}", target.symbol_id, target.number),
+            );
+            document.pages[target.page_index]
+                .items
+                .push(SchItem::NoConnect(crate::NoConnect {
+                    id,
+                    at: target.point,
+                    unsupported: Vec::new(),
+                }));
+        }
+    }
+    Ok(())
 }
 
 fn is_connectivity_issue(issue: &SchematicIssue) -> bool {

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -83,10 +83,6 @@ pub(crate) fn reconcile_document(
     let expected_slots = component_slots::component_symbol_slots(netlist)?
         .into_iter()
         .collect::<BTreeSet<_>>();
-    // Invalid cached definitions are repaired later; they cannot provide
-    // trustworthy pre-projection endpoint geometry.
-    let existing_placed =
-        existing.and_then(|document| placed_symbols_from_document(document, &expected_slots).ok());
     let RepairTargets {
         missing_sheets,
         project_slots,
@@ -308,7 +304,7 @@ pub(crate) fn reconcile_document(
     // Library cleanup is a whole-document concern; a scoped repair must not
     // touch pages outside its selection.
     if complete {
-        reconcile_not_connected_markers(&mut document, netlist, existing_placed.as_ref(), &placed)?;
+        reconcile_not_connected_markers(&mut document, netlist, existing, &placed)?;
         prune_unused_symbol_definitions(&mut document);
     }
     Ok(document)
@@ -317,7 +313,7 @@ pub(crate) fn reconcile_document(
 fn reconcile_not_connected_markers(
     document: &mut SchDocument,
     netlist: &Schematic,
-    existing_placed: Option<&BTreeMap<SymbolSlotKey, PlacedSymbol>>,
+    existing: Option<&SchDocument>,
     placed: &BTreeMap<SymbolSlotKey, PlacedSymbol>,
 ) -> Result<()> {
     let connected_nets = named_connected_nets(netlist)
@@ -331,7 +327,6 @@ fn reconcile_not_connected_markers(
         }
     }
     let mut targets = Vec::new();
-    let mut old_targets = Vec::new();
     for terminal in not_connected_terminals(netlist) {
         let Terminal::ComponentPin {
             component: ComponentIdentity::ManagedPath(path),
@@ -342,32 +337,53 @@ fn reconcile_not_connected_markers(
             continue;
         };
         targets.extend(resolve_pin_targets(placed, &path, &pin_name, &pin_numbers)?);
-        if let Some(existing_placed) = existing_placed {
-            // New or renamed source pins need not exist in the old definition.
-            old_targets.extend(
-                resolve_pin_targets(existing_placed, &path, &pin_name, &pin_numbers)
-                    .unwrap_or_default(),
-            );
-        }
     }
-    for old_target in old_targets {
-        if targets.iter().any(|target| {
-            target.page_index == old_target.page_index
-                && points_coincide(target.point, old_target.point)
-        }) {
-            continue;
+    targets.retain(|target| !target.hidden);
+    // A marker previously attached to a managed pin must not become an orphan
+    // when the component/pin disappears, becomes hidden, or reconnects elsewhere.
+    // Use old geometry, not UUID ownership or only the new netlist's terminals.
+    for old_page in existing.into_iter().flat_map(|document| &document.pages) {
+        let old_points = old_page
+            .items
+            .iter()
+            .filter_map(|item| match item {
+                SchItem::Symbol(symbol) if symbol.field_value("Path").is_some() => {
+                    // Missing/invalid old definitions are repaired by projection;
+                    // skip only that symbol's unavailable historical geometry.
+                    old_page
+                        .library
+                        .definitions
+                        .get(&symbol.lib_id)?
+                        .placed_pins(symbol)
+                        .ok()
+                }
+                _ => None,
+            })
+            .flatten()
+            .map(|pin| pin.point)
+            .collect::<Vec<_>>();
+        for (page_index, page) in document
+            .pages
+            .iter_mut()
+            .enumerate()
+            .filter(|(_, page)| page.id == old_page.id)
+        {
+            page.items.retain(|item| match item {
+                SchItem::NoConnect(marker) => {
+                    !old_points
+                        .iter()
+                        .any(|point| points_coincide(*point, marker.at))
+                        || targets.iter().any(|target| {
+                            target.page_index == page_index
+                                && points_coincide(target.point, marker.at)
+                        })
+                }
+                _ => true,
+            });
         }
-        // Use pre-projection geometry, not deterministic UUID ownership.
-        // Preserve an endpoint still used by any NC pin, including swapped pins.
-        document.pages[old_target.page_index].items.retain(|item| {
-            !matches!(item, SchItem::NoConnect(marker) if points_coincide(marker.at, old_target.point))
-        });
     }
     let observed = reduce_with_provenance(document, PinVisibility::VisibleOnly)?;
     for target in targets {
-        if target.hidden {
-            continue;
-        }
         let pin = target.physical_pin(&document.pages[target.page_index].id);
         // Check each physical endpoint separately: a logical terminal may
         // represent multiple pads, only some of which carry existing wiring.

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -83,6 +83,10 @@ pub(crate) fn reconcile_document(
     let expected_slots = component_slots::component_symbol_slots(netlist)?
         .into_iter()
         .collect::<BTreeSet<_>>();
+    // Invalid cached definitions are repaired later; they cannot provide
+    // trustworthy pre-projection endpoint geometry.
+    let existing_placed =
+        existing.and_then(|document| placed_symbols_from_document(document, &expected_slots).ok());
     let RepairTargets {
         missing_sheets,
         project_slots,
@@ -304,7 +308,7 @@ pub(crate) fn reconcile_document(
     // Library cleanup is a whole-document concern; a scoped repair must not
     // touch pages outside its selection.
     if complete {
-        reconcile_not_connected_markers(&mut document, netlist, &placed)?;
+        reconcile_not_connected_markers(&mut document, netlist, existing_placed.as_ref(), &placed)?;
         prune_unused_symbol_definitions(&mut document);
     }
     Ok(document)
@@ -313,6 +317,7 @@ pub(crate) fn reconcile_document(
 fn reconcile_not_connected_markers(
     document: &mut SchDocument,
     netlist: &Schematic,
+    existing_placed: Option<&BTreeMap<SymbolSlotKey, PlacedSymbol>>,
     placed: &BTreeMap<SymbolSlotKey, PlacedSymbol>,
 ) -> Result<()> {
     let connected_nets = named_connected_nets(netlist)
@@ -325,6 +330,8 @@ fn reconcile_not_connected_markers(
             });
         }
     }
+    let mut targets = Vec::new();
+    let mut old_targets = Vec::new();
     for terminal in not_connected_terminals(netlist) {
         let Terminal::ComponentPin {
             component: ComponentIdentity::ManagedPath(path),
@@ -334,29 +341,67 @@ fn reconcile_not_connected_markers(
         else {
             continue;
         };
-        for target in resolve_pin_targets(placed, &path, &pin_name, &pin_numbers)? {
-            if target.hidden {
-                continue;
-            }
-            // A marker belongs to an endpoint, not a pin identity. Preserve
-            // user markers and use one marker for stacked physical pins.
-            if document.pages[target.page_index].items.iter().any(|item| {
+        targets.extend(resolve_pin_targets(placed, &path, &pin_name, &pin_numbers)?);
+        if let Some(existing_placed) = existing_placed {
+            // New or renamed source pins need not exist in the old definition.
+            old_targets.extend(
+                resolve_pin_targets(existing_placed, &path, &pin_name, &pin_numbers)
+                    .unwrap_or_default(),
+            );
+        }
+    }
+    for old_target in old_targets {
+        if targets.iter().any(|target| {
+            target.page_index == old_target.page_index
+                && points_coincide(target.point, old_target.point)
+        }) {
+            continue;
+        }
+        // Use pre-projection geometry, not deterministic UUID ownership.
+        // Preserve an endpoint still used by any NC pin, including swapped pins.
+        document.pages[old_target.page_index].items.retain(|item| {
+            !matches!(item, SchItem::NoConnect(marker) if points_coincide(marker.at, old_target.point))
+        });
+    }
+    let observed = reduce_with_provenance(document, PinVisibility::VisibleOnly)?;
+    for target in targets {
+        if target.hidden {
+            continue;
+        }
+        let pin = target.physical_pin(&document.pages[target.page_index].id);
+        // Check each physical endpoint separately: a logical terminal may
+        // represent multiple pads, only some of which carry existing wiring.
+        let attached = observed.islands.values().any(|island| {
+            island.pins.contains(&pin)
+                && island
+                    .items
+                    .iter()
+                    .any(|item| !matches!(item, ConnectivityItemRef::NoConnect { .. }))
+        });
+        if attached {
+            document.pages[target.page_index].items.retain(|item| {
+                !matches!(item, SchItem::NoConnect(marker) if points_coincide(marker.at, target.point))
+            });
+            continue;
+        }
+        // A marker belongs to an endpoint, not a pin identity. Preserve
+        // user markers and use one marker for stacked physical pins.
+        if document.pages[target.page_index].items.iter().any(|item| {
                 matches!(item, SchItem::NoConnect(marker) if points_coincide(marker.at, target.point))
             }) {
                 continue;
             }
-            let id = available_deterministic_id(
-                document,
-                &format!("zener:no-connect:{}:{}", target.symbol_id, target.number),
-            );
-            document.pages[target.page_index]
-                .items
-                .push(SchItem::NoConnect(crate::NoConnect {
-                    id,
-                    at: target.point,
-                    unsupported: Vec::new(),
-                }));
-        }
+        let id = available_deterministic_id(
+            document,
+            &format!("zener:no-connect:{}:{}", target.symbol_id, target.number),
+        );
+        document.pages[target.page_index]
+            .items
+            .push(SchItem::NoConnect(crate::NoConnect {
+                id,
+                at: target.point,
+                unsupported: Vec::new(),
+            }));
     }
     Ok(())
 }

--- a/crates/pcbc/tests/schematic_apply_flow.rs
+++ b/crates/pcbc/tests/schematic_apply_flow.rs
@@ -235,6 +235,29 @@ fn hide_symbol_pin(node: &mut Sexpr, number: &str) -> bool {
         .is_some_and(|items| items.iter_mut().any(|child| hide_symbol_pin(child, number)))
 }
 
+fn move_symbol_pin(node: &mut Sexpr, number: &str, x: f64) -> bool {
+    let Some(items) = node.as_list_mut() else {
+        return false;
+    };
+    let is_target = items.first().and_then(Sexpr::as_sym) == Some("pin")
+        && items.iter().filter_map(Sexpr::as_list).any(|child| {
+            child.first().and_then(Sexpr::as_sym) == Some("number")
+                && child.get(1).and_then(Sexpr::as_atom) == Some(number)
+        });
+    if is_target {
+        let at = items
+            .iter_mut()
+            .filter_map(Sexpr::as_list_mut)
+            .find(|child| child.first().and_then(Sexpr::as_sym) == Some("at"))
+            .expect("pin position");
+        at[1] = Sexpr::float(x);
+        return true;
+    }
+    items
+        .iter_mut()
+        .any(|child| move_symbol_pin(child, number, x))
+}
+
 #[test]
 fn creates_a_verified_project_and_then_makes_no_changes() {
     let workspace = tempfile::tempdir().unwrap();
@@ -750,6 +773,131 @@ fn restores_nc_markers_at_transformed_pin_endpoints() {
         );
     }
     assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+}
+
+#[test]
+fn moves_nc_marker_when_source_pin_geometry_changes() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project_dir = workspace.path().join("hardware");
+    let mut netlist = linked_fixture(&project_dir);
+    let mut not_connected = netlist.nets.remove("RIGHT").unwrap();
+    not_connected.kind = "NotConnected".to_string();
+    not_connected.name.clear();
+    netlist.nets.insert(String::new(), not_connected);
+    apply_linked_schematic(&netlist).unwrap().unwrap();
+
+    let mut project = KicadProject::load(&project_dir).unwrap();
+    let old_marker = project.document.pages[0]
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SchItem::NoConnect(marker) => Some(marker.at),
+            _ => None,
+        })
+        .unwrap();
+    let user_marker = Point::new(old_marker.x + 25.4, old_marker.y + 25.4);
+    project.document.pages[0]
+        .items
+        .push(SchItem::NoConnect(pcb_kicad_sch::NoConnect {
+            id: "00000000-0000-4000-8000-000000000142".to_string(),
+            at: user_marker,
+            unsupported: Vec::new(),
+        }));
+    fs::write(
+        &project.root_schematics[0],
+        project.document.to_kicad_sch().unwrap(),
+    )
+    .unwrap();
+
+    for component in netlist
+        .instances
+        .values_mut()
+        .filter(|instance| instance.kind == pcb_sch::InstanceKind::Component)
+    {
+        let Some(AttributeValue::String(source)) = component.attributes.get_mut("__symbol_value")
+        else {
+            continue;
+        };
+        let mut symbol = pcb_sexpr::parse(source).unwrap();
+        if move_symbol_pin(&mut symbol, "2", 7.62) {
+            *source = symbol.to_string();
+        }
+    }
+
+    assert!(apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    let repaired = KicadProject::load(&project_dir).unwrap();
+    let markers = repaired.document.pages[0]
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            SchItem::NoConnect(marker) => Some(marker.at),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(markers.len(), 2, "stale NC marker must be removed");
+    assert!(!markers.contains(&old_marker));
+    assert!(
+        markers.contains(&user_marker),
+        "unrelated user marker must remain"
+    );
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+}
+
+#[test]
+fn apply_does_not_mark_a_wire_attached_to_an_nc_pin() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project_dir = workspace.path().join("hardware");
+    let mut netlist = linked_fixture(&project_dir);
+    let mut not_connected = netlist.nets.remove("RIGHT").unwrap();
+    not_connected.kind = "NotConnected".to_string();
+    not_connected.name.clear();
+    netlist.nets.insert(String::new(), not_connected);
+    apply_linked_schematic(&netlist).unwrap().unwrap();
+
+    let mut project = KicadProject::load(&project_dir).unwrap();
+    let endpoint = project.document.pages[0]
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SchItem::NoConnect(marker) => Some(marker.at),
+            _ => None,
+        })
+        .unwrap();
+    project.document.pages[0]
+        .items
+        .retain(|item| !matches!(item, SchItem::NoConnect(_)));
+    project.document.pages[0].items.push(SchItem::Wire(Wire {
+        id: "wire-on-nc-pin".to_string(),
+        a: endpoint,
+        b: Point::new(endpoint.x + 2.54, endpoint.y),
+        unsupported: Vec::new(),
+    }));
+    fs::write(
+        &project.root_schematics[0],
+        project.document.to_kicad_sch().unwrap(),
+    )
+    .unwrap();
+
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    let repaired = KicadProject::load(&project_dir).unwrap();
+    assert!(
+        repaired.document.pages[0]
+            .items
+            .iter()
+            .any(|item| matches!(item, SchItem::Wire(wire) if wire.id == "wire-on-nc-pin"))
+    );
+    assert!(
+        !repaired.document.pages[0]
+            .items
+            .iter()
+            .any(|item| matches!(item, SchItem::NoConnect(_)))
+    );
+    assert!(
+        inspect_schematic(&repaired.document, &netlist)
+            .unwrap()
+            .analysis
+            .is_equivalent()
+    );
 }
 
 #[test]

--- a/crates/pcbc/tests/schematic_apply_flow.rs
+++ b/crates/pcbc/tests/schematic_apply_flow.rs
@@ -634,12 +634,122 @@ fn accepts_an_isolated_not_connected_pin() {
         .unwrap()
         .analysis;
     assert!(analysis.is_equivalent(), "{:?}", analysis.issues());
+    let markers = project.document.pages[0]
+        .items
+        .iter()
+        .filter(|item| matches!(item, SchItem::NoConnect(_)))
+        .count();
+    assert_eq!(markers, 1, "intentional NC must have a persisted marker");
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+
+    let mut damaged = project.document.clone();
+    damaged.pages[0]
+        .items
+        .retain(|item| !matches!(item, SchItem::NoConnect(_)));
+    fs::write(&project.root_schematics[0], damaged.to_kicad_sch().unwrap()).unwrap();
+    assert!(apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    let repaired = KicadProject::load(&project.project_file).unwrap();
+    assert_eq!(repaired.document, project.document);
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    let mut user_document = repaired.document;
+    let marker = user_document.pages[0]
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SchItem::NoConnect(marker) => Some(marker),
+            _ => None,
+        })
+        .unwrap();
+    marker.id = "00000000-0000-4000-8000-000000000141".to_string();
+    fs::write(
+        &project.root_schematics[0],
+        user_document.to_kicad_sch().unwrap(),
+    )
+    .unwrap();
+    assert!(
+        !apply_linked_schematic(&netlist).unwrap().unwrap().changed,
+        "preserve a user marker at the expected endpoint"
+    );
     assert!(
         !project.document.pages[0]
             .items
             .iter()
             .any(|item| matches!(item, SchItem::Label(label) if label.text == "RIGHT"))
     );
+
+    // Changing the source back to a connected pin must not leave an NC cross
+    // on the newly connected endpoint.
+    let connected = linked_fixture(&project.directory);
+    assert!(apply_linked_schematic(&connected).unwrap().unwrap().changed);
+    let reconnected = KicadProject::load(&project.project_file).unwrap();
+    assert!(
+        !reconnected.document.pages[0]
+            .items
+            .iter()
+            .any(|item| matches!(item, SchItem::NoConnect(_)))
+    );
+}
+
+#[test]
+fn restores_nc_markers_at_transformed_pin_endpoints() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project_dir = workspace.path().join("hardware");
+    let mut netlist = linked_fixture(&project_dir);
+    for net in netlist.nets.values_mut() {
+        net.kind = "NotConnected".to_string();
+        net.name.clear();
+    }
+    apply_linked_schematic(&netlist).unwrap().unwrap();
+    let mut project = KicadProject::load(&project_dir).unwrap();
+    let page = &mut project.document.pages[0];
+    assert_eq!(
+        page.items
+            .iter()
+            .filter(|item| matches!(item, SchItem::NoConnect(_)))
+            .count(),
+        4
+    );
+    page.items
+        .retain(|item| !matches!(item, SchItem::NoConnect(_)));
+    let mut expected = Vec::new();
+    for item in &mut page.items {
+        if let SchItem::Symbol(symbol) = item {
+            symbol.rotation = pcb_kicad_sch::Rotation::Deg90;
+            symbol.mirror = Some(pcb_kicad_sch::MirrorAxis::X);
+            symbol.at.x += 12.7;
+            expected.extend(
+                page.library.definitions[&symbol.lib_id]
+                    .placed_pins(symbol)
+                    .unwrap()
+                    .into_iter()
+                    .map(|pin| pin.point),
+            );
+        }
+    }
+    assert_eq!(expected.len(), 4);
+    fs::write(
+        &project.root_schematics[0],
+        project.document.to_kicad_sch().unwrap(),
+    )
+    .unwrap();
+    assert!(apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    let repaired = KicadProject::load(&project_dir).unwrap();
+    let actual = repaired.document.pages[0]
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            SchItem::NoConnect(marker) => Some(marker.at),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(actual.len(), expected.len());
+    for point in expected {
+        assert!(
+            actual.contains(&point),
+            "missing marker at transformed endpoint {point:?}"
+        );
+    }
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
 }
 
 #[test]

--- a/crates/pcbc/tests/schematic_apply_flow.rs
+++ b/crates/pcbc/tests/schematic_apply_flow.rs
@@ -777,6 +777,25 @@ fn restores_nc_markers_at_transformed_pin_endpoints() {
 
 #[test]
 fn moves_nc_marker_when_source_pin_geometry_changes() {
+    check_stale_nc_marker("move");
+}
+
+#[test]
+fn removes_nc_marker_when_source_component_is_deleted() {
+    check_stale_nc_marker("delete");
+}
+
+#[test]
+fn removes_nc_marker_when_source_pin_becomes_hidden() {
+    check_stale_nc_marker("hide");
+}
+
+#[test]
+fn removes_nc_marker_when_source_pin_moves_and_reconnects() {
+    check_stale_nc_marker("reconnect");
+}
+
+fn check_stale_nc_marker(change: &str) {
     let workspace = tempfile::tempdir().unwrap();
     let project_dir = workspace.path().join("hardware");
     let mut netlist = linked_fixture(&project_dir);
@@ -809,17 +828,34 @@ fn moves_nc_marker_when_source_pin_geometry_changes() {
     )
     .unwrap();
 
+    if change == "reconnect" {
+        netlist = linked_fixture(&project_dir);
+    }
+    if change == "delete" {
+        netlist
+            .instances
+            .retain(|reference, _| !reference.instance_path.iter().any(|part| part == "R2"));
+        for net in netlist.nets.values_mut() {
+            net.ports
+                .retain(|reference| !reference.instance_path.iter().any(|part| part == "R2"));
+        }
+    }
     for component in netlist
         .instances
         .values_mut()
-        .filter(|instance| instance.kind == pcb_sch::InstanceKind::Component)
+        .filter(|instance| change != "delete" && instance.kind == pcb_sch::InstanceKind::Component)
     {
         let Some(AttributeValue::String(source)) = component.attributes.get_mut("__symbol_value")
         else {
             continue;
         };
         let mut symbol = pcb_sexpr::parse(source).unwrap();
-        if move_symbol_pin(&mut symbol, "2", 7.62) {
+        let changed = if change == "hide" {
+            hide_symbol_pin(&mut symbol, "2")
+        } else {
+            move_symbol_pin(&mut symbol, "2", 7.62)
+        };
+        if changed {
             *source = symbol.to_string();
         }
     }
@@ -834,7 +870,11 @@ fn moves_nc_marker_when_source_pin_geometry_changes() {
             _ => None,
         })
         .collect::<Vec<_>>();
-    assert_eq!(markers.len(), 2, "stale NC marker must be removed");
+    assert_eq!(
+        markers.len(),
+        if change == "move" { 2 } else { 1 },
+        "stale NC marker must be removed ({change})"
+    );
     assert!(!markers.contains(&old_marker));
     assert!(
         markers.contains(&user_marker),

--- a/crates/pcbc/tests/schematic_apply_flow.rs
+++ b/crates/pcbc/tests/schematic_apply_flow.rs
@@ -640,16 +640,20 @@ fn preserves_user_symbol_and_equivalent_label_geometry() {
     assert_eq!(label.spin, expected_spin);
 }
 
-#[test]
-fn accepts_an_isolated_not_connected_pin() {
-    let workspace = tempfile::tempdir().unwrap();
-    let project_dir = workspace.path().join("hardware");
-    let mut netlist = linked_fixture(&project_dir);
+fn linked_nc_fixture(project_dir: &std::path::Path) -> pcb_sch::Schematic {
+    let mut netlist = linked_fixture(project_dir);
     let mut not_connected = netlist.nets.remove("RIGHT").unwrap();
     not_connected.kind = "NotConnected".to_string();
     not_connected.name.clear();
     netlist.nets.insert(String::new(), not_connected);
+    netlist
+}
 
+#[test]
+fn reconciles_nc_markers_and_preserves_user_markers() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project_dir = workspace.path().join("hardware");
+    let mut netlist = linked_nc_fixture(&project_dir);
     apply_linked_schematic(&netlist).unwrap().unwrap();
 
     let project = KicadProject::load(project_dir).unwrap();
@@ -699,6 +703,28 @@ fn accepts_an_isolated_not_connected_pin() {
             .iter()
             .any(|item| matches!(item, SchItem::Label(label) if label.text == "RIGHT"))
     );
+
+    // The source may leave this pin unspecified rather than explicitly NC.
+    netlist.nets.remove("");
+    for instance in netlist.instances.values_mut() {
+        instance.attributes.remove("__signature");
+    }
+    assert!(
+        inspect_schematic(&user_document, &netlist)
+            .unwrap()
+            .analysis
+            .is_equivalent()
+    );
+    for _ in 0..2 {
+        assert!(
+            !apply_linked_schematic(&netlist).unwrap().unwrap().changed,
+            "an unchanged unspecified pin must retain its user marker"
+        );
+        assert_eq!(
+            KicadProject::load(&project.project_file).unwrap().document,
+            user_document
+        );
+    }
 
     // Changing the source back to a connected pin must not leave an NC cross
     // on the newly connected endpoint.
@@ -777,75 +803,36 @@ fn restores_nc_markers_at_transformed_pin_endpoints() {
 
 #[test]
 fn moves_nc_marker_when_source_pin_geometry_changes() {
-    check_stale_nc_marker("move");
-}
-
-#[test]
-fn preserves_user_nc_marker_on_unspecified_pin() {
-    let workspace = tempfile::tempdir().unwrap();
-    let project_dir = workspace.path().join("hardware");
-    let mut netlist = linked_fixture(&project_dir);
-    let mut not_connected = netlist.nets.remove("RIGHT").unwrap();
-    not_connected.kind = "NotConnected".to_string();
-    not_connected.name.clear();
-    netlist.nets.insert(String::new(), not_connected);
-    apply_linked_schematic(&netlist).unwrap().unwrap();
-
-    let mut project = KicadProject::load(&project_dir).unwrap();
-    for item in &mut project.document.pages[0].items {
-        if let SchItem::NoConnect(marker) = item {
-            marker.id = "00000000-0000-4000-8000-000000000143".to_string();
-        }
-    }
-    fs::write(
-        &project.root_schematics[0],
-        project.document.to_kicad_sch().unwrap(),
-    )
-    .unwrap();
-    netlist.nets.remove("");
-    for instance in netlist.instances.values_mut() {
-        instance.attributes.remove("__signature");
-    }
-    assert!(
-        inspect_schematic(&project.document, &netlist)
-            .unwrap()
-            .analysis
-            .is_equivalent()
-    );
-    assert!(
-        !apply_linked_schematic(&netlist).unwrap().unwrap().changed,
-        "an unchanged unspecified pin must retain its user marker"
-    );
-    assert_eq!(
-        KicadProject::load(&project_dir).unwrap().document,
-        project.document
-    );
-    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    check_stale_nc_marker(NcChange::Move);
 }
 
 #[test]
 fn removes_nc_marker_when_source_component_is_deleted() {
-    check_stale_nc_marker("delete");
+    check_stale_nc_marker(NcChange::Delete);
 }
 
 #[test]
 fn removes_nc_marker_when_source_pin_becomes_hidden() {
-    check_stale_nc_marker("hide");
+    check_stale_nc_marker(NcChange::Hide);
 }
 
 #[test]
 fn removes_nc_marker_when_source_pin_moves_and_reconnects() {
-    check_stale_nc_marker("reconnect");
+    check_stale_nc_marker(NcChange::Reconnect);
 }
 
-fn check_stale_nc_marker(change: &str) {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NcChange {
+    Move,
+    Delete,
+    Hide,
+    Reconnect,
+}
+
+fn check_stale_nc_marker(change: NcChange) {
     let workspace = tempfile::tempdir().unwrap();
     let project_dir = workspace.path().join("hardware");
-    let mut netlist = linked_fixture(&project_dir);
-    let mut not_connected = netlist.nets.remove("RIGHT").unwrap();
-    not_connected.kind = "NotConnected".to_string();
-    not_connected.name.clear();
-    netlist.nets.insert(String::new(), not_connected);
+    let mut netlist = linked_nc_fixture(&project_dir);
     apply_linked_schematic(&netlist).unwrap().unwrap();
 
     let mut project = KicadProject::load(&project_dir).unwrap();
@@ -871,10 +858,10 @@ fn check_stale_nc_marker(change: &str) {
     )
     .unwrap();
 
-    if change == "reconnect" {
+    if change == NcChange::Reconnect {
         netlist = linked_fixture(&project_dir);
     }
-    if change == "delete" {
+    if change == NcChange::Delete {
         netlist
             .instances
             .retain(|reference, _| !reference.instance_path.iter().any(|part| part == "R2"));
@@ -883,20 +870,18 @@ fn check_stale_nc_marker(change: &str) {
                 .retain(|reference| !reference.instance_path.iter().any(|part| part == "R2"));
         }
     }
-    for component in netlist
-        .instances
-        .values_mut()
-        .filter(|instance| change != "delete" && instance.kind == pcb_sch::InstanceKind::Component)
-    {
+    for component in netlist.instances.values_mut().filter(|instance| {
+        change != NcChange::Delete && instance.kind == pcb_sch::InstanceKind::Component
+    }) {
         let Some(AttributeValue::String(source)) = component.attributes.get_mut("__symbol_value")
         else {
             continue;
         };
         let mut symbol = pcb_sexpr::parse(source).unwrap();
-        let changed = if change == "hide" {
-            hide_symbol_pin(&mut symbol, "2")
-        } else {
-            move_symbol_pin(&mut symbol, "2", 7.62)
+        let changed = match change {
+            NcChange::Hide => hide_symbol_pin(&mut symbol, "2"),
+            NcChange::Move | NcChange::Reconnect => move_symbol_pin(&mut symbol, "2", 7.62),
+            NcChange::Delete => unreachable!(),
         };
         if changed {
             *source = symbol.to_string();
@@ -915,8 +900,8 @@ fn check_stale_nc_marker(change: &str) {
         .collect::<Vec<_>>();
     assert_eq!(
         markers.len(),
-        if change == "move" { 2 } else { 1 },
-        "stale NC marker must be removed ({change})"
+        if change == NcChange::Move { 2 } else { 1 },
+        "stale NC marker must be removed ({change:?})"
     );
     assert!(!markers.contains(&old_marker));
     assert!(
@@ -930,11 +915,7 @@ fn check_stale_nc_marker(change: &str) {
 fn apply_does_not_mark_a_wire_attached_to_an_nc_pin() {
     let workspace = tempfile::tempdir().unwrap();
     let project_dir = workspace.path().join("hardware");
-    let mut netlist = linked_fixture(&project_dir);
-    let mut not_connected = netlist.nets.remove("RIGHT").unwrap();
-    not_connected.kind = "NotConnected".to_string();
-    not_connected.name.clear();
-    netlist.nets.insert(String::new(), not_connected);
+    let netlist = linked_nc_fixture(&project_dir);
     apply_linked_schematic(&netlist).unwrap().unwrap();
 
     let mut project = KicadProject::load(&project_dir).unwrap();

--- a/crates/pcbc/tests/schematic_apply_flow.rs
+++ b/crates/pcbc/tests/schematic_apply_flow.rs
@@ -781,6 +781,49 @@ fn moves_nc_marker_when_source_pin_geometry_changes() {
 }
 
 #[test]
+fn preserves_user_nc_marker_on_unspecified_pin() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project_dir = workspace.path().join("hardware");
+    let mut netlist = linked_fixture(&project_dir);
+    let mut not_connected = netlist.nets.remove("RIGHT").unwrap();
+    not_connected.kind = "NotConnected".to_string();
+    not_connected.name.clear();
+    netlist.nets.insert(String::new(), not_connected);
+    apply_linked_schematic(&netlist).unwrap().unwrap();
+
+    let mut project = KicadProject::load(&project_dir).unwrap();
+    for item in &mut project.document.pages[0].items {
+        if let SchItem::NoConnect(marker) = item {
+            marker.id = "00000000-0000-4000-8000-000000000143".to_string();
+        }
+    }
+    fs::write(
+        &project.root_schematics[0],
+        project.document.to_kicad_sch().unwrap(),
+    )
+    .unwrap();
+    netlist.nets.remove("");
+    for instance in netlist.instances.values_mut() {
+        instance.attributes.remove("__signature");
+    }
+    assert!(
+        inspect_schematic(&project.document, &netlist)
+            .unwrap()
+            .analysis
+            .is_equivalent()
+    );
+    assert!(
+        !apply_linked_schematic(&netlist).unwrap().unwrap().changed,
+        "an unchanged unspecified pin must retain its user marker"
+    );
+    assert_eq!(
+        KicadProject::load(&project_dir).unwrap().document,
+        project.document
+    );
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+}
+
+#[test]
 fn removes_nc_marker_when_source_component_is_deleted() {
     check_stale_nc_marker("delete");
 }


### PR DESCRIPTION
## Summary
Fixes ENG-1411.

`pcb apply schematic` previously considered isolated intentional-NC pins electrically valid but never emitted their schematic-level no-connect markers. Add marker reconciliation in the full schematic planner:

- Create missing markers at resolved visible physical pin endpoints.
- Preserve existing user markers at the same endpoint without duplication.
- Restore deleted markers on re-apply and remain unchanged on subsequent runs.
- Remove obsolete markers at pins the source now defines as connected.
- Keep scoped repairs and unrelated items outside this whole-document operation.

No Quiche renderer or agent-schema changes. This does not claim to resolve ENG-1412 (stacked-pin freshness validation).

## Review and verification
- Reproduced ENG-1411 before the fix: integration regression expected 1 persisted marker and found 0.
- Reviewed pin resolution, full-vs-scoped repair boundaries, persistence/idempotence, and NC-to-connected transitions.
- Added review coverage for four NC endpoints on translated, rotated, mirrored symbols, checking exact positions after save/reload.
- `cargo test -p pcbc --test integration schematic_apply`: 22 passed.
- `cargo test -p pcb-kicad-sch`: 184 passed; doctests passed (0 cases).
- `cargo clippy -p pcb-kicad-sch --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.
- No snapshots changed. Used cargo test because cargo-nextest is not installed in the orb.

Requested by LK in https://ampcode.com/threads/T-01a077ef-80e6-749e-92a4-e78b91027931.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes whole-document schematic composition and persisted KiCad geometry; behavior is connectivity-sensitive but heavily covered by new integration tests.
> 
> **Overview**
> **`pcb apply` schematic reconciliation now maintains KiCad no-connect (NC) markers** for pins the netlist marks as intentionally not connected, fixing cases where connectivity was valid but crosses never appeared on the sheet.
> 
> During **full-document** compose (not scoped repairs), a new `reconcile_not_connected_markers` pass runs after connectivity repair: it strips NC markers from endpoints that are now on **connected** nets, drops **stale** markers tied to removed/hidden/moved pins (using prior schematic geometry), and **adds** deterministic markers at visible physical pin endpoints when none exist—without duplicating user-placed markers at the same point. Markers are **not** kept when real wiring (not just an NC item) attaches to that endpoint.
> 
> Integration tests cover idempotent apply, repair after marker deletion, user-marker preservation, NC→connected transitions, transformed symbols, and stale-marker cleanup when pins move, hide, delete, or reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa1f02ed1983a36869ade32b217ab85e2eac0979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->