### PR TITLE
ENG-1444: Centralize geometry accuracy allocation

### DIFF
--- a/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
+++ b/crates/pcb-ir/src/dialects/ipc/balancing_region.rs
@@ -38,6 +38,7 @@ use crate::dialects::ipc::{
     BoardArrayFabricationProfile, Document, Feature, FeatureSpan, LayoutPurpose,
     ProfileOccurrenceRole, ProfileSet, profile_occurrences_for, relief::is_vcut_operation_feature,
 };
+use crate::geom::accuracy::{ErrorAllocation, allocate_error};
 use crate::geom::{ContourSet, FillRule, Paint};
 
 /// Default Euclidean clearance from every protected feature.
@@ -389,16 +390,14 @@ pub fn board_array_balancing_region(
         .board_footprints
         .union(&input.material_removal)?
         .union(&input.support_features)?;
-    // Construction reserves half the budget the inputs were prepared at: the
-    // two offsets that build the region each spend at most a quarter of it,
-    // so every checked quantity stays strictly separated from a constructed
-    // one.
-    let numerical_guard_mm = input
-        .panel_outer
-        .budget()
-        .min(raw_obstacles.budget())
-        .max_error_mm()
-        / 2.0;
+    let numerical_guard_mm = allocate_error(
+        input
+            .panel_outer
+            .budget()
+            .min(raw_obstacles.budget())
+            .max_error_mm(),
+        ErrorAllocation::ConstructionGuard,
+    );
     let construction_clearance_mm = options.clearance_mm + numerical_guard_mm;
     let panel_keep_in = input.panel_outer.disk_erode(construction_clearance_mm)?;
     let obstacle_keep_out = raw_obstacles.disk_dilate(construction_clearance_mm)?;

--- a/crates/pcb-ir/src/geom/accuracy.rs
+++ b/crates/pcb-ir/src/geom/accuracy.rs
@@ -192,7 +192,10 @@ impl GeometryAccuracy {
     }
 
     pub(crate) fn allowance(self, uncertainty_mm: f64) -> Result<f64, AccuracyError> {
-        Ok(self.remaining(uncertainty_mm)? / 4.0)
+        Ok(allocate_error(
+            self.remaining(uncertainty_mm)?,
+            ErrorAllocation::Operation,
+        ))
     }
 
     pub(crate) fn before_transform(
@@ -260,6 +263,35 @@ impl fmt::Display for AccuracyError {
 }
 
 impl std::error::Error for AccuracyError {}
+
+pub(crate) enum ErrorAllocation {
+    Operation,
+    CurveConversion,
+    ConstructionGuard,
+}
+
+/// Allocate approximation targets and construction separation together.
+///
+/// An operation receives a quarter of the remaining budget, leaving room for
+/// later composition and certification. Curve conversion receives an eighth
+/// of that operation allowance; chord flattening gets the rest. The balancing
+/// construction guard is half the total budget: its two construction offsets
+/// each target at most a quarter, separating construction from nominal checks.
+/// These fractions interact; increasing the operation share alone can break
+/// balancing certification.
+///
+/// These are targets, not recorded uncertainty. Callers still charge actual
+/// conversion/join error and coordinate rounding and check the accumulated
+/// total. Spending the full remainder is only appropriate for an explicitly
+/// terminal operation after reserving all of its numerical error; it must not
+/// replace the allowance used by intermediate or certification operations.
+pub(crate) fn allocate_error(budget_mm: f64, allocation: ErrorAllocation) -> f64 {
+    match allocation {
+        ErrorAllocation::Operation => budget_mm / 4.0,
+        ErrorAllocation::CurveConversion => budget_mm / 8.0,
+        ErrorAllocation::ConstructionGuard => budget_mm / 2.0,
+    }
+}
 
 /// Floating arithmetic allowance. Overlay uses an automatic integer grid;
 /// the i64 adapter retains the floating point coordinate precision.

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -28,7 +28,7 @@ use i_overlay::i_float::int::point::IntPoint;
 use i_overlay::mesh::outline::offset::OutlineOffset;
 use i_overlay::mesh::style::{LineJoin as OutlineLineJoin, OutlineStyle};
 
-use crate::geom::accuracy::numerical_error;
+use crate::geom::accuracy::{ErrorAllocation, allocate_error, numerical_error};
 use crate::geom::affine::Affine2;
 use crate::geom::bbox::BBox;
 use crate::geom::dist::{self, Distance};
@@ -54,7 +54,7 @@ fn flatten_contours(contours: &[ContourBuf], accuracy: f64) -> (Vec<Ring>, f64) 
     // the conversion reports, such as a mismatched arc radius, is charged on
     // top rather than squeezed out of the chord tolerance, so an inconsistent
     // arc fails its budget instead of being flattened without bound.
-    let conversion_target = accuracy / 8.0;
+    let conversion_target = allocate_error(accuracy, ErrorAllocation::CurveConversion);
     let (bez_path, conversion_error) =
         crate::geom::path::contours_to_kurbo(contours, conversion_target);
     let curved = bez_path


### PR DESCRIPTION
Centralize the three geometry accuracy allocations in one documented function in pcb-ir. Keep the existing allocation ratios and boundary uncertainty checks unchanged to preserve balancing certification.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->