### PR TITLE
Consolidate BOM table and JSON rows by selected offer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Consolidate `pcb bom` table and JSON rows by selected offer.
 - Upgrade all remaining bundled standard-library and example symbols to KiCad 10 format.
 - Create a starter `spec.md` when scaffolding a new board repository.
 

--- a/crates/pcb-sch/src/bom/core.rs
+++ b/crates/pcb-sch/src/bom/core.rs
@@ -30,6 +30,10 @@ pub fn trim_description(s: Option<String>) -> Option<String> {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GroupedBomEntry {
     pub designators: BTreeSet<NaturalString>,
+    pub quantity: usize,
+    /// Original per-path lines, including their distinct requirements and match data.
+    pub members: Vec<UngroupedBomEntry>,
+    /// Representative design entry from the first naturally sorted member.
     #[serde(flatten)]
     pub entry: BomEntry,
 }
@@ -339,7 +343,9 @@ impl Bom {
             .collect::<Vec<_>>();
         // Sort by DNP status first (non-DNP before DNP), then by designator naturally
         entries.sort_by(|a, b| match a.entry.dnp.cmp(&b.entry.dnp) {
-            std::cmp::Ordering::Equal => natord::compare(&a.designator, &b.designator),
+            std::cmp::Ordering::Equal => {
+                natord::compare(&a.designator, &b.designator).then_with(|| a.path.cmp(&b.path))
+            }
             other => other,
         });
         entries
@@ -349,40 +355,50 @@ impl Bom {
         serde_json::to_string_pretty(&self.ungrouped_entries()).unwrap()
     }
 
-    #[cfg(feature = "table")]
-    pub(crate) fn grouped_entries(&self) -> Vec<GroupedBomEntry> {
-        // Path-only entries do not identify a common component and must not be
-        // collapsed into one row.
-        let mut groups = HashMap::<(BomEntry, Option<String>), BTreeSet<NaturalString>>::new();
-
-        for (path, entry) in &self.entries {
-            let instance_path = (!entry.has_stable_aggregation_identity()).then(|| path.clone());
-            let group = groups.entry((entry.clone(), instance_path)).or_default();
-            group.insert(self.designators[path].clone().into());
+    /// Presentation grouping only: matching and release artifacts keep authored lines.
+    pub fn grouped_entries(&self) -> Vec<GroupedBomEntry> {
+        #[derive(PartialEq, Eq, Hash)]
+        enum Key {
+            Selection(String, bool, bool),
+            Design(Box<BomEntry>, Option<String>),
         }
 
-        // Convert to vec
-        let mut grouped_entries = groups
-            .into_iter()
-            .map(|((entry, _), designators)| GroupedBomEntry { entry, designators })
-            .collect::<Vec<_>>();
+        let mut indices = HashMap::<Key, usize>::new();
+        let mut groups = Vec::<GroupedBomEntry>::new();
+        for member in self.ungrouped_entries() {
+            let entry = &member.entry;
+            // Match Diode's display identity: the server-selected offer, not the
+            // authored requirements or MPN alone. Never select or rerank locally.
+            let key = match member
+                .availability
+                .as_ref()
+                .and_then(|a| a.selected_offer_id.as_ref())
+            {
+                Some(id) => Key::Selection(id.clone(), entry.dnp, entry.skip_bom),
+                None => Key::Design(
+                    Box::new(entry.clone()),
+                    (!entry.has_stable_aggregation_identity()).then(|| member.path.clone()),
+                ),
+            };
+            let index = *indices.entry(key).or_insert_with(|| {
+                groups.push(GroupedBomEntry {
+                    designators: BTreeSet::new(),
+                    quantity: 0,
+                    members: Vec::new(),
+                    entry: entry.clone(),
+                });
+                groups.len() - 1
+            });
+            let group = &mut groups[index];
+            group.designators.insert(member.designator.clone().into());
+            group.quantity += 1;
+            group.members.push(member);
+        }
+        groups
+    }
 
-        grouped_entries.sort_by(|a, b| {
-            // Sort by DNP status first (non-DNP before DNP)
-            match a.entry.dnp.cmp(&b.entry.dnp) {
-                std::cmp::Ordering::Equal => {
-                    // Within same DNP status, sort by first designator
-                    // BTreeSet<NaturalString> maintains natural order, so first() is correct
-                    a.designators
-                        .iter()
-                        .next()
-                        .cmp(&b.designators.iter().next())
-                }
-                other => other,
-            }
-        });
-
-        grouped_entries
+    pub fn grouped_json(&self) -> String {
+        serde_json::to_string_pretty(&self.grouped_entries()).unwrap()
     }
 
     /// Filter out components that have skip_bom=true
@@ -689,7 +705,6 @@ mod tests {
         assert_eq!(truncated.chars().count(), 100);
     }
 
-    #[cfg(feature = "table")]
     #[test]
     fn identityless_entries_remain_separate_table_rows() {
         let entry = BomEntry {
@@ -716,6 +731,77 @@ mod tests {
         );
 
         assert_eq!(bom.grouped_entries().len(), 2);
+    }
+
+    #[test]
+    fn presentation_groups_server_selections_without_losing_member_details() {
+        use crate::bom::availability::Availability;
+
+        let mut bom = Bom::new(HashMap::new(), HashMap::new());
+        for (designator, description, selection, dnp, skip_bom) in [
+            ("C10", "1 uF", Some("shared"), false, false),
+            ("C2", "1 uF 10 V", Some("shared"), false, false),
+            ("C3", "1 uF", Some("other-seller"), false, false),
+            ("C4", "1 uF", None, false, false),
+            ("C5", "1 uF", Some("shared"), true, false),
+            ("C6", "1 uF", Some("shared"), false, true),
+        ] {
+            let path = format!("root.{designator}");
+            let entry = serde_json::from_value(serde_json::json!({
+                "mpn": "same-part", "manufacturer": "same-maker",
+                "description": description, "alternatives": [],
+                "dnp": dnp, "skip_bom": skip_bom
+            }))
+            .unwrap();
+            bom.entries.insert(path.clone(), entry);
+            bom.designators.insert(path.clone(), designator.to_string());
+            bom.availability.insert(
+                path,
+                Availability {
+                    selected_offer_id: selection.map(str::to_string),
+                    ..Default::default()
+                },
+            );
+        }
+        let groups = bom.grouped_entries();
+        assert_eq!(groups.len(), 5);
+        assert_eq!(groups[0].quantity, 2);
+        assert_eq!(groups[0].entry.description.as_deref(), Some("1 uF 10 V"));
+        assert_eq!(groups[0].members[0].path, "root.C2");
+        assert_eq!(groups[0].members[1].path, "root.C10");
+        assert_eq!(
+            groups[0].members[1].entry.description.as_deref(),
+            Some("1 uF")
+        );
+        let json: serde_json::Value = serde_json::from_str(&bom.grouped_json()).unwrap();
+        assert_eq!(json[0]["quantity"], 2);
+        assert_eq!(json[0]["designators"], serde_json::json!(["C2", "C10"]));
+        assert_eq!(json[0]["members"][1]["path"], "root.C10");
+        assert_eq!(json[0]["members"][1]["description"], "1 uF");
+        assert_eq!(
+            json[0]["members"][1]["availability"]["selected_offer_id"],
+            "shared"
+        );
+        assert_eq!(bom.ungrouped_entries().len(), 6);
+
+        // HashMap insertion order must not choose a different representative.
+        let mut reordered = bom.clone();
+        reordered.entries = bom
+            .ungrouped_entries()
+            .into_iter()
+            .rev()
+            .map(|line| (line.path, line.entry))
+            .collect();
+        assert_eq!(reordered.grouped_json(), bom.grouped_json());
+
+        #[cfg(feature = "table")]
+        {
+            let mut output = Vec::new();
+            bom.write_table(&mut output).unwrap();
+            let table = String::from_utf8(output).unwrap();
+            assert!(table.contains("C2,C10"), "{table}");
+            println!("{table}");
+        }
     }
 
     #[test]

--- a/crates/pcb-sch/src/bom/core.rs
+++ b/crates/pcb-sch/src/bom/core.rs
@@ -31,11 +31,20 @@ pub fn trim_description(s: Option<String>) -> Option<String> {
 pub struct GroupedBomEntry {
     pub designators: BTreeSet<NaturalString>,
     pub quantity: usize,
-    /// Original per-path lines, including their distinct requirements and match data.
-    pub members: Vec<UngroupedBomEntry>,
-    /// Representative design entry from the first naturally sorted member.
+    pub members: Vec<GroupedBomMember>,
+    /// Sourcing shared by every member; match status remains per-member.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub availability: Option<super::availability::Availability>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct GroupedBomMember {
+    pub path: String,
+    pub designator: String,
     #[serde(flatten)]
     pub entry: BomEntry,
+    #[serde(rename = "match", skip_serializing_if = "Option::is_none")]
+    pub match_status: Option<super::availability::BomMatchStatus>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -365,7 +374,11 @@ impl Bom {
 
         let mut indices = HashMap::<Key, Vec<usize>>::new();
         let mut groups = Vec::<GroupedBomEntry>::new();
-        for member in self.ungrouped_entries() {
+        for mut member in self.ungrouped_entries() {
+            let match_status = member
+                .availability
+                .as_mut()
+                .and_then(|a| a.match_status.take());
             let entry = &member.entry;
             // Match Diode's display identity: the server-selected offer, not the
             // authored requirements or MPN alone. Never select or rerank locally.
@@ -387,24 +400,13 @@ impl Bom {
             let index = candidates
                 .iter()
                 .copied()
-                .find(|&index| {
-                    match (&groups[index].members[0].availability, &member.availability) {
-                        (Some(a), Some(b)) => {
-                            a.us == b.us
-                                && a.global == b.global
-                                && a.offers == b.offers
-                                && a.no_match == b.no_match
-                        }
-                        (None, None) => true,
-                        _ => false,
-                    }
-                })
+                .find(|&index| groups[index].availability == member.availability)
                 .unwrap_or_else(|| {
                     groups.push(GroupedBomEntry {
                         designators: BTreeSet::new(),
                         quantity: 0,
                         members: Vec::new(),
-                        entry: entry.clone(),
+                        availability: member.availability.clone(),
                     });
                     let index = groups.len() - 1;
                     candidates.push(index);
@@ -413,7 +415,12 @@ impl Bom {
             let group = &mut groups[index];
             group.designators.insert(member.designator.clone().into());
             group.quantity += 1;
-            group.members.push(member);
+            group.members.push(GroupedBomMember {
+                path: member.path,
+                designator: member.designator,
+                entry: member.entry,
+                match_status,
+            });
         }
         groups
     }
@@ -756,7 +763,7 @@ mod tests {
 
     #[test]
     fn presentation_groups_server_selections_without_losing_member_details() {
-        use crate::bom::availability::Availability;
+        use crate::bom::availability::{Availability, BomMatchStatus};
 
         let mut bom = Bom::new(HashMap::new(), HashMap::new());
         for (designator, description, selection, dnp, skip_bom) in [
@@ -779,15 +786,24 @@ mod tests {
             bom.availability.insert(
                 path,
                 Availability {
+                    match_status: Some(if designator == "C10" {
+                        BomMatchStatus::Exact
+                    } else {
+                        BomMatchStatus::Compatible
+                    }),
                     selected_offer_id: selection.map(str::to_string),
                     ..Default::default()
                 },
             );
         }
+        bom.availability.remove("root.C4");
         let groups = bom.grouped_entries();
         assert_eq!(groups.len(), 5);
         assert_eq!(groups[0].quantity, 2);
-        assert_eq!(groups[0].entry.description.as_deref(), Some("1 uF 10 V"));
+        assert_eq!(
+            groups[0].members[0].entry.description.as_deref(),
+            Some("1 uF 10 V")
+        );
         assert_eq!(groups[0].members[0].path, "root.C2");
         assert_eq!(groups[0].members[1].path, "root.C10");
         assert_eq!(
@@ -799,10 +815,32 @@ mod tests {
         assert_eq!(json[0]["designators"], serde_json::json!(["C2", "C10"]));
         assert_eq!(json[0]["members"][1]["path"], "root.C10");
         assert_eq!(json[0]["members"][1]["description"], "1 uF");
-        assert_eq!(
-            json[0]["members"][1]["availability"]["selected_offer_id"],
-            "shared"
-        );
+        assert_eq!(json[0]["availability"]["selected_offer_id"], "shared");
+        assert!(json[0].get("description").is_none());
+        assert!(json[0]["availability"].get("match").is_none());
+        assert!(json[0]["members"][0].get("availability").is_none());
+        assert_eq!(json[0]["members"][0]["match"], "MATCH_COMPATIBLE");
+        assert_eq!(json[0]["members"][1]["match"], "MATCH_EXACT");
+
+        // Factoring sourcing must preserve every original field, including absence.
+        for group in json.as_array().unwrap() {
+            for member in group["members"].as_array().unwrap() {
+                let mut restored = member.clone();
+                let fields = restored.as_object_mut().unwrap();
+                if let Some(mut availability) = group.get("availability").cloned() {
+                    if let Some(status) = fields.remove("match") {
+                        availability["match"] = status;
+                    }
+                    fields.insert("availability".to_string(), availability);
+                }
+                let original = bom
+                    .ungrouped_entries()
+                    .into_iter()
+                    .find(|line| line.path == restored["path"].as_str().unwrap())
+                    .unwrap();
+                assert_eq!(restored, serde_json::to_value(original).unwrap());
+            }
+        }
         assert_eq!(bom.ungrouped_entries().len(), 6);
 
         // HashMap insertion order must not choose a different representative.

--- a/crates/pcb-sch/src/bom/core.rs
+++ b/crates/pcb-sch/src/bom/core.rs
@@ -363,7 +363,7 @@ impl Bom {
             Design(Box<BomEntry>, Option<String>),
         }
 
-        let mut indices = HashMap::<Key, usize>::new();
+        let mut indices = HashMap::<Key, Vec<usize>>::new();
         let mut groups = Vec::<GroupedBomEntry>::new();
         for member in self.ungrouped_entries() {
             let entry = &member.entry;
@@ -380,15 +380,36 @@ impl Bom {
                     (!entry.has_stable_aggregation_identity()).then(|| member.path.clone()),
                 ),
             };
-            let index = *indices.entry(key).or_insert_with(|| {
-                groups.push(GroupedBomEntry {
-                    designators: BTreeSet::new(),
-                    quantity: 0,
-                    members: Vec::new(),
-                    entry: entry.clone(),
+            let candidates = indices.entry(key).or_default();
+            // Separate planner groups can select the same offer (for example,
+            // with insufficient stock). Share a row only if its sourcing data
+            // represents every member; match status itself remains per-member.
+            let index = candidates
+                .iter()
+                .copied()
+                .find(|&index| {
+                    match (&groups[index].members[0].availability, &member.availability) {
+                        (Some(a), Some(b)) => {
+                            a.us == b.us
+                                && a.global == b.global
+                                && a.offers == b.offers
+                                && a.no_match == b.no_match
+                        }
+                        (None, None) => true,
+                        _ => false,
+                    }
+                })
+                .unwrap_or_else(|| {
+                    groups.push(GroupedBomEntry {
+                        designators: BTreeSet::new(),
+                        quantity: 0,
+                        members: Vec::new(),
+                        entry: entry.clone(),
+                    });
+                    let index = groups.len() - 1;
+                    candidates.push(index);
+                    index
                 });
-                groups.len() - 1
-            });
             let group = &mut groups[index];
             group.designators.insert(member.designator.clone().into());
             group.quantity += 1;

--- a/crates/pcb-sch/src/bom_table.rs
+++ b/crates/pcb-sch/src/bom_table.rs
@@ -332,6 +332,8 @@ impl Bom {
         let mut extended_qty = 0;
         let mut unclassified_count = 0;
         let mut unclassified_qty = 0;
+        let mut total_us = 0.0;
+        let mut total_global = 0.0;
 
         let mut table = Table::new();
         table.load_style(comfy_table::presets::UTF8_FULL_CONDENSED);
@@ -363,15 +365,8 @@ impl Bom {
                 .unwrap_or_default();
             let is_dnp = entry.dnp;
 
-            // A grouped row is sourceable only when every represented line has match data.
-            let availabilities = grouped
-                .members
-                .iter()
-                .map(|member| member.availability.as_ref())
-                .collect::<Option<Vec<_>>>();
-            let avail = availabilities
-                .as_deref()
-                .and_then(|availabilities| availabilities.first().copied());
+            // Grouping guarantees that every member has the same sourcing data.
+            let avail = grouped.members[0].availability.as_ref();
             let no_match = avail.map(|availability| availability.no_match);
             let collection = avail.and_then(|availability| availability.selected_part_collection());
 
@@ -379,6 +374,11 @@ impl Bom {
                 RegionDisplayData::from_region_avail(avail.and_then(|a| a.us.as_ref()), qty);
             let global_data =
                 RegionDisplayData::from_region_avail(avail.and_then(|a| a.global.as_ref()), qty);
+
+            // Sum the displayed one-board row prices, including their rounding.
+            // Preserve the existing inclusion of DNP rows in estimated totals.
+            total_us += ceil_cents(us_data.price_single.unwrap_or_default());
+            total_global += ceil_cents(global_data.price_single.unwrap_or_default());
 
             let line_sourceability =
                 line_sourceability(us_data.sourceability, global_data.sourceability);
@@ -522,47 +522,12 @@ impl Bom {
 
         writeln!(writer, "{table}")?;
 
-        // Calculate and print total BOM cost per region if availability data is present
+        // Print the sum of the displayed grouped row prices.
         if has_availability {
-            let (total_us, total_global) =
-                self.entries
-                    .iter()
-                    .fold((0.0, 0.0), |(acc_us, acc_global), (path, _entry)| {
-                        let qty = self
-                            .designators
-                            .iter()
-                            .filter(|(p, _)| p.as_str() == path)
-                            .count() as i32;
-
-                        if let Some(avail) = self.availability.get(path) {
-                            let us_price = avail
-                                .us
-                                .as_ref()
-                                .and_then(|r| r.price_breaks.as_ref())
-                                .and_then(|breaks| unit_price_from_breaks(breaks, qty))
-                                .map(|unit_price| unit_price * qty as f64)
-                                .unwrap_or(0.0);
-
-                            let global_price = avail
-                                .global
-                                .as_ref()
-                                .and_then(|r| r.price_breaks.as_ref())
-                                .and_then(|breaks| unit_price_from_breaks(breaks, qty))
-                                .map(|unit_price| unit_price * qty as f64)
-                                .unwrap_or(0.0);
-
-                            (acc_us + us_price, acc_global + global_price)
-                        } else {
-                            (acc_us, acc_global)
-                        }
-                    });
-
-            let total_us_cents = (total_us * 100.0).ceil() / 100.0;
-            let total_global_cents = (total_global * 100.0).ceil() / 100.0;
             writeln!(
                 writer,
                 "Total: US ${:.2} | Global ${:.2}",
-                total_us_cents, total_global_cents
+                total_us, total_global
             )?;
         }
 
@@ -660,6 +625,81 @@ mod tests {
 
     use super::*;
     use crate::bom::{Availability, BomEntry};
+
+    #[test]
+    fn grouped_sourcing_and_totals_follow_displayed_rows() {
+        let mut bom = Bom::new(HashMap::new(), HashMap::new());
+        for (designator, description, dnp) in [
+            ("C1", "1uF 10V", false),
+            ("C2", "1uF", false),
+            ("C3", "DNP", true),
+        ] {
+            bom.entries.insert(
+                designator.to_string(),
+                serde_json::from_value(serde_json::json!({
+                    "mpn": "shared-part", "description": description, "dnp": dnp, "alternatives": []
+                }))
+                .unwrap(),
+            );
+            bom.designators
+                .insert(designator.to_string(), designator.to_string());
+            let summary = |breaks| {
+                Some(AvailabilitySummary {
+                    stock: 100,
+                    stock_class: SourcingStockClass::Plenty,
+                    price_breaks: Some(breaks),
+                    ..Default::default()
+                })
+            };
+            bom.availability.insert(
+                designator.to_string(),
+                Availability {
+                    selected_offer_id: Some("shared-offer".to_string()),
+                    us: summary(if dnp {
+                        vec![(1, 0.003)]
+                    } else {
+                        vec![(1, 1.0), (2, 0.25)]
+                    }),
+                    global: summary(if dnp {
+                        vec![(1, 0.003)]
+                    } else {
+                        vec![(1, 0.5), (2, 0.1)]
+                    }),
+                    ..Default::default()
+                },
+            );
+        }
+        let render = |bom: &Bom| {
+            let mut output = Vec::new();
+            bom.write_table(&mut output).unwrap();
+            String::from_utf8(output).unwrap()
+        };
+        let table = render(&bom);
+        assert!(table.contains("C1,C2"), "{table}");
+        assert!(table.contains("$0.50 ($2.50)"), "{table}");
+        assert!(table.contains("$0.20 ($1.00)"), "{table}");
+        assert!(table.contains("Total: US $0.51 | Global $0.21"), "{table}");
+        println!("{table}");
+
+        let original = bom.availability["C2"].clone();
+        let mut different_class = original.clone();
+        different_class.us.as_mut().unwrap().stock_class = SourcingStockClass::Insufficient;
+        let mut different_region = original.clone();
+        different_region.global.as_mut().unwrap().alt_stock = 900;
+        let mut different_offers = original;
+        different_offers.offers.push(serde_json::from_value(serde_json::json!({
+            "id": "line-only-alternative", "region": "Global", "distributor": "LCSC", "stock": 900
+        })).unwrap());
+        for availability in [different_class, different_region, different_offers] {
+            bom.availability.insert("C2".to_string(), availability);
+            assert_eq!(bom.grouped_entries().len(), 3);
+            let json: serde_json::Value = serde_json::from_str(&bom.grouped_json()).unwrap();
+            assert_eq!(json.as_array().unwrap().len(), 3);
+            let table = render(&bom);
+            assert!(!table.contains("C1,C2"), "{table}");
+            println!("{table}");
+        }
+    }
 
     #[test]
     fn no_match_status_is_magenta() {

--- a/crates/pcb-sch/src/bom_table.rs
+++ b/crates/pcb-sch/src/bom_table.rs
@@ -337,23 +337,12 @@ impl Bom {
         table.load_style(comfy_table::presets::UTF8_FULL_CONDENSED);
         table.set_content_arrangement(comfy_table::ContentArrangement::DynamicFullWidth);
 
-        let mut entries = self.grouped_entries();
-        // Sort entries: non-DNP first (sorted by first designator), then DNP items (sorted by first designator)
-        entries.sort_by(|a, b| {
-            a.entry.dnp.cmp(&b.entry.dnp).then_with(|| {
-                a.designators
-                    .iter()
-                    .next()
-                    .cmp(&b.designators.iter().next())
-            })
-        });
-
-        for grouped in entries {
+        for grouped in self.grouped_entries() {
             let designators_vec: Vec<&str> =
                 grouped.designators.iter().map(AsRef::as_ref).collect();
 
             // Designators already naturally sorted by BTreeSet<NaturalString>
-            let qty = designators_vec.len();
+            let qty = grouped.quantity;
             let designators = designators_vec.join(",");
             let entry = &grouped.entry;
 
@@ -374,18 +363,11 @@ impl Bom {
                 .unwrap_or_default();
             let is_dnp = entry.dnp;
 
-            let mut paths: Vec<&String> = self
-                .designators
-                .iter()
-                .filter(|(_, d)| designators_vec.contains(&d.as_str()))
-                .map(|(p, _)| p)
-                .collect();
-            paths.sort_unstable();
-
             // A grouped row is sourceable only when every represented line has match data.
-            let availabilities = paths
+            let availabilities = grouped
+                .members
                 .iter()
-                .map(|path| self.availability.get(*path))
+                .map(|member| member.availability.as_ref())
                 .collect::<Option<Vec<_>>>();
             let avail = availabilities
                 .as_deref()

--- a/crates/pcb-sch/src/bom_table.rs
+++ b/crates/pcb-sch/src/bom_table.rs
@@ -346,7 +346,7 @@ impl Bom {
             // Designators already naturally sorted by BTreeSet<NaturalString>
             let qty = grouped.quantity;
             let designators = designators_vec.join(",");
-            let entry = &grouped.entry;
+            let entry = &grouped.members[0].entry;
 
             let mpn = entry
                 .mpn
@@ -366,7 +366,7 @@ impl Bom {
             let is_dnp = entry.dnp;
 
             // Grouping guarantees that every member has the same sourcing data.
-            let avail = grouped.members[0].availability.as_ref();
+            let avail = grouped.availability.as_ref();
             let no_match = avail.map(|availability| availability.no_match);
             let collection = avail.and_then(|availability| availability.selected_part_collection());
 

--- a/crates/pcbc/src/bom.rs
+++ b/crates/pcbc/src/bom.rs
@@ -146,7 +146,7 @@ pub fn execute(args: BomArgs) -> Result<()> {
     spinner.finish();
 
     pcb_ui::write_stdout(|writer| match args.format {
-        BomFormat::Json => write!(writer, "{}", bom.ungrouped_json()),
+        BomFormat::Json => write!(writer, "{}", bom.grouped_json()),
         BomFormat::Table => bom.write_table(writer),
     })?;
 

--- a/crates/pcbc/tests/bom.rs
+++ b/crates/pcbc/tests/bom.rs
@@ -457,7 +457,7 @@ Component(
 
     let bom: serde_json::Value =
         serde_json::from_slice(&output.stdout).expect("BOM output should be valid JSON");
-    let entry = &bom[0];
+    let entry = &bom[0]["members"][0];
     assert_eq!(entry["value"], "32MHz");
     assert_eq!(
         entry["description"],

--- a/crates/pcbc/tests/snapshots/bom__bom_capacitors_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_capacitors_json.snap
@@ -8,8 +8,33 @@ Exit Code: 0
 --- STDOUT ---
 [
   {
-    "path": "C1.C",
-    "designator": "C1",
+    "designators": [
+      "C1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "C1.C",
+        "designator": "C1",
+        "package": "0402",
+        "value": "100nF 16V X7R",
+        "description": "100nF 16V X7R",
+        "component_type": "Capacitor",
+        "capacitance": {
+          "nominal": "0.000000100",
+          "min": "0.000000100",
+          "max": "0.000000100",
+          "unit": "Farads"
+        },
+        "dielectric": "X7R",
+        "voltage": {
+          "nominal": "16",
+          "min": "16",
+          "max": "16",
+          "unit": "Volts"
+        }
+      }
+    ],
     "package": "0402",
     "value": "100nF 16V X7R",
     "description": "100nF 16V X7R",
@@ -29,8 +54,33 @@ Exit Code: 0
     }
   },
   {
-    "path": "C2.C",
-    "designator": "C2",
+    "designators": [
+      "C2"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "C2.C",
+        "designator": "C2",
+        "package": "0805",
+        "value": "10uF 25V X5R",
+        "description": "10uF 25V X5R",
+        "component_type": "Capacitor",
+        "capacitance": {
+          "nominal": "0.000010",
+          "min": "0.000010",
+          "max": "0.000010",
+          "unit": "Farads"
+        },
+        "dielectric": "X5R",
+        "voltage": {
+          "nominal": "25",
+          "min": "25",
+          "max": "25",
+          "unit": "Volts"
+        }
+      }
+    ],
     "package": "0805",
     "value": "10uF 25V X5R",
     "description": "10uF 25V X5R",
@@ -50,8 +100,26 @@ Exit Code: 0
     }
   },
   {
-    "path": "C3.C",
-    "designator": "C3",
+    "designators": [
+      "C3"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "C3.C",
+        "designator": "C3",
+        "package": "0603",
+        "value": "1uF",
+        "description": "1uF",
+        "component_type": "Capacitor",
+        "capacitance": {
+          "nominal": "0.000001",
+          "min": "0.000001",
+          "max": "0.000001",
+          "unit": "Farads"
+        }
+      }
+    ],
     "package": "0603",
     "value": "1uF",
     "description": "1uF",

--- a/crates/pcbc/tests/snapshots/bom__bom_capacitors_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_capacitors_json.snap
@@ -34,24 +34,7 @@ Exit Code: 0
           "unit": "Volts"
         }
       }
-    ],
-    "package": "0402",
-    "value": "100nF 16V X7R",
-    "description": "100nF 16V X7R",
-    "component_type": "Capacitor",
-    "capacitance": {
-      "nominal": "0.000000100",
-      "min": "0.000000100",
-      "max": "0.000000100",
-      "unit": "Farads"
-    },
-    "dielectric": "X7R",
-    "voltage": {
-      "nominal": "16",
-      "min": "16",
-      "max": "16",
-      "unit": "Volts"
-    }
+    ]
   },
   {
     "designators": [
@@ -80,24 +63,7 @@ Exit Code: 0
           "unit": "Volts"
         }
       }
-    ],
-    "package": "0805",
-    "value": "10uF 25V X5R",
-    "description": "10uF 25V X5R",
-    "component_type": "Capacitor",
-    "capacitance": {
-      "nominal": "0.000010",
-      "min": "0.000010",
-      "max": "0.000010",
-      "unit": "Farads"
-    },
-    "dielectric": "X5R",
-    "voltage": {
-      "nominal": "25",
-      "min": "25",
-      "max": "25",
-      "unit": "Volts"
-    }
+    ]
   },
   {
     "designators": [
@@ -119,17 +85,7 @@ Exit Code: 0
           "unit": "Farads"
         }
       }
-    ],
-    "package": "0603",
-    "value": "1uF",
-    "description": "1uF",
-    "component_type": "Capacitor",
-    "capacitance": {
-      "nominal": "0.000001",
-      "min": "0.000001",
-      "max": "0.000001",
-      "unit": "Farads"
-    }
+    ]
   }
 ]
 --- STDERR ---

--- a/crates/pcbc/tests/snapshots/bom__bom_dnp_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_dnp_json.snap
@@ -19,9 +19,7 @@ Exit Code: 0
         "mpn": "RC0603FR-071KL",
         "manufacturer": "Yageo"
       }
-    ],
-    "mpn": "RC0603FR-071KL",
-    "manufacturer": "Yageo"
+    ]
   },
   {
     "designators": [
@@ -36,10 +34,7 @@ Exit Code: 0
         "manufacturer": "Yageo",
         "dnp": true
       }
-    ],
-    "mpn": "RC0603FR-0710KL",
-    "manufacturer": "Yageo",
-    "dnp": true
+    ]
   },
   {
     "designators": [
@@ -54,10 +49,7 @@ Exit Code: 0
         "manufacturer": "Yageo",
         "dnp": true
       }
-    ],
-    "mpn": "RC0603FR-074K7L",
-    "manufacturer": "Yageo",
-    "dnp": true
+    ]
   }
 ]
 --- STDERR ---

--- a/crates/pcbc/tests/snapshots/bom__bom_dnp_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_dnp_json.snap
@@ -8,21 +8,53 @@ Exit Code: 0
 --- STDOUT ---
 [
   {
-    "path": "normal",
-    "designator": "U4",
+    "designators": [
+      "U4"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "normal",
+        "designator": "U4",
+        "mpn": "RC0603FR-071KL",
+        "manufacturer": "Yageo"
+      }
+    ],
     "mpn": "RC0603FR-071KL",
     "manufacturer": "Yageo"
   },
   {
-    "path": "dnp_kwarg_1",
-    "designator": "U2",
+    "designators": [
+      "U2"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "dnp_kwarg_1",
+        "designator": "U2",
+        "mpn": "RC0603FR-0710KL",
+        "manufacturer": "Yageo",
+        "dnp": true
+      }
+    ],
     "mpn": "RC0603FR-0710KL",
     "manufacturer": "Yageo",
     "dnp": true
   },
   {
-    "path": "dnp_kwarg_2",
-    "designator": "U3",
+    "designators": [
+      "U3"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "dnp_kwarg_2",
+        "designator": "U3",
+        "mpn": "RC0603FR-074K7L",
+        "manufacturer": "Yageo",
+        "dnp": true
+      }
+    ],
     "mpn": "RC0603FR-074K7L",
     "manufacturer": "Yageo",
     "dnp": true

--- a/crates/pcbc/tests/snapshots/bom__bom_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_json.snap
@@ -8,8 +8,26 @@ Exit Code: 0
 --- STDOUT ---
 [
   {
-    "path": "C1.C",
-    "designator": "C1",
+    "designators": [
+      "C1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "C1.C",
+        "designator": "C1",
+        "package": "0402",
+        "value": "100nF",
+        "description": "100nF",
+        "component_type": "Capacitor",
+        "capacitance": {
+          "nominal": "0.000000100",
+          "min": "0.000000100",
+          "max": "0.000000100",
+          "unit": "Farads"
+        }
+      }
+    ],
     "package": "0402",
     "value": "100nF",
     "description": "100nF",
@@ -22,8 +40,26 @@ Exit Code: 0
     }
   },
   {
-    "path": "C2.C",
-    "designator": "C2",
+    "designators": [
+      "C2"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "C2.C",
+        "designator": "C2",
+        "package": "0805",
+        "value": "10uF",
+        "description": "10uF",
+        "component_type": "Capacitor",
+        "capacitance": {
+          "nominal": "0.000010",
+          "min": "0.000010",
+          "max": "0.000010",
+          "unit": "Farads"
+        }
+      }
+    ],
     "package": "0805",
     "value": "10uF",
     "description": "10uF",
@@ -36,8 +72,41 @@ Exit Code: 0
     }
   },
   {
-    "path": "C3.C",
-    "designator": "C3",
+    "designators": [
+      "C3",
+      "C4"
+    ],
+    "quantity": 2,
+    "members": [
+      {
+        "path": "C3.C",
+        "designator": "C3",
+        "package": "0402",
+        "value": "22pF",
+        "description": "22pF",
+        "component_type": "Capacitor",
+        "capacitance": {
+          "nominal": "0.000000000022",
+          "min": "0.000000000022",
+          "max": "0.000000000022",
+          "unit": "Farads"
+        }
+      },
+      {
+        "path": "C4.C",
+        "designator": "C4",
+        "package": "0402",
+        "value": "22pF",
+        "description": "22pF",
+        "component_type": "Capacitor",
+        "capacitance": {
+          "nominal": "0.000000000022",
+          "min": "0.000000000022",
+          "max": "0.000000000022",
+          "unit": "Farads"
+        }
+      }
+    ],
     "package": "0402",
     "value": "22pF",
     "description": "22pF",
@@ -50,22 +119,21 @@ Exit Code: 0
     }
   },
   {
-    "path": "C4.C",
-    "designator": "C4",
-    "package": "0402",
-    "value": "22pF",
-    "description": "22pF",
-    "component_type": "Capacitor",
-    "capacitance": {
-      "nominal": "0.000000000022",
-      "min": "0.000000000022",
-      "max": "0.000000000022",
-      "unit": "Farads"
-    }
-  },
-  {
-    "path": "LED1.D1.LED",
-    "designator": "D1",
+    "designators": [
+      "D1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "LED1.D1.LED",
+        "designator": "D1",
+        "package": "0603",
+        "value": "LED GREEN",
+        "description": "LED GREEN",
+        "component_type": "Led",
+        "color": "green"
+      }
+    ],
     "package": "0603",
     "value": "LED GREEN",
     "description": "LED GREEN",
@@ -73,8 +141,21 @@ Exit Code: 0
     "color": "green"
   },
   {
-    "path": "LED2.D1.LED",
-    "designator": "D2",
+    "designators": [
+      "D2"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "LED2.D1.LED",
+        "designator": "D2",
+        "package": "0603",
+        "value": "LED RED",
+        "description": "LED RED",
+        "component_type": "Led",
+        "color": "red"
+      }
+    ],
     "package": "0603",
     "value": "LED RED",
     "description": "LED RED",
@@ -82,8 +163,41 @@ Exit Code: 0
     "color": "red"
   },
   {
-    "path": "LED1.R1.R",
-    "designator": "R1",
+    "designators": [
+      "R1",
+      "R2"
+    ],
+    "quantity": 2,
+    "members": [
+      {
+        "path": "LED1.R1.R",
+        "designator": "R1",
+        "package": "0603",
+        "value": "330",
+        "description": "330",
+        "component_type": "Resistor",
+        "resistance": {
+          "nominal": "330",
+          "min": "330",
+          "max": "330",
+          "unit": "Ohms"
+        }
+      },
+      {
+        "path": "LED2.R1.R",
+        "designator": "R2",
+        "package": "0603",
+        "value": "330",
+        "description": "330",
+        "component_type": "Resistor",
+        "resistance": {
+          "nominal": "330",
+          "min": "330",
+          "max": "330",
+          "unit": "Ohms"
+        }
+      }
+    ],
     "package": "0603",
     "value": "330",
     "description": "330",
@@ -96,22 +210,26 @@ Exit Code: 0
     }
   },
   {
-    "path": "LED2.R1.R",
-    "designator": "R2",
-    "package": "0603",
-    "value": "330",
-    "description": "330",
-    "component_type": "Resistor",
-    "resistance": {
-      "nominal": "330",
-      "min": "330",
-      "max": "330",
-      "unit": "Ohms"
-    }
-  },
-  {
-    "path": "R1.R",
-    "designator": "R3",
+    "designators": [
+      "R3"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "R1.R",
+        "designator": "R3",
+        "package": "0603",
+        "value": "10k",
+        "description": "10k",
+        "component_type": "Resistor",
+        "resistance": {
+          "nominal": "10000",
+          "min": "10000",
+          "max": "10000",
+          "unit": "Ohms"
+        }
+      }
+    ],
     "package": "0603",
     "value": "10k",
     "description": "10k",
@@ -124,8 +242,32 @@ Exit Code: 0
     }
   },
   {
-    "path": "X1.Y",
-    "designator": "Y1",
+    "designators": [
+      "Y1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "X1.Y",
+        "designator": "Y1",
+        "package": "5032_2Pin",
+        "value": "16MHz 18pF",
+        "description": "16MHz 18pF",
+        "component_type": "Crystal",
+        "frequency": {
+          "nominal": "16000000",
+          "min": "16000000",
+          "max": "16000000",
+          "unit": "Hertz"
+        },
+        "load_capacitance": {
+          "nominal": "0.000000000018",
+          "min": "0.000000000018",
+          "max": "0.000000000018",
+          "unit": "Farads"
+        }
+      }
+    ],
     "package": "5032_2Pin",
     "value": "16MHz 18pF",
     "description": "16MHz 18pF",

--- a/crates/pcbc/tests/snapshots/bom__bom_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_json.snap
@@ -27,17 +27,7 @@ Exit Code: 0
           "unit": "Farads"
         }
       }
-    ],
-    "package": "0402",
-    "value": "100nF",
-    "description": "100nF",
-    "component_type": "Capacitor",
-    "capacitance": {
-      "nominal": "0.000000100",
-      "min": "0.000000100",
-      "max": "0.000000100",
-      "unit": "Farads"
-    }
+    ]
   },
   {
     "designators": [
@@ -59,17 +49,7 @@ Exit Code: 0
           "unit": "Farads"
         }
       }
-    ],
-    "package": "0805",
-    "value": "10uF",
-    "description": "10uF",
-    "component_type": "Capacitor",
-    "capacitance": {
-      "nominal": "0.000010",
-      "min": "0.000010",
-      "max": "0.000010",
-      "unit": "Farads"
-    }
+    ]
   },
   {
     "designators": [
@@ -106,17 +86,7 @@ Exit Code: 0
           "unit": "Farads"
         }
       }
-    ],
-    "package": "0402",
-    "value": "22pF",
-    "description": "22pF",
-    "component_type": "Capacitor",
-    "capacitance": {
-      "nominal": "0.000000000022",
-      "min": "0.000000000022",
-      "max": "0.000000000022",
-      "unit": "Farads"
-    }
+    ]
   },
   {
     "designators": [
@@ -133,12 +103,7 @@ Exit Code: 0
         "component_type": "Led",
         "color": "green"
       }
-    ],
-    "package": "0603",
-    "value": "LED GREEN",
-    "description": "LED GREEN",
-    "component_type": "Led",
-    "color": "green"
+    ]
   },
   {
     "designators": [
@@ -155,12 +120,7 @@ Exit Code: 0
         "component_type": "Led",
         "color": "red"
       }
-    ],
-    "package": "0603",
-    "value": "LED RED",
-    "description": "LED RED",
-    "component_type": "Led",
-    "color": "red"
+    ]
   },
   {
     "designators": [
@@ -197,17 +157,7 @@ Exit Code: 0
           "unit": "Ohms"
         }
       }
-    ],
-    "package": "0603",
-    "value": "330",
-    "description": "330",
-    "component_type": "Resistor",
-    "resistance": {
-      "nominal": "330",
-      "min": "330",
-      "max": "330",
-      "unit": "Ohms"
-    }
+    ]
   },
   {
     "designators": [
@@ -229,17 +179,7 @@ Exit Code: 0
           "unit": "Ohms"
         }
       }
-    ],
-    "package": "0603",
-    "value": "10k",
-    "description": "10k",
-    "component_type": "Resistor",
-    "resistance": {
-      "nominal": "10000",
-      "min": "10000",
-      "max": "10000",
-      "unit": "Ohms"
-    }
+    ]
   },
   {
     "designators": [
@@ -267,23 +207,7 @@ Exit Code: 0
           "unit": "Farads"
         }
       }
-    ],
-    "package": "5032_2Pin",
-    "value": "16MHz 18pF",
-    "description": "16MHz 18pF",
-    "component_type": "Crystal",
-    "frequency": {
-      "nominal": "16000000",
-      "min": "16000000",
-      "max": "16000000",
-      "unit": "Hertz"
-    },
-    "load_capacitance": {
-      "nominal": "0.000000000018",
-      "min": "0.000000000018",
-      "max": "0.000000000018",
-      "unit": "Farads"
-    }
+    ]
   }
 ]
 --- STDERR ---

--- a/crates/pcbc/tests/snapshots/bom__bom_kicad_fallback_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_kicad_fallback_json.snap
@@ -8,16 +8,41 @@ Exit Code: 0
 --- STDOUT ---
 [
   {
-    "path": "kicad::R1",
-    "designator": "R1",
+    "designators": [
+      "R1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "kicad::R1",
+        "designator": "R1",
+        "mpn": "ERJ-2RKF1003X",
+        "package": "R_0402_1005Metric",
+        "value": "ERJ-2RKF1003X",
+        "description": "Resistor"
+      }
+    ],
     "mpn": "ERJ-2RKF1003X",
     "package": "R_0402_1005Metric",
     "value": "ERJ-2RKF1003X",
     "description": "Resistor"
   },
   {
-    "path": "kicad::R2",
-    "designator": "R2",
+    "designators": [
+      "R2"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "kicad::R2",
+        "designator": "R2",
+        "mpn": "ERJ-2RKF1003X",
+        "package": "R_0402_1005Metric",
+        "value": "ERJ-2RKF1003X",
+        "description": "Resistor",
+        "dnp": true
+      }
+    ],
     "mpn": "ERJ-2RKF1003X",
     "package": "R_0402_1005Metric",
     "value": "ERJ-2RKF1003X",

--- a/crates/pcbc/tests/snapshots/bom__bom_kicad_fallback_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_kicad_fallback_json.snap
@@ -21,11 +21,7 @@ Exit Code: 0
         "value": "ERJ-2RKF1003X",
         "description": "Resistor"
       }
-    ],
-    "mpn": "ERJ-2RKF1003X",
-    "package": "R_0402_1005Metric",
-    "value": "ERJ-2RKF1003X",
-    "description": "Resistor"
+    ]
   },
   {
     "designators": [
@@ -42,12 +38,7 @@ Exit Code: 0
         "description": "Resistor",
         "dnp": true
       }
-    ],
-    "mpn": "ERJ-2RKF1003X",
-    "package": "R_0402_1005Metric",
-    "value": "ERJ-2RKF1003X",
-    "description": "Resistor",
-    "dnp": true
+    ]
   }
 ]
 --- STDERR ---

--- a/crates/pcbc/tests/snapshots/bom__bom_module_dnp_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_module_dnp_json.snap
@@ -8,8 +8,26 @@ Exit Code: 0
 --- STDOUT ---
 [
   {
-    "path": "C2.C",
-    "designator": "C2",
+    "designators": [
+      "C2"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "C2.C",
+        "designator": "C2",
+        "package": "0805",
+        "value": "10uF",
+        "description": "10uF",
+        "component_type": "Capacitor",
+        "capacitance": {
+          "nominal": "0.000010",
+          "min": "0.000010",
+          "max": "0.000010",
+          "unit": "Farads"
+        }
+      }
+    ],
     "package": "0805",
     "value": "10uF",
     "description": "10uF",
@@ -22,8 +40,26 @@ Exit Code: 0
     }
   },
   {
-    "path": "R1.R",
-    "designator": "R1",
+    "designators": [
+      "R1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "R1.R",
+        "designator": "R1",
+        "package": "0603",
+        "value": "1k",
+        "description": "1k",
+        "component_type": "Resistor",
+        "resistance": {
+          "nominal": "1000",
+          "min": "1000",
+          "max": "1000",
+          "unit": "Ohms"
+        }
+      }
+    ],
     "package": "0603",
     "value": "1k",
     "description": "1k",
@@ -36,8 +72,27 @@ Exit Code: 0
     }
   },
   {
-    "path": "C1_DNP.C",
-    "designator": "C1",
+    "designators": [
+      "C1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "C1_DNP.C",
+        "designator": "C1",
+        "package": "0402",
+        "value": "100nF",
+        "description": "100nF",
+        "component_type": "Capacitor",
+        "capacitance": {
+          "nominal": "0.000000100",
+          "min": "0.000000100",
+          "max": "0.000000100",
+          "unit": "Farads"
+        },
+        "dnp": true
+      }
+    ],
     "package": "0402",
     "value": "100nF",
     "description": "100nF",
@@ -51,8 +106,27 @@ Exit Code: 0
     "dnp": true
   },
   {
-    "path": "R2_DNP.R",
-    "designator": "R2",
+    "designators": [
+      "R2"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "R2_DNP.R",
+        "designator": "R2",
+        "package": "0603",
+        "value": "10k",
+        "description": "10k",
+        "component_type": "Resistor",
+        "resistance": {
+          "nominal": "10000",
+          "min": "10000",
+          "max": "10000",
+          "unit": "Ohms"
+        },
+        "dnp": true
+      }
+    ],
     "package": "0603",
     "value": "10k",
     "description": "10k",

--- a/crates/pcbc/tests/snapshots/bom__bom_module_dnp_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_module_dnp_json.snap
@@ -27,17 +27,7 @@ Exit Code: 0
           "unit": "Farads"
         }
       }
-    ],
-    "package": "0805",
-    "value": "10uF",
-    "description": "10uF",
-    "component_type": "Capacitor",
-    "capacitance": {
-      "nominal": "0.000010",
-      "min": "0.000010",
-      "max": "0.000010",
-      "unit": "Farads"
-    }
+    ]
   },
   {
     "designators": [
@@ -59,17 +49,7 @@ Exit Code: 0
           "unit": "Ohms"
         }
       }
-    ],
-    "package": "0603",
-    "value": "1k",
-    "description": "1k",
-    "component_type": "Resistor",
-    "resistance": {
-      "nominal": "1000",
-      "min": "1000",
-      "max": "1000",
-      "unit": "Ohms"
-    }
+    ]
   },
   {
     "designators": [
@@ -92,18 +72,7 @@ Exit Code: 0
         },
         "dnp": true
       }
-    ],
-    "package": "0402",
-    "value": "100nF",
-    "description": "100nF",
-    "component_type": "Capacitor",
-    "capacitance": {
-      "nominal": "0.000000100",
-      "min": "0.000000100",
-      "max": "0.000000100",
-      "unit": "Farads"
-    },
-    "dnp": true
+    ]
   },
   {
     "designators": [
@@ -126,18 +95,7 @@ Exit Code: 0
         },
         "dnp": true
       }
-    ],
-    "package": "0603",
-    "value": "10k",
-    "description": "10k",
-    "component_type": "Resistor",
-    "resistance": {
-      "nominal": "10000",
-      "min": "10000",
-      "max": "10000",
-      "unit": "Ohms"
-    },
-    "dnp": true
+    ]
   }
 ]
 --- STDERR ---

--- a/crates/pcbc/tests/snapshots/bom__bom_parametric_generics_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_parametric_generics_json.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcbc/tests/bom.rs
-assertion_line: 272
 expression: output
 ---
 Command: pcbc bom boards/ParametricGenerics.zen --offline -f json
@@ -9,8 +8,39 @@ Exit Code: 0
 --- STDOUT ---
 [
   {
-    "path": "D1.D",
-    "designator": "D1",
+    "designators": [
+      "D1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "D1.D",
+        "designator": "D1",
+        "package": "SOD-123",
+        "value": "1A 40V Schottky Rectifier",
+        "description": "1A 40V Schottky Rectifier",
+        "component_type": "Rectifier",
+        "technology": "Schottky",
+        "reverse_voltage": {
+          "nominal": "40",
+          "min": "40",
+          "max": "40",
+          "unit": "Volts"
+        },
+        "forward_current": {
+          "nominal": "1",
+          "min": "1",
+          "max": "1",
+          "unit": "Amperes"
+        },
+        "forward_voltage": {
+          "nominal": "0.500",
+          "min": "0.500",
+          "max": "0.500",
+          "unit": "Volts"
+        }
+      }
+    ],
     "package": "SOD-123",
     "value": "1A 40V Schottky Rectifier",
     "description": "1A 40V Schottky Rectifier",
@@ -36,8 +66,33 @@ Exit Code: 0
     }
   },
   {
-    "path": "D2.LED",
-    "designator": "D2",
+    "designators": [
+      "D2"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "D2.LED",
+        "designator": "D2",
+        "package": "0402",
+        "value": "LED RED 2V",
+        "description": "LED RED 2V",
+        "component_type": "Led",
+        "color": "red",
+        "forward_voltage": {
+          "nominal": "2",
+          "min": "2",
+          "max": "2",
+          "unit": "Volts"
+        },
+        "forward_current": {
+          "nominal": "0.020",
+          "min": "0.020",
+          "max": "0.020",
+          "unit": "Amperes"
+        }
+      }
+    ],
     "package": "0402",
     "value": "LED RED 2V",
     "description": "LED RED 2V",
@@ -57,8 +112,45 @@ Exit Code: 0
     }
   },
   {
-    "path": "TVS1.D",
-    "designator": "D3",
+    "designators": [
+      "D3"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "TVS1.D",
+        "designator": "D3",
+        "package": "DO-219AB",
+        "value": "5V TVS Diode 400W",
+        "description": "5V TVS Diode 400W",
+        "component_type": "Tvs",
+        "direction": "Unidirectional",
+        "reverse_standoff_voltage": {
+          "nominal": "5",
+          "min": "5",
+          "max": "5",
+          "unit": "Volts"
+        },
+        "reverse_clamping_voltage": {
+          "nominal": "9",
+          "min": "9",
+          "max": "9",
+          "unit": "Volts"
+        },
+        "peak_pulse_power": {
+          "nominal": "400",
+          "min": "400",
+          "max": "400",
+          "unit": "Watts"
+        },
+        "capacitance": {
+          "nominal": "0.000000000030",
+          "min": "0.000000000030",
+          "max": "0.000000000030",
+          "unit": "Farads"
+        }
+      }
+    ],
     "package": "DO-219AB",
     "value": "5V TVS Diode 400W",
     "description": "5V TVS Diode 400W",
@@ -90,8 +182,32 @@ Exit Code: 0
     }
   },
   {
-    "path": "Z1.D",
-    "designator": "D4",
+    "designators": [
+      "D4"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "Z1.D",
+        "designator": "D4",
+        "package": "SOD-123",
+        "value": "5.1V Zener 500mW",
+        "description": "5.1V Zener 500mW",
+        "component_type": "Zener",
+        "zener_voltage": {
+          "nominal": "5.1",
+          "min": "5.1",
+          "max": "5.1",
+          "unit": "Volts"
+        },
+        "power": {
+          "nominal": "0.500",
+          "min": "0.500",
+          "max": "0.500",
+          "unit": "Watts"
+        }
+      }
+    ],
     "package": "SOD-123",
     "value": "5.1V Zener 500mW",
     "description": "5.1V Zener 500mW",
@@ -110,8 +226,44 @@ Exit Code: 0
     }
   },
   {
-    "path": "FB1.FB",
-    "designator": "FB1",
+    "designators": [
+      "FB1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "FB1.FB",
+        "designator": "FB1",
+        "package": "0603",
+        "value": "600 500mA 100MHz",
+        "description": "600 500mA 100MHz",
+        "component_type": "FerriteBead",
+        "impedance": {
+          "nominal": "600",
+          "min": "600",
+          "max": "600",
+          "unit": "Ohms"
+        },
+        "frequency": {
+          "nominal": "100000000",
+          "min": "100000000",
+          "max": "100000000",
+          "unit": "Hertz"
+        },
+        "current": {
+          "nominal": "0.500",
+          "min": "0.500",
+          "max": "0.500",
+          "unit": "Amperes"
+        },
+        "dcr": {
+          "nominal": "0.200",
+          "min": "0.200",
+          "max": "0.200",
+          "unit": "Ohms"
+        }
+      }
+    ],
     "package": "0603",
     "value": "600 500mA 100MHz",
     "description": "600 500mA 100MHz",
@@ -142,8 +294,26 @@ Exit Code: 0
     }
   },
   {
-    "path": "J1.PH",
-    "designator": "J1",
+    "designators": [
+      "J1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "J1.PH",
+        "designator": "J1",
+        "package": "PinHeader_1x02_P2.54mm_Vertical",
+        "value": "2.54mm 2 x 1 THT Vertical Male",
+        "description": "2.54mm 2 x 1 THT Vertical Male",
+        "component_type": "PinHeader",
+        "pitch": "2.54mm",
+        "rows": 1,
+        "pins": 2,
+        "orientation": "Vertical",
+        "gender": "Male",
+        "mount": "THT"
+      }
+    ],
     "package": "PinHeader_1x02_P2.54mm_Vertical",
     "value": "2.54mm 2 x 1 THT Vertical Male",
     "description": "2.54mm 2 x 1 THT Vertical Male",
@@ -156,8 +326,38 @@ Exit Code: 0
     "mount": "THT"
   },
   {
-    "path": "L1.L",
-    "designator": "L1",
+    "designators": [
+      "L1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "L1.L",
+        "designator": "L1",
+        "package": "0603",
+        "value": "4.7uH 1A",
+        "description": "4.7uH 1A",
+        "component_type": "Inductor",
+        "inductance": {
+          "nominal": "0.0000047",
+          "min": "0.0000047",
+          "max": "0.0000047",
+          "unit": "Henries"
+        },
+        "current": {
+          "nominal": "1",
+          "min": "1",
+          "max": "1",
+          "unit": "Amperes"
+        },
+        "dcr": {
+          "nominal": "0.120",
+          "min": "0.120",
+          "max": "0.120",
+          "unit": "Ohms"
+        }
+      }
+    ],
     "package": "0603",
     "value": "4.7uH 1A",
     "description": "4.7uH 1A",
@@ -182,8 +382,32 @@ Exit Code: 0
     }
   },
   {
-    "path": "R1.R",
-    "designator": "R1",
+    "designators": [
+      "R1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "R1.R",
+        "designator": "R1",
+        "package": "0603",
+        "value": "10k 250mW",
+        "description": "10k 250mW",
+        "component_type": "Resistor",
+        "resistance": {
+          "nominal": "10000",
+          "min": "10000",
+          "max": "10000",
+          "unit": "Ohms"
+        },
+        "power": {
+          "nominal": "0.250",
+          "min": "0.250",
+          "max": "0.250",
+          "unit": "Watts"
+        }
+      }
+    ],
     "package": "0603",
     "value": "10k 250mW",
     "description": "10k 250mW",
@@ -202,8 +426,38 @@ Exit Code: 0
     }
   },
   {
-    "path": "Y1.Y",
-    "designator": "Y1",
+    "designators": [
+      "Y1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "Y1.Y",
+        "designator": "Y1",
+        "package": "3215_2Pin",
+        "value": "32.768kHz 12.5pF",
+        "description": "32.768kHz 12.5pF",
+        "component_type": "Crystal",
+        "frequency": {
+          "nominal": "32768.000",
+          "min": "32768.000",
+          "max": "32768.000",
+          "unit": "Hertz"
+        },
+        "load_capacitance": {
+          "nominal": "0.0000000000125",
+          "min": "0.0000000000125",
+          "max": "0.0000000000125",
+          "unit": "Farads"
+        },
+        "esr": {
+          "nominal": "70000",
+          "min": "70000",
+          "max": "70000",
+          "unit": "Ohms"
+        }
+      }
+    ],
     "package": "3215_2Pin",
     "value": "32.768kHz 12.5pF",
     "description": "32.768kHz 12.5pF",

--- a/crates/pcbc/tests/snapshots/bom__bom_parametric_generics_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_parametric_generics_json.snap
@@ -40,30 +40,7 @@ Exit Code: 0
           "unit": "Volts"
         }
       }
-    ],
-    "package": "SOD-123",
-    "value": "1A 40V Schottky Rectifier",
-    "description": "1A 40V Schottky Rectifier",
-    "component_type": "Rectifier",
-    "technology": "Schottky",
-    "reverse_voltage": {
-      "nominal": "40",
-      "min": "40",
-      "max": "40",
-      "unit": "Volts"
-    },
-    "forward_current": {
-      "nominal": "1",
-      "min": "1",
-      "max": "1",
-      "unit": "Amperes"
-    },
-    "forward_voltage": {
-      "nominal": "0.500",
-      "min": "0.500",
-      "max": "0.500",
-      "unit": "Volts"
-    }
+    ]
   },
   {
     "designators": [
@@ -92,24 +69,7 @@ Exit Code: 0
           "unit": "Amperes"
         }
       }
-    ],
-    "package": "0402",
-    "value": "LED RED 2V",
-    "description": "LED RED 2V",
-    "component_type": "Led",
-    "color": "red",
-    "forward_voltage": {
-      "nominal": "2",
-      "min": "2",
-      "max": "2",
-      "unit": "Volts"
-    },
-    "forward_current": {
-      "nominal": "0.020",
-      "min": "0.020",
-      "max": "0.020",
-      "unit": "Amperes"
-    }
+    ]
   },
   {
     "designators": [
@@ -150,36 +110,7 @@ Exit Code: 0
           "unit": "Farads"
         }
       }
-    ],
-    "package": "DO-219AB",
-    "value": "5V TVS Diode 400W",
-    "description": "5V TVS Diode 400W",
-    "component_type": "Tvs",
-    "direction": "Unidirectional",
-    "reverse_standoff_voltage": {
-      "nominal": "5",
-      "min": "5",
-      "max": "5",
-      "unit": "Volts"
-    },
-    "reverse_clamping_voltage": {
-      "nominal": "9",
-      "min": "9",
-      "max": "9",
-      "unit": "Volts"
-    },
-    "peak_pulse_power": {
-      "nominal": "400",
-      "min": "400",
-      "max": "400",
-      "unit": "Watts"
-    },
-    "capacitance": {
-      "nominal": "0.000000000030",
-      "min": "0.000000000030",
-      "max": "0.000000000030",
-      "unit": "Farads"
-    }
+    ]
   },
   {
     "designators": [
@@ -207,23 +138,7 @@ Exit Code: 0
           "unit": "Watts"
         }
       }
-    ],
-    "package": "SOD-123",
-    "value": "5.1V Zener 500mW",
-    "description": "5.1V Zener 500mW",
-    "component_type": "Zener",
-    "zener_voltage": {
-      "nominal": "5.1",
-      "min": "5.1",
-      "max": "5.1",
-      "unit": "Volts"
-    },
-    "power": {
-      "nominal": "0.500",
-      "min": "0.500",
-      "max": "0.500",
-      "unit": "Watts"
-    }
+    ]
   },
   {
     "designators": [
@@ -263,35 +178,7 @@ Exit Code: 0
           "unit": "Ohms"
         }
       }
-    ],
-    "package": "0603",
-    "value": "600 500mA 100MHz",
-    "description": "600 500mA 100MHz",
-    "component_type": "FerriteBead",
-    "impedance": {
-      "nominal": "600",
-      "min": "600",
-      "max": "600",
-      "unit": "Ohms"
-    },
-    "frequency": {
-      "nominal": "100000000",
-      "min": "100000000",
-      "max": "100000000",
-      "unit": "Hertz"
-    },
-    "current": {
-      "nominal": "0.500",
-      "min": "0.500",
-      "max": "0.500",
-      "unit": "Amperes"
-    },
-    "dcr": {
-      "nominal": "0.200",
-      "min": "0.200",
-      "max": "0.200",
-      "unit": "Ohms"
-    }
+    ]
   },
   {
     "designators": [
@@ -313,17 +200,7 @@ Exit Code: 0
         "gender": "Male",
         "mount": "THT"
       }
-    ],
-    "package": "PinHeader_1x02_P2.54mm_Vertical",
-    "value": "2.54mm 2 x 1 THT Vertical Male",
-    "description": "2.54mm 2 x 1 THT Vertical Male",
-    "component_type": "PinHeader",
-    "pitch": "2.54mm",
-    "rows": 1,
-    "pins": 2,
-    "orientation": "Vertical",
-    "gender": "Male",
-    "mount": "THT"
+    ]
   },
   {
     "designators": [
@@ -357,29 +234,7 @@ Exit Code: 0
           "unit": "Ohms"
         }
       }
-    ],
-    "package": "0603",
-    "value": "4.7uH 1A",
-    "description": "4.7uH 1A",
-    "component_type": "Inductor",
-    "inductance": {
-      "nominal": "0.0000047",
-      "min": "0.0000047",
-      "max": "0.0000047",
-      "unit": "Henries"
-    },
-    "current": {
-      "nominal": "1",
-      "min": "1",
-      "max": "1",
-      "unit": "Amperes"
-    },
-    "dcr": {
-      "nominal": "0.120",
-      "min": "0.120",
-      "max": "0.120",
-      "unit": "Ohms"
-    }
+    ]
   },
   {
     "designators": [
@@ -407,23 +262,7 @@ Exit Code: 0
           "unit": "Watts"
         }
       }
-    ],
-    "package": "0603",
-    "value": "10k 250mW",
-    "description": "10k 250mW",
-    "component_type": "Resistor",
-    "resistance": {
-      "nominal": "10000",
-      "min": "10000",
-      "max": "10000",
-      "unit": "Ohms"
-    },
-    "power": {
-      "nominal": "0.250",
-      "min": "0.250",
-      "max": "0.250",
-      "unit": "Watts"
-    }
+    ]
   },
   {
     "designators": [
@@ -457,29 +296,7 @@ Exit Code: 0
           "unit": "Ohms"
         }
       }
-    ],
-    "package": "3215_2Pin",
-    "value": "32.768kHz 12.5pF",
-    "description": "32.768kHz 12.5pF",
-    "component_type": "Crystal",
-    "frequency": {
-      "nominal": "32768.000",
-      "min": "32768.000",
-      "max": "32768.000",
-      "unit": "Hertz"
-    },
-    "load_capacitance": {
-      "nominal": "0.0000000000125",
-      "min": "0.0000000000125",
-      "max": "0.0000000000125",
-      "unit": "Farads"
-    },
-    "esr": {
-      "nominal": "70000",
-      "min": "70000",
-      "max": "70000",
-      "unit": "Ohms"
-    }
+    ]
   }
 ]
 --- STDERR ---

--- a/crates/pcbc/tests/snapshots/bom__bom_simple_resistors_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_simple_resistors_json.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/pcbc/tests/bom.rs
-assertion_line: 257
 expression: output
 ---
 Command: pcbc bom boards/SimpleResistors.zen -f json
@@ -9,8 +8,41 @@ Exit Code: 0
 --- STDOUT ---
 [
   {
-    "path": "R1.R",
-    "designator": "R1",
+    "designators": [
+      "R1",
+      "R2"
+    ],
+    "quantity": 2,
+    "members": [
+      {
+        "path": "R1.R",
+        "designator": "R1",
+        "package": "0603",
+        "value": "1k",
+        "description": "1k",
+        "component_type": "Resistor",
+        "resistance": {
+          "nominal": "1000",
+          "min": "1000",
+          "max": "1000",
+          "unit": "Ohms"
+        }
+      },
+      {
+        "path": "R2.R",
+        "designator": "R2",
+        "package": "0603",
+        "value": "1k",
+        "description": "1k",
+        "component_type": "Resistor",
+        "resistance": {
+          "nominal": "1000",
+          "min": "1000",
+          "max": "1000",
+          "unit": "Ohms"
+        }
+      }
+    ],
     "package": "0603",
     "value": "1k",
     "description": "1k",
@@ -23,22 +55,26 @@ Exit Code: 0
     }
   },
   {
-    "path": "R2.R",
-    "designator": "R2",
-    "package": "0603",
-    "value": "1k",
-    "description": "1k",
-    "component_type": "Resistor",
-    "resistance": {
-      "nominal": "1000",
-      "min": "1000",
-      "max": "1000",
-      "unit": "Ohms"
-    }
-  },
-  {
-    "path": "R3.R",
-    "designator": "R3",
+    "designators": [
+      "R3"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "R3.R",
+        "designator": "R3",
+        "package": "0402",
+        "value": "4.7k",
+        "description": "4.7k",
+        "component_type": "Resistor",
+        "resistance": {
+          "nominal": "4700.0",
+          "min": "4700.0",
+          "max": "4700.0",
+          "unit": "Ohms"
+        }
+      }
+    ],
     "package": "0402",
     "value": "4.7k",
     "description": "4.7k",

--- a/crates/pcbc/tests/snapshots/bom__bom_simple_resistors_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_simple_resistors_json.snap
@@ -42,17 +42,7 @@ Exit Code: 0
           "unit": "Ohms"
         }
       }
-    ],
-    "package": "0603",
-    "value": "1k",
-    "description": "1k",
-    "component_type": "Resistor",
-    "resistance": {
-      "nominal": "1000",
-      "min": "1000",
-      "max": "1000",
-      "unit": "Ohms"
-    }
+    ]
   },
   {
     "designators": [
@@ -74,17 +64,7 @@ Exit Code: 0
           "unit": "Ohms"
         }
       }
-    ],
-    "package": "0402",
-    "value": "4.7k",
-    "description": "4.7k",
-    "component_type": "Resistor",
-    "resistance": {
-      "nominal": "4700.0",
-      "min": "4700.0",
-      "max": "4700.0",
-      "unit": "Ohms"
-    }
+    ]
   }
 ]
 --- STDERR ---

--- a/crates/pcbc/tests/snapshots/bom__bom_skip_bom_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_skip_bom_json.snap
@@ -8,14 +8,34 @@ Exit Code: 0
 --- STDOUT ---
 [
   {
-    "path": "normal",
-    "designator": "U1",
+    "designators": [
+      "U1"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "normal",
+        "designator": "U1",
+        "mpn": "RC0603FR-071KL",
+        "manufacturer": "Yageo"
+      }
+    ],
     "mpn": "RC0603FR-071KL",
     "manufacturer": "Yageo"
   },
   {
-    "path": "normal2",
-    "designator": "U2",
+    "designators": [
+      "U2"
+    ],
+    "quantity": 1,
+    "members": [
+      {
+        "path": "normal2",
+        "designator": "U2",
+        "mpn": "RC0603FR-0710KL",
+        "manufacturer": "Yageo"
+      }
+    ],
     "mpn": "RC0603FR-0710KL",
     "manufacturer": "Yageo"
   }

--- a/crates/pcbc/tests/snapshots/bom__bom_skip_bom_json.snap
+++ b/crates/pcbc/tests/snapshots/bom__bom_skip_bom_json.snap
@@ -19,9 +19,7 @@ Exit Code: 0
         "mpn": "RC0603FR-071KL",
         "manufacturer": "Yageo"
       }
-    ],
-    "mpn": "RC0603FR-071KL",
-    "manufacturer": "Yageo"
+    ]
   },
   {
     "designators": [
@@ -35,9 +33,7 @@ Exit Code: 0
         "mpn": "RC0603FR-0710KL",
         "manufacturer": "Yageo"
       }
-    ],
-    "mpn": "RC0603FR-0710KL",
-    "manufacturer": "Yageo"
+    ]
   }
 ]
 --- STDERR ---


### PR DESCRIPTION
Group BOM table and JSON rows by the API-selected offer so compatible components share one row. Preserve each member’s path and line details in JSON, and keep different offers and DNP states separate. Update the eight JSON snapshots to match the grouped output.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1225" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for consumers of `pcb bom -f json` (per-line objects → grouped rows with `members`), while API matching and IPC BOM export still use ungrouped lines.
> 
> **Overview**
> **`pcb bom` table and `-f json` output now share one presentation grouping** so lines that resolve to the same API-selected offer appear as a single row with combined designators, `quantity`, and a `members` array that keeps each path’s authored fields and availability.
> 
> Grouping keys on `selected_offer_id` (plus DNP/`skip_bom`); without match data it still falls back to design identity, with path-specific rows for identity-less entries. Ungrouped lines remain for matching (`pcb-diode-api`) and other release paths; only CLI presentation changes.
> 
> The BOM table reads quantities and per-member availability from grouped rows instead of re-deriving paths from designators. JSON snapshots were updated for the new grouped shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcd85a266d001f0470cf03573bb2392442def5c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->