### PR TITLE
ENG-1442: Pass caller resolution through IPC library paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Preserve caller geometry accuracy through IPC import, relief generation, and export helpers.
 - Migrate registry references in root-level `.zen` files in container workspaces.
 - Make `pcb rectify fix` and `pcb rectify audit` exit non-zero on batch evaluation errors.
 - Report malformed SPICE `PARAMS:` tokens instead of panicking.

--- a/crates/pcb-ipc-wasm/src/lib.rs
+++ b/crates/pcb-ipc-wasm/src/lib.rs
@@ -70,7 +70,10 @@ impl IpcDocument {
     /// The native IPC info JSON summary.
     #[wasm_bindgen(unchecked_return_type = "IpcInfo")]
     pub fn info(&self) -> Result<JsValue, JsError> {
-        to_js(&commands::info::info_json(&self.accessor()).map_err(js_error)?)
+        to_js(
+            &commands::info::info_json(&self.accessor(), Resolution::default())
+                .map_err(js_error)?,
+        )
     }
 
     /// Source layer names accepted by SVG and PNG export.
@@ -122,7 +125,7 @@ impl IpcDocument {
         };
         to_js(
             &dfm::check(
-                self.design().map_err(js_error)?,
+                self.design(resolution).map_err(js_error)?,
                 dfm::CheckRequest {
                     input: self.input.clone(),
                     pdk,
@@ -160,10 +163,10 @@ impl IpcDocument {
         IpcAccessor::new(&self.ipc)
     }
 
-    fn design(&self) -> Result<&ImportedDesign> {
+    fn design(&self, resolution: Resolution) -> Result<&ImportedDesign> {
         if self.imported.get().is_none() {
-            let imported =
-                import_design(&self.ipc).context("failed to import physical PCB design")?;
+            let imported = import_design(&self.ipc, resolution)
+                .context("failed to import physical PCB design")?;
             let _ = self.imported.set(imported);
         }
         Ok(self.imported.get().expect("design was initialized"))
@@ -183,7 +186,7 @@ impl IpcDocument {
             ),
             ExportOptions::Gerber { layout_target, zip } => {
                 let package = manufacturing::build_manufacturing_package(
-                    self.design()?,
+                    self.design(resolution)?,
                     &manufacturing::ManufacturingExportOptions {
                         view: layout_target.artwork_scope(),
                         relief_debug_dir: None,
@@ -205,8 +208,12 @@ impl IpcDocument {
                 layout_target,
             } => {
                 let scope = layout_target.artwork_scope();
-                let geometry =
-                    geometry::render::prepare_layer(self.design()?, &layer, scope, resolution)?;
+                let geometry = geometry::render::prepare_layer(
+                    self.design(resolution)?,
+                    &layer,
+                    scope,
+                    resolution,
+                )?;
                 ExportFile::new(
                     format!("{}.svg", safe_name(&layer)),
                     "image/svg+xml",
@@ -223,8 +230,12 @@ impl IpcDocument {
                 layout_target,
             } => {
                 let scope = layout_target.artwork_scope();
-                let geometry =
-                    geometry::render::prepare_layer(self.design()?, &layer, scope, resolution)?;
+                let geometry = geometry::render::prepare_layer(
+                    self.design(resolution)?,
+                    &layer,
+                    scope,
+                    resolution,
+                )?;
                 ExportFile::new(
                     format!("{}.png", safe_name(&layer)),
                     "image/png",
@@ -240,7 +251,7 @@ impl IpcDocument {
             ExportOptions::Dxf { layout_target } => ExportFile::new(
                 "outline.dxf",
                 "image/vnd.dxf",
-                commands::outline::export_dxf(&self.ipc, layout_target, false)?,
+                commands::outline::export_dxf(&self.ipc, layout_target, false, resolution)?,
             ),
             ExportOptions::Bom {} => ExportFile::new(
                 "bom.json",
@@ -248,7 +259,8 @@ impl IpcDocument {
                 serde_json::to_vec_pretty(&commands::bom::extract_bom_lines(&self.accessor()))?,
             ),
             ExportOptions::Cpl { side, exclude_dnp } => {
-                let placements = placement::extract_single_board_placements(self.design()?)?;
+                let placements =
+                    placement::extract_single_board_placements(self.design(resolution)?)?;
                 ExportFile::new(
                     "placements.csv",
                     "text/csv",
@@ -266,7 +278,11 @@ impl IpcDocument {
                 "ict.csv",
                 "text/csv",
                 commands::ict::emit_ict_csv(
-                    &commands::ict::extract_contacts(&self.ipc, self.design()?, resolution)?,
+                    &commands::ict::extract_contacts(
+                        &self.ipc,
+                        self.design(resolution)?,
+                        resolution,
+                    )?,
                     side,
                 ),
             ),

--- a/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
+++ b/crates/pcb-ipc2581-tools/examples/board_array_balancing_region.rs
@@ -330,7 +330,7 @@ fn main() -> Result<()> {
         bail!("input is not a board array: the IPC root step is not a panel");
     }
 
-    let imported = pcb_ir::import::ipc2581::import_design(&ipc)?;
+    let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution)?;
     let score_lines = board_array_vscore_lines(&imported)
         .context("failed to extract board-array V-score lines")?;
     let (fabrication_profile, relief_debug) =

--- a/crates/pcb-ipc2581-tools/src/accessors/drills.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/drills.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use ipc2581::types::LayerFunction;
 use pcb_ir::dialects::ipc::{ArtworkScope, FeatureKind, PlatingKind};
+use pcb_ir::geom::Resolution;
 use serde::{Deserialize, Serialize};
 
 use super::IpcAccessor;
@@ -55,22 +56,32 @@ pub struct DrillSize {
 
 impl<'a> IpcAccessor<'a> {
     /// Get board-local drill hole statistics with per-type distribution.
-    pub fn board_drill_stats(&self) -> anyhow::Result<Option<DrillStats>> {
-        self.drill_stats_for_view(ArtworkScope::Board)
+    pub fn board_drill_stats(&self, resolution: Resolution) -> anyhow::Result<Option<DrillStats>> {
+        self.drill_stats_for_view(ArtworkScope::Board, resolution)
     }
 
     /// Get array-local drill hole statistics, excluding repeated board drills.
-    pub fn board_array_drill_stats(&self) -> anyhow::Result<Option<DrillStats>> {
-        self.drill_stats_for_view(ArtworkScope::ArrayLocal)
+    pub fn board_array_drill_stats(
+        &self,
+        resolution: Resolution,
+    ) -> anyhow::Result<Option<DrillStats>> {
+        self.drill_stats_for_view(ArtworkScope::ArrayLocal, resolution)
     }
 
     /// Get flattened board-array drill statistics, including repeated board drills
     /// and array-local drill features.
-    pub fn board_array_flattened_drill_stats(&self) -> anyhow::Result<Option<DrillStats>> {
-        self.drill_stats_for_view(ArtworkScope::ArrayFlattened)
+    pub fn board_array_flattened_drill_stats(
+        &self,
+        resolution: Resolution,
+    ) -> anyhow::Result<Option<DrillStats>> {
+        self.drill_stats_for_view(ArtworkScope::ArrayFlattened, resolution)
     }
 
-    fn drill_stats_for_view(&self, view: ArtworkScope) -> anyhow::Result<Option<DrillStats>> {
+    fn drill_stats_for_view(
+        &self,
+        view: ArtworkScope,
+        resolution: Resolution,
+    ) -> anyhow::Result<Option<DrillStats>> {
         let Some(ecad) = self.ecad() else {
             return Ok(None);
         };
@@ -83,7 +94,7 @@ impl<'a> IpcAccessor<'a> {
             }
             has_drill_layer = true;
             let layer_name = self.ipc.resolve(layer.name);
-            let doc = geometry::extract_layer_for_view(self.ipc, layer_name, view)?;
+            let doc = geometry::extract_layer_for_view(self.ipc, layer_name, view, resolution)?;
             collect_drill_info(&doc, &mut collector);
         }
 
@@ -236,16 +247,22 @@ mod tests {
         .unwrap();
         let accessor = IpcAccessor::new(&ipc);
 
-        let board = accessor.board_drill_stats().unwrap().unwrap();
+        let board = accessor
+            .board_drill_stats(Resolution::default())
+            .unwrap()
+            .unwrap();
         assert_eq!(board.total_holes, 1);
         assert_eq!(board.distribution[0].hole_type, DrillHoleType::Via);
 
-        let array = accessor.board_array_drill_stats().unwrap().unwrap();
+        let array = accessor
+            .board_array_drill_stats(Resolution::default())
+            .unwrap()
+            .unwrap();
         assert_eq!(array.total_holes, 1);
         assert_eq!(array.distribution[0].hole_type, DrillHoleType::NonPlated);
 
         let flattened = accessor
-            .board_array_flattened_drill_stats()
+            .board_array_flattened_drill_stats(Resolution::default())
             .unwrap()
             .unwrap();
         assert_eq!(flattened.total_holes, 3);

--- a/crates/pcb-ipc2581-tools/src/assembly/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/assembly/tests.rs
@@ -19,7 +19,7 @@ fn report_xml(xml: &str, target: LayoutTarget) -> report::AssemblyReport {
 
     ipc2581::validate(xml).expect("assembly report fixture conforms to IPC-2581C");
     let ipc = Ipc2581::parse(xml).unwrap();
-    let imported = import_design(&ipc).unwrap();
+    let imported = import_design(&ipc, resolution).unwrap();
     build_report(&imported, target, resolution).unwrap()
 }
 
@@ -781,7 +781,7 @@ fn reports_missing_style_references_without_guessing() {
     let resolution = Resolution::default();
 
     let ipc = Ipc2581::parse(FIXTURE).unwrap();
-    let mut imported = import_design(&ipc).unwrap();
+    let mut imported = import_design(&ipc, resolution).unwrap();
     let void = imported
         .content
         .dictionary_fill_desc
@@ -826,7 +826,7 @@ fn panel_without_root_profile_does_not_invent_an_envelope() {
     xml.replace_range(profile_start..profile_end, "");
     ipc2581::validate(&xml).expect("panel without a Profile conforms to IPC-2581C");
     let ipc = Ipc2581::parse(&xml).unwrap();
-    let imported = import_design(&ipc).unwrap();
+    let imported = import_design(&ipc, resolution).unwrap();
 
     let report = build_report(&imported, LayoutTarget::BoardArray, resolution).unwrap();
 
@@ -895,7 +895,7 @@ fn rejects_non_finite_report_numbers() {
     let resolution = Resolution::default();
 
     let ipc = Ipc2581::parse(FIXTURE).unwrap();
-    let mut imported = import_design(&ipc).unwrap();
+    let mut imported = import_design(&ipc, resolution).unwrap();
     imported.packages[0].source.height = Some(f64::NAN);
 
     let error = build_report(&imported, LayoutTarget::BoardArray, resolution).unwrap_err();
@@ -913,7 +913,7 @@ fn dm0002_excludes_document_objects_from_assembly_work() {
     let compressed = include_bytes!("../../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");
     let xml = zstd::decode_all(Cursor::new(compressed)).unwrap();
     let ipc = Ipc2581::parse(std::str::from_utf8(&xml).unwrap()).unwrap();
-    let imported = import_design(&ipc).unwrap();
+    let imported = import_design(&ipc, resolution).unwrap();
 
     let report = build_report(&imported, LayoutTarget::BoardArray, resolution).unwrap();
 

--- a/crates/pcb-ipc2581-tools/src/board_array.rs
+++ b/crates/pcb-ipc2581-tools/src/board_array.rs
@@ -33,7 +33,7 @@ pub fn render_board_array_overview_svg(
         return Ok(None);
     };
     let array_height = dimensions.height_mm();
-    let imported = import_design(accessor.ipc())?;
+    let imported = import_design(accessor.ipc(), resolution)?;
     let layer_overlays = board_array_layer_overlays(&imported, array_height, resolution)?;
     render_board_array_svg(&imported, board_array, &doc, &layer_overlays, resolution)
 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/balance.rs
@@ -37,7 +37,7 @@ pub fn generate_automatic_board_array_copper_balance(
     tolerance_mm: f64,
 ) -> Result<CopperBalancePlan> {
     let resolution = Resolution::new(tolerance_mm, DenseCopperBalanceProfile::V1.accuracy);
-    let imported = import_design(ipc)?;
+    let imported = import_design(ipc, resolution)?;
     let layout = &imported.geometry;
     let score_lines = geometry::board_array_vscore_lines(&imported)
         .context("failed to extract board-array V-scores for copper balancing")?;

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -411,9 +411,8 @@ pub fn execute(
     output: &Path,
     options: &BoardArrayCreateOptions,
     balance_copper: bool,
+    resolution: Resolution,
 ) -> Result<()> {
-    let resolution = Resolution::default();
-
     let content = file_utils::load_ipc_file(input)?;
     let creation = create_board_array(&content, options, balance_copper, resolution)?;
     print_copper_balance_summary(creation.copper_balance.as_ref());
@@ -503,7 +502,8 @@ pub fn create_auto_board_array(
     resolution: Resolution,
 ) -> Result<BoardArrayCreation> {
     let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
-    let (options, validation_mode, panelization) = auto_board_array_options(&ipc, sheet)?;
+    let (options, validation_mode, panelization) =
+        auto_board_array_options(&ipc, sheet, resolution)?;
     let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization)?;
     write_board_array_creation(xml, spec, balance_copper, resolution)
 }
@@ -521,13 +521,14 @@ fn create_auto_board_array_xml_with_sheet(
 fn auto_board_array_options(
     ipc: &Ipc2581,
     sheet: Option<AutoSheetSize>,
+    resolution: Resolution,
 ) -> Result<(
     BoardArrayCreateOptions,
     BoardArrayValidationMode,
     BoardArrayPanelizationMetadata,
 )> {
     let board = primary_board_layout(ipc)?;
-    let board_margin = auto_board_margin(ipc, board.bbox)?;
+    let board_margin = auto_board_margin(ipc, board.bbox, resolution)?;
     let board_width = board.bbox.width();
     let board_height = board.bbox.height();
 
@@ -578,8 +579,12 @@ fn minimum_single_board_auto_options(board_margin: BoardMarginMm) -> BoardArrayC
     }
 }
 
-fn auto_board_margin(ipc: &Ipc2581, board_bbox: BBox) -> Result<BoardMarginMm> {
-    let safe_bbox = board_bbox.union(board_courtyard_bbox(ipc)?);
+fn auto_board_margin(
+    ipc: &Ipc2581,
+    board_bbox: BBox,
+    resolution: Resolution,
+) -> Result<BoardMarginMm> {
+    let safe_bbox = board_bbox.union(board_courtyard_bbox(ipc, resolution)?);
     Ok(BoardMarginMm {
         top: (safe_bbox.max.y - board_bbox.max.y).max(0.0) + MIN_BOARD_CELL_FIDUCIAL_MARGIN_MM,
         right: (safe_bbox.max.x - board_bbox.max.x).max(0.0) + MIN_BOARD_CELL_FIDUCIAL_MARGIN_MM,
@@ -588,7 +593,7 @@ fn auto_board_margin(ipc: &Ipc2581, board_bbox: BBox) -> Result<BoardMarginMm> {
     })
 }
 
-fn board_courtyard_bbox(ipc: &Ipc2581) -> Result<BBox> {
+fn board_courtyard_bbox(ipc: &Ipc2581, resolution: Resolution) -> Result<BBox> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let mut bbox = BBox::empty();
 
@@ -603,6 +608,7 @@ fn board_courtyard_bbox(ipc: &Ipc2581) -> Result<BBox> {
             ipc,
             layer_name,
             pcb_ir::dialects::ipc::ArtworkScope::Board,
+            resolution,
         )
         .with_context(|| format!("failed to extract IPC-2581 courtyard layer '{layer_name}'"))?;
         for feature in doc

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -21,7 +21,7 @@ use pcb_ir::geom::{BBox, ContourSet, Point};
 use pcb_ir::import::ipc2581::ImportedDesign;
 
 fn design(ipc: &Ipc2581) -> ImportedDesign {
-    pcb_ir::import::ipc2581::import_design(ipc).unwrap()
+    pcb_ir::import::ipc2581::import_design(ipc, Resolution::default()).unwrap()
 }
 
 fn manufacturing_package(
@@ -152,8 +152,13 @@ fn creates_rounded_panel_step_from_board_bbox() {
     assert_point_close(first_instance.bbox.min, Point::new(7.5, 7.5));
     assert_point_close(first_instance.bbox.max, Point::new(17.5, 17.5));
 
-    let vcut =
-        geometry::extract_layer_for_view(&ipc, "V-Score", ArtworkScope::ArrayFlattened).unwrap();
+    let vcut = geometry::extract_layer_for_view(
+        &ipc,
+        "V-Score",
+        ArtworkScope::ArrayFlattened,
+        Resolution::default(),
+    )
+    .unwrap();
     assert!(vcut.features.len() > 24);
     assert!(
         vcut.features
@@ -174,7 +179,8 @@ fn generated_board_array_has_a_certified_safe_balancing_region() {
 
     let input = board_fixture_with_mask_bbox_mm(12.0, 10.0);
     let source = Ipc2581::parse(&input).unwrap();
-    let (options, validation_mode, panelization) = auto_board_array_options(&source, None).unwrap();
+    let (options, validation_mode, panelization) =
+        auto_board_array_options(&source, None, resolution).unwrap();
     let spec = build_board_array_spec(&source, &options, validation_mode, panelization).unwrap();
     // Safe-region discovery runs on the completed but not-yet-balanced array;
     // otherwise the generated balance copper becomes its own obstacle.
@@ -186,9 +192,10 @@ fn generated_board_array_has_a_certified_safe_balancing_region() {
         geometry::board_array_fabrication_profile(&design(&ipc), &layout, &score_lines, resolution)
             .unwrap();
     let ecad = ipc.ecad().unwrap();
-    let support_layers =
-        extract_array_support_layers(&pcb_ir::import::ipc2581::import_design(&ipc).unwrap())
-            .unwrap();
+    let support_layers = extract_array_support_layers(
+        &pcb_ir::import::ipc2581::import_design(&ipc, resolution).unwrap(),
+    )
+    .unwrap();
     let copper_layers = crate::layers::copper_layers(ecad);
 
     let collection = collect_board_array_balancing_input(
@@ -235,7 +242,8 @@ fn board_array_balancing_solves_every_copper_layer() {
     let input = two_layer_board_xml();
     let ipc = Ipc2581::parse(&input).unwrap();
     let sheet = Some(AutoSheetSize::A7);
-    let (options, validation_mode, panelization) = auto_board_array_options(&ipc, sheet).unwrap();
+    let (options, validation_mode, panelization) =
+        auto_board_array_options(&ipc, sheet, resolution).unwrap();
     let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization).unwrap();
     let provisional_xml = write_board_array_xml(&input, &spec).unwrap();
     let provisional = Ipc2581::parse(&provisional_xml).unwrap();
@@ -267,6 +275,10 @@ fn board_array_balancing_solves_every_copper_layer() {
     assert!(bottom.features.is_empty());
 
     for layer in &balance.layers {
+        assert_eq!(
+            layer.result.usable.resolution.accuracy,
+            pcb_ir::geom::GeometryAccuracy::micrometres(50)
+        );
         assert!(
             layer
                 .result
@@ -293,6 +305,17 @@ fn board_array_creation_reports_and_emits_the_balance() {
     let creation =
         create_auto_board_array(&input, Some(AutoSheetSize::A7), true, resolution).unwrap();
     let copper_balance = creation.copper_balance.as_ref().unwrap();
+    let coarser = create_auto_board_array(
+        &input,
+        Some(AutoSheetSize::A7),
+        true,
+        resolution.with_accuracy(pcb_ir::geom::GeometryAccuracy::micrometres(30)),
+    )
+    .unwrap();
+    assert_eq!(
+        serde_json::to_value(&coarser.copper_balance).unwrap(),
+        serde_json::to_value(&creation.copper_balance).unwrap()
+    );
     assert_eq!(copper_balance.layers.len(), 2);
     for report in &copper_balance.layers {
         // Fixed copper, fillable region, and permanently bare area partition
@@ -361,7 +384,8 @@ fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_laye
     // The smallest sheet the board fits: fiducial scoping does not depend on
     // how much panel surrounds it.
     let sheet = Some(AutoSheetSize::A6);
-    let (options, validation_mode, panelization) = auto_board_array_options(&ipc, sheet).unwrap();
+    let (options, validation_mode, panelization) =
+        auto_board_array_options(&ipc, sheet, resolution).unwrap();
     let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization).unwrap();
     let provisional_xml = write_board_array_xml(input, &spec).unwrap();
     let provisional = Ipc2581::parse(&provisional_xml).unwrap();
@@ -375,7 +399,7 @@ fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_laye
     )
     .unwrap();
     let support_layers = extract_array_support_layers(
-        &pcb_ir::import::ipc2581::import_design(&provisional).unwrap(),
+        &pcb_ir::import::ipc2581::import_design(&provisional, resolution).unwrap(),
     )
     .unwrap();
     let copper_layers = crate::layers::copper_layers(provisional.ecad().unwrap());
@@ -523,7 +547,7 @@ fn auto_create_derives_board_margin_from_courtyard_overhang() {
     let input = board_fixture_with_courtyard_overhang_mm();
     let ipc = Ipc2581::parse(input).unwrap();
     let board = primary_board_layout(&ipc).unwrap();
-    let margin = auto_board_margin(&ipc, board.bbox).unwrap();
+    let margin = auto_board_margin(&ipc, board.bbox, Resolution::default()).unwrap();
 
     assert_eq!(
         margin,
@@ -549,7 +573,7 @@ fn auto_create_allows_large_computed_board_margins() {
     let input = board_fixture_with_large_courtyard_overhang_mm();
     let ipc = Ipc2581::parse(input).unwrap();
     let board = primary_board_layout(&ipc).unwrap();
-    let margin = auto_board_margin(&ipc, board.bbox).unwrap();
+    let margin = auto_board_margin(&ipc, board.bbox, Resolution::default()).unwrap();
 
     assert_eq!(
         margin,
@@ -806,7 +830,13 @@ fn board_array_creation_drops_source_board_outline_layer_features() {
 fn board_array_creation_preserves_board_target_geometry() {
     let input = board_fixture_with_top_line_mm();
     let before_ipc = Ipc2581::parse(input).unwrap();
-    let before = geometry::extract_layer_for_view(&before_ipc, "TOP", ArtworkScope::Board).unwrap();
+    let before = geometry::extract_layer_for_view(
+        &before_ipc,
+        "TOP",
+        ArtworkScope::Board,
+        Resolution::default(),
+    )
+    .unwrap();
 
     let xml = create_board_array_xml(
         input,
@@ -819,7 +849,13 @@ fn board_array_creation_preserves_board_target_geometry() {
     )
     .unwrap();
     let after_ipc = Ipc2581::parse(&xml).unwrap();
-    let after = geometry::extract_layer_for_view(&after_ipc, "TOP", ArtworkScope::Board).unwrap();
+    let after = geometry::extract_layer_for_view(
+        &after_ipc,
+        "TOP",
+        ArtworkScope::Board,
+        Resolution::default(),
+    )
+    .unwrap();
 
     assert_eq!(before.features.len(), after.features.len());
     assert_eq!(before.arena.paths.len(), after.arena.paths.len());
@@ -908,16 +944,25 @@ fn generated_array_geometry_writes_fiducials_and_nonplated_holes() {
     assert!(xml.contains(r#"x="20" y="20""#));
 
     let parsed = Ipc2581::parse(&xml).unwrap();
-    let top =
-        geometry::extract_layer_for_view(&parsed, "TOP", ArtworkScope::ArrayFlattened).unwrap();
+    let top = geometry::extract_layer_for_view(
+        &parsed,
+        "TOP",
+        ArtworkScope::ArrayFlattened,
+        Resolution::default(),
+    )
+    .unwrap();
     assert!(top.features.iter().any(|feature| {
         feature.intent.role == FeatureRole::Fiducial
             && feature.fiducial_kind == FiducialKind::Global
     }));
 
-    let drill =
-        geometry::extract_layer_for_view(&parsed, "Array_Drill", ArtworkScope::ArrayFlattened)
-            .unwrap();
+    let drill = geometry::extract_layer_for_view(
+        &parsed,
+        "Array_Drill",
+        ArtworkScope::ArrayFlattened,
+        Resolution::default(),
+    )
+    .unwrap();
     assert_eq!(drill.features.len(), 1);
     assert_eq!(drill.features[0].kind, FeatureKind::Hole);
     assert_eq!(drill.features[0].bucket, FeatureBucket::Cutout);
@@ -1036,8 +1081,13 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
     assert!(xml.matches("<Location ").count() >= void_count);
     assert!(xml.matches("<UserPrimitiveRef").count() < void_count);
 
-    let mut top =
-        geometry::extract_layer_for_view(&parsed, "TOP", ArtworkScope::ArrayFlattened).unwrap();
+    let mut top = geometry::extract_layer_for_view(
+        &parsed,
+        "TOP",
+        ArtworkScope::ArrayFlattened,
+        Resolution::default(),
+    )
+    .unwrap();
     assert!(
         !top.feature_placement_groups.is_empty(),
         "shared IPC Locations should remain a placement group"
@@ -1107,7 +1157,8 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
 
     // The composed Gerber image must match the composed IPC image.
     let ipc_copper = {
-        let imported = pcb_ir::import::ipc2581::import_design(&parsed).unwrap();
+        let imported =
+            pcb_ir::import::ipc2581::import_design(&parsed, Resolution::default()).unwrap();
         imported.composed_layer_image(
             imported.layer_id("TOP").unwrap(),
             pcb_ir::dialects::ipc::ArtworkScope::ArrayFlattened,
@@ -1418,7 +1469,13 @@ fn board_array_creation_adds_board_cell_fiducials_on_top_bottom_margins() {
         &[(3.0, 38.0), (37.0, 38.0), (7.0, 2.0), (33.0, 2.0)],
     );
 
-    let top = geometry::extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened).unwrap();
+    let top = geometry::extract_layer_for_view(
+        &ipc,
+        "TOP",
+        ArtworkScope::ArrayFlattened,
+        Resolution::default(),
+    )
+    .unwrap();
     assert_eq!(
         top.features
             .iter()

--- a/crates/pcb-ipc2581-tools/src/commands/cpl.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/cpl.rs
@@ -13,6 +13,8 @@ use pcb_ir::dialects::assembly::BomCategory;
 use pcb_ir::dialects::placement::{
     Document as PlacementDocument, Placement, PlacementSide, Population,
 };
+#[cfg(feature = "cli")]
+use pcb_ir::geom::Resolution;
 
 #[cfg(feature = "cli")]
 use crate::placement::extract_single_board_placements;
@@ -37,9 +39,9 @@ pub struct CplOptions {
 }
 
 #[cfg(feature = "cli")]
-pub fn execute(file: &Path, options: &CplOptions) -> Result<()> {
+pub fn execute(file: &Path, options: &CplOptions, resolution: Resolution) -> Result<()> {
     let ipc = Ipc2581::parse_file(file)?;
-    let placements = extract_single_board_placements(&import_design(&ipc)?)?;
+    let placements = extract_single_board_placements(&import_design(&ipc, resolution)?)?;
     let cpl = emit_cpl_csv(&placements, options);
 
     if let Some(output) = &options.output {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -326,7 +326,8 @@ fn build_report(file: &Path, options: &CheckOptions, resolution: Resolution) -> 
     let ipc = Ipc2581::parse(&content).context("failed to parse IPC-2581 file")?;
     drop(content);
     drop(input_bytes);
-    let imported = import_design(&ipc).context("failed to import IPC-2581 physical design")?;
+    let imported =
+        import_design(&ipc, resolution).context("failed to import IPC-2581 physical design")?;
     check(
         &imported,
         CheckRequest {
@@ -540,7 +541,7 @@ limit = { minimum = "300 mil" }
         let resolution = Resolution::default();
 
         let ipc = Ipc2581::parse(xml).unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, resolution).unwrap();
         super::check(
             &imported,
             CheckRequest {
@@ -816,7 +817,7 @@ limit = { minimum = "300 mil" }
     fn in_memory_report_keeps_source_identity_and_waiver_dates() {
         let resolution = Resolution::default();
 
-        let imported = import_design(&Ipc2581::parse(BOARD).unwrap()).unwrap();
+        let imported = import_design(&Ipc2581::parse(BOARD).unwrap(), resolution).unwrap();
         let pdk_source = PDK.replace("minimum = 2", "minimum = 3");
         let run = |waivers, day| {
             super::check(
@@ -932,7 +933,7 @@ reason = "old finding"
     fn rejects_oversize_pdk_source() {
         let resolution = Resolution::default();
 
-        let imported = import_design(&Ipc2581::parse(BOARD).unwrap()).unwrap();
+        let imported = import_design(&Ipc2581::parse(BOARD).unwrap(), resolution).unwrap();
         let source = " ".repeat(MAX_PDK_BYTES + 1);
         let error = super::check(
             &imported,
@@ -1076,7 +1077,7 @@ reason = "old finding"
         .unwrap();
         let pdk = pdk::Pdk::parse(PDK).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, resolution).unwrap();
 
         let error = design::Design::extract(&imported, ArtworkScope::Board, &rules, resolution)
             .err()

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/annular_ring.rs
@@ -357,7 +357,7 @@ limit = { minimum = "0.2 mm" }
 
     fn evaluate_pth(ipc: &Ipc2581) -> Evaluation {
         let rule = rule();
-        let imported = pcb_ir::import::ipc2581::import_design(ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(ipc, Resolution::default()).unwrap();
         let design = Design::extract(
             &imported,
             ArtworkScope::Board,
@@ -424,7 +424,7 @@ limit = { minimum = "0.2 mm" }
 </IPC-2581>"#,
         )
         .unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, Resolution::default()).unwrap();
         let middle = imported.layer_id("L1").unwrap();
         assert!(
             imported

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/copper_clearance.rs
@@ -294,7 +294,7 @@ limit = { minimum = "0.15 mm" }
         let ipc = Ipc2581::parse(xml).unwrap();
         let pdk = Pdk::parse(PDK).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, Resolution::default()).unwrap();
         let design = Design::extract(
             &imported,
             ArtworkScope::Board,
@@ -359,7 +359,7 @@ limit = { minimum = "0.15 mm" }
         let ipc = Ipc2581::parse(&xml).unwrap();
         let pdk = Pdk::parse(PDK).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution).unwrap();
 
         let error = Design::extract(&imported, ArtworkScope::Board, &rules, resolution)
             .err()

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/drilled_board_edge_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/drilled_board_edge_clearance.rs
@@ -414,7 +414,7 @@ name = "Test"
     fn check(xml: &str, pdk_source: &str, target: LayoutTarget) -> super::super::super::DfmReport {
         let resolution = Resolution::default();
 
-        let imported = import_design(&Ipc2581::parse(xml).unwrap()).unwrap();
+        let imported = import_design(&Ipc2581::parse(xml).unwrap(), resolution).unwrap();
         super::super::super::check(
             &imported,
             CheckRequest {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_aspect_ratio.rs
@@ -211,7 +211,7 @@ cases = [
         let resolution = Resolution::default();
 
         let ipc = Ipc2581::parse(xml).unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, resolution).unwrap();
         check(
             &imported,
             CheckRequest {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_clearance.rs
@@ -363,7 +363,7 @@ limit = {{ minimum = "0.20 mm" }}
         let ipc = Ipc2581::parse(xml).unwrap();
         let pdk = Pdk::parse(&pdk(hole)).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, Resolution::default()).unwrap();
         let design = Design::extract(
             &imported,
             ArtworkScope::Board,
@@ -419,7 +419,7 @@ limit = {{ minimum = "0.20 mm" }}
         let xml = board("VIA", Some((0, 2)), &[copper(0, Some("N2"), 0.65)]);
         let source = pdk("via");
         let ipc = Ipc2581::parse(&xml).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution).unwrap();
         let checked = crate::commands::dfm::check(
             &imported,
             CheckRequest {
@@ -558,7 +558,7 @@ limit = {{ minimum = "0.20 mm" }}
         let ipc = Ipc2581::parse(&xml).unwrap();
         let pdk = Pdk::parse(&pdk("via")).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution).unwrap();
         let error = Design::extract(&imported, ArtworkScope::Board, &rules, resolution)
             .err()
             .expect("an unknown span must fail closed");
@@ -588,7 +588,8 @@ limit = {{ minimum = "0.20 mm" }}
                 let ipc = Ipc2581::parse(&xml).unwrap();
                 let pdk = Pdk::parse(&pdk("via")).unwrap();
                 let rules = rules::lower(&pdk, None).unwrap();
-                let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+                let imported =
+                    pcb_ir::import::ipc2581::import_design(&ipc, Resolution::default()).unwrap();
                 let design = Design::extract(
                     &imported,
                     ArtworkScope::Board,
@@ -634,7 +635,7 @@ limit = {{ minimum = "0.20 mm" }}
         let ipc = Ipc2581::parse(&xml).unwrap();
         let pdk = Pdk::parse(&source).unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution).unwrap();
         let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
         let results = checks::run(
             &rules,

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/hole_pair_clearance.rs
@@ -194,7 +194,8 @@ mod tests {
                 )
                 .unwrap();
                 let rules = rules::lower(&pdk, None).unwrap();
-                let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+                let imported =
+                    pcb_ir::import::ipc2581::import_design(&ipc, Resolution::default()).unwrap();
                 let design = Design::extract(
                     &imported,
                     ArtworkScope::Board,
@@ -244,7 +245,7 @@ mod tests {
         )
         .unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution).unwrap();
         let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
         let evaluation = evaluate(0.2, HoleClass::Pth, HoleClass::Pth, &design).unwrap();
         assert_eq!(evaluation.measured.len(), 1);

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/plated_slot_enclosure.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/plated_slot_enclosure.rs
@@ -189,7 +189,7 @@ limit = { minimum = "0.2 mm", preferred = "0.3 mm" }
     }
 
     fn check(xml: &str) -> dfm::DfmReport {
-        let imported = import_design(&Ipc2581::parse(xml).unwrap()).unwrap();
+        let imported = import_design(&Ipc2581::parse(xml).unwrap(), Resolution::default()).unwrap();
         dfm::check(
             &imported,
             CheckRequest {
@@ -329,7 +329,8 @@ limit = { minimum = "0.2 mm", preferred = "0.3 mm" }
         let rules = rules::lower(&Pdk::parse(PDK).unwrap(), None).unwrap();
         for span in ["", r#"<Span fromLayer="L0"/>"#, THROUGH] {
             let xml = board(OVAL, [&copper, "", &copper], span);
-            let mut imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
+            let mut imported =
+                import_design(&Ipc2581::parse(&xml).unwrap(), Resolution::default()).unwrap();
             if span == THROUGH {
                 imported.stackups.clear();
             }

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_clearance.rs
@@ -185,7 +185,8 @@ limit = {{ minimum = "0.20 mm" }}
     }
 
     fn check(xml: &str, source: &str, target: LayoutTarget) -> anyhow::Result<report::DfmReport> {
-        let imported = pcb_ir::import::ipc2581::import_design(&Ipc2581::parse(xml)?)?;
+        let imported =
+            pcb_ir::import::ipc2581::import_design(&Ipc2581::parse(xml)?, Resolution::default())?;
         dfm::check(
             &imported,
             CheckRequest {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/checks/slot_width.rs
@@ -122,7 +122,7 @@ mod tests {
         )
         .unwrap();
         let rules = rules::lower(&pdk, None).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution).unwrap();
         let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
         let evaluation = evaluate(0.8, SlotPlating::Plated, &design).unwrap();
         assert_eq!(evaluation.measured.len(), 1);

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -1691,7 +1691,7 @@ mod tests {
             rectangle("POSITIVE", 1.8, 2.2),
         );
         let ipc = Ipc2581::parse(&source).unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, resolution).unwrap();
         let document = imported
             .materialize_layer(
                 imported.layer_id("F.Mask").unwrap(),
@@ -1771,7 +1771,7 @@ mod tests {
             r#"<Location x="10" y="20"/>
               <Oval width="1.8" height="0.6"/>"#,
         );
-        let oval = import_design(&oval).unwrap();
+        let oval = import_design(&oval, resolution).unwrap();
         let (_, slots) = collect_drilled(&oval, ArtworkScope::Board, None, resolution).unwrap();
         assert_eq!(slots.len(), 1);
         assert!((slots[0].width.mm - 0.6).abs() < 1e-9);
@@ -1826,7 +1826,7 @@ mod tests {
                 <LineDesc lineWidth="0" lineEnd="ROUND"/>
               </Outline>"#,
         );
-        let outline = import_design(&outline).unwrap();
+        let outline = import_design(&outline, resolution).unwrap();
         let (_, slots) = collect_drilled(&outline, ArtworkScope::Board, None, resolution).unwrap();
         assert_eq!(slots.len(), 1);
         let width = slots[0].width;
@@ -1862,7 +1862,7 @@ mod tests {
             r#"<Location x="10" y="20"/>
               <Oval width="1.8" height="0.6"/>"#,
         );
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, resolution).unwrap();
         let oval = collect_drilled(&imported, ArtworkScope::Board, None, resolution)
             .unwrap()
             .1

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/scene.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/scene.rs
@@ -402,7 +402,7 @@ mod tests {
 
         let ipc = Ipc2581::parse(MASK_BOARD).unwrap();
         let rules = rules::lower(&pdk::Pdk::parse(MASK_PDK).unwrap(), None).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution).unwrap();
         let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
         let artwork = native_artwork(&design, "F.Mask").unwrap();
         let rendered = pcb_ir::dialects::artwork::compose_to_mask(&artwork, resolution).unwrap();
@@ -443,7 +443,7 @@ mod tests {
 
         let ipc = Ipc2581::parse(MASK_BOARD).unwrap();
         let rules = rules::lower(&pdk::Pdk::parse(MASK_PDK).unwrap(), None).unwrap();
-        let imported = pcb_ir::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution).unwrap();
         let design = Design::extract(&imported, ArtworkScope::Board, &rules, resolution).unwrap();
         let outline = ContourSet::rectangle(
             BBox::new(Point::new(-50.0, -50.0), Point::new(50.0, 50.0)),

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/balance.rs
@@ -38,7 +38,7 @@ pub(super) fn generate_automatic_fab_panel_copper_balance(
     tolerance_mm: f64,
 ) -> Result<CopperBalancePlan> {
     let resolution = Resolution::new(tolerance_mm, DenseCopperBalanceProfile::V1.accuracy);
-    let imported = import_design(ipc)?;
+    let imported = import_design(ipc, resolution)?;
     let layout = &imported.geometry;
     // V-scores and profile cutouts all lie inside the placed assembly panels,
     // so the fabrication profile needs no relief geometry here.

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -223,9 +223,8 @@ pub fn execute(
     output: &Path,
     spec: FabPanelSpec,
     balance_copper: bool,
+    resolution: Resolution,
 ) -> Result<()> {
-    let resolution = Resolution::default();
-
     if inputs.is_empty() {
         bail!("at least one assembly panel IPC-2581 file is required");
     }

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -12,7 +12,7 @@ use pcb_ir::import::ipc2581::ImportedDesign;
 use super::*;
 
 fn design(ipc: &Ipc2581) -> ImportedDesign {
-    pcb_ir::import::ipc2581::import_design(ipc).unwrap()
+    pcb_ir::import::ipc2581::import_design(ipc, Resolution::default()).unwrap()
 }
 
 fn manufacturing_package(
@@ -900,7 +900,7 @@ fn balances_gutters_at_the_assembly_panel_density_and_leaves_margins_bare() {
     let footprints = ContourSet::from_filled_contours(&panel_contours, resolution).unwrap();
     let usable = ContourSet::rectangle(BALANCE_SPEC.usable_bbox().unwrap(), resolution);
     let copper = {
-        let imported = pcb_ir::import::ipc2581::import_design(&parsed).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&parsed, resolution).unwrap();
         imported.composed_layer_image(
             imported.layer_id("TOP").unwrap(),
             pcb_ir::dialects::ipc::ArtworkScope::ArrayFlattened,

--- a/crates/pcb-ipc2581-tools/src/commands/html_export.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/html_export.rs
@@ -23,9 +23,8 @@ pub fn execute(
     input_file: &Path,
     output_file: Option<&Path>,
     unit_format: UnitFormat,
+    resolution: Resolution,
 ) -> Result<()> {
-    let resolution = Resolution::default();
-
     // Load and parse IPC-2581 file
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
@@ -239,7 +238,7 @@ fn extract_board_summary(
                     ),
                 }),
                 drill_holes: accessor
-                    .board_array_drill_stats()?
+                    .board_array_drill_stats(resolution)?
                     .and_then(format_drill_count),
                 overview_svg: array_overview_svg,
             })
@@ -265,7 +264,9 @@ fn extract_board_summary(
 
     let components = accessor.component_stats().map(|stats| stats.total);
     let nets = accessor.net_stats().map(|stats| stats.count);
-    let drill_holes = accessor.board_drill_stats()?.and_then(format_drill_count);
+    let drill_holes = accessor
+        .board_drill_stats(resolution)?
+        .and_then(format_drill_count);
 
     Ok(BoardSummary {
         design_name,
@@ -410,7 +411,7 @@ fn rendered_source_layer(
         has_native_content: false,
     };
 
-    match geometry::extract_layer_for_view(ipc, &name, ArtworkScope::Board) {
+    match geometry::extract_layer_for_view(ipc, &name, ArtworkScope::Board, resolution) {
         Ok(geometry) => render_extracted_layer(
             &mut rendered,
             geometry,

--- a/crates/pcb-ipc2581-tools/src/commands/ict.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/ict.rs
@@ -49,11 +49,9 @@ pub struct IctContact {
 }
 
 #[cfg(feature = "cli")]
-pub fn execute(file: &Path, options: &IctOptions) -> Result<()> {
-    let resolution = Resolution::default();
-
+pub fn execute(file: &Path, options: &IctOptions, resolution: Resolution) -> Result<()> {
     let ipc = Ipc2581::parse_file(file)?;
-    let contacts = extract_contacts(&ipc, &import_design(&ipc)?, resolution)?;
+    let contacts = extract_contacts(&ipc, &import_design(&ipc, resolution)?, resolution)?;
     let csv = emit_ict_csv(&contacts, options.side);
 
     if let Some(output) = &options.output {
@@ -419,7 +417,8 @@ mod tests {
 
         let ipc = Ipc2581::parse(FIXTURE).expect("fixture parses");
         let contacts =
-            extract_contacts(&ipc, &import_design(&ipc).unwrap(), resolution).expect("extracts");
+            extract_contacts(&ipc, &import_design(&ipc, resolution).unwrap(), resolution)
+                .expect("extracts");
 
         assert_eq!(contacts.len(), 1);
         let contact = &contacts[0];

--- a/crates/pcb-ipc2581-tools/src/commands/info.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/info.rs
@@ -12,6 +12,7 @@ use colored::Colorize;
 use comfy_table::presets::UTF8_FULL_CONDENSED;
 #[cfg(feature = "cli")]
 use comfy_table::{Cell, Color, Table};
+use pcb_ir::geom::Resolution;
 use serde::Serialize;
 use serde_json::json;
 
@@ -29,14 +30,19 @@ fn format_diameter(mm: f64) -> String {
 }
 
 #[cfg(feature = "cli")]
-pub fn execute(file: &Path, format: OutputFormat, units: UnitFormat) -> Result<()> {
+pub fn execute(
+    file: &Path,
+    format: OutputFormat,
+    units: UnitFormat,
+    resolution: Resolution,
+) -> Result<()> {
     let content = file_utils::load_ipc_file(file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
     let accessor = IpcAccessor::new(&ipc);
 
     match format {
-        OutputFormat::Text => output_text(&accessor, units),
-        OutputFormat::Json => output_json(&accessor),
+        OutputFormat::Text => output_text(&accessor, units, resolution),
+        OutputFormat::Json => output_json(&accessor, resolution),
     }
 }
 
@@ -153,7 +159,11 @@ fn canonical_soldermask_kind(color: Option<&ColorInfo>) -> SoldermaskKind {
 }
 
 #[cfg(feature = "cli")]
-fn output_text(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<()> {
+fn output_text(
+    accessor: &IpcAccessor,
+    unit_format: UnitFormat,
+    resolution: Resolution,
+) -> Result<()> {
     // Board Summary header
     println!("{}", "Board Summary".bold());
 
@@ -206,7 +216,7 @@ fn output_text(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<()> {
     }
 
     // Drill statistics (summary)
-    if let Some(drills) = accessor.board_drill_stats()?
+    if let Some(drills) = accessor.board_drill_stats(resolution)?
         && drills.total_holes > 0
     {
         summary_table.add_row(vec![
@@ -480,17 +490,17 @@ fn output_text(accessor: &IpcAccessor, unit_format: UnitFormat) -> Result<()> {
     }
 
     // Drill distribution
-    if let Some(drills) = accessor.board_drill_stats()?
+    if let Some(drills) = accessor.board_drill_stats(resolution)?
         && !drills.distribution.is_empty()
     {
         print_drill_distribution("Drill Distribution", &drills);
     }
 
     if let Some(board_array) = layout.and_then(|layout| layout.board_array) {
-        print_board_array_summary(&board_array, accessor, unit_format)?;
+        print_board_array_summary(&board_array, accessor, unit_format, resolution)?;
     }
 
-    if let Some(drills) = accessor.board_array_drill_stats()?
+    if let Some(drills) = accessor.board_array_drill_stats(resolution)?
         && !drills.distribution.is_empty()
     {
         print_drill_distribution("Array Drill Distribution", &drills);
@@ -536,6 +546,7 @@ fn print_board_array_summary(
     board_array: &BoardArrayInfo,
     accessor: &IpcAccessor,
     unit_format: UnitFormat,
+    resolution: Resolution,
 ) -> anyhow::Result<()> {
     println!("{}", "Board Array Summary".bold());
 
@@ -574,7 +585,7 @@ fn print_board_array_summary(
         ]);
     }
 
-    if let Some(drills) = accessor.board_array_drill_stats()?
+    if let Some(drills) = accessor.board_array_drill_stats(resolution)?
         && drills.total_holes > 0
     {
         table.add_row(vec![
@@ -662,13 +673,19 @@ fn drill_stats_json(drills: &DrillStats) -> serde_json::Value {
 }
 
 #[cfg(feature = "cli")]
-fn output_json(accessor: &IpcAccessor) -> Result<()> {
-    println!("{}", serde_json::to_string_pretty(&info_json(accessor)?)?);
+fn output_json(accessor: &IpcAccessor, resolution: Resolution) -> Result<()> {
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&info_json(accessor, resolution)?)?
+    );
     Ok(())
 }
 
 /// Extract the same board, assembly, and fabrication summary emitted by `ipc info --format json`.
-pub fn info_json(accessor: &IpcAccessor) -> anyhow::Result<serde_json::Value> {
+pub fn info_json(
+    accessor: &IpcAccessor,
+    resolution: Resolution,
+) -> anyhow::Result<serde_json::Value> {
     let ipc = accessor.ipc();
     let content = ipc.content();
     let layer_side_map: BTreeMap<_, _> = ipc
@@ -760,7 +777,7 @@ pub fn info_json(accessor: &IpcAccessor) -> anyhow::Result<serde_json::Value> {
                 "height_inch": dimensions.height_inch(),
             });
         }
-        if let Some(drills) = accessor.board_array_drill_stats()?
+        if let Some(drills) = accessor.board_array_drill_stats(resolution)?
             && drills.total_holes > 0
         {
             info["board_array"]["drills"] = drill_stats_json(&drills);
@@ -778,7 +795,7 @@ pub fn info_json(accessor: &IpcAccessor) -> anyhow::Result<serde_json::Value> {
     }
 
     // Drill statistics with distribution
-    if let Some(drills) = accessor.board_drill_stats()?
+    if let Some(drills) = accessor.board_drill_stats(resolution)?
         && drills.total_holes > 0
     {
         info["drills"] = drill_stats_json(&drills);
@@ -960,6 +977,7 @@ pub fn info_json(accessor: &IpcAccessor) -> anyhow::Result<serde_json::Value> {
 mod tests {
     use super::info_json;
     use crate::accessors::IpcAccessor;
+    use pcb_ir::geom::Resolution;
 
     #[test]
     fn component_placements_deduplicate_bom_refdes() {
@@ -999,7 +1017,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let info = info_json(&IpcAccessor::new(&ipc)).unwrap();
+        let info = info_json(&IpcAccessor::new(&ipc), Resolution::default()).unwrap();
         let placements = info["component_placements"].as_array().unwrap();
         assert_eq!(
             placements

--- a/crates/pcb-ipc2581-tools/src/commands/outline.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/outline.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use anyhow::{Result, bail};
 use pcb_ir::dialects::ipc::{ProfileSet, profile_occurrences_for};
+use pcb_ir::geom::Resolution;
 
 use crate::LayoutTarget;
 use crate::geometry;
@@ -25,10 +26,15 @@ pub struct OutlineOptions {
 
 /// Export Step/Profile outlines as a DXF file.
 #[cfg(feature = "cli")]
-pub fn execute(input_file: &Path, options: &OutlineOptions) -> Result<()> {
+pub fn execute(input_file: &Path, options: &OutlineOptions, resolution: Resolution) -> Result<()> {
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = Ipc2581::parse(&content)?;
-    let dxf = export_dxf(&ipc, options.layout_target, options.nested_outlines)?;
+    let dxf = export_dxf(
+        &ipc,
+        options.layout_target,
+        options.nested_outlines,
+        resolution,
+    )?;
     std::fs::write(&options.output, dxf)
         .with_context(|| format!("Failed to write DXF to {}", options.output.display()))?;
     println!(
@@ -43,6 +49,7 @@ pub fn export_dxf(
     ipc: &Ipc2581,
     layout_target: LayoutTarget,
     nested_outlines: bool,
+    resolution: Resolution,
 ) -> Result<String> {
     let layout = geometry::extract_layout(ipc)?;
     let profile_set = if nested_outlines {
@@ -54,7 +61,7 @@ pub fn export_dxf(
         bail!("IPC-2581 primary step and repeated child steps have no board Profile outline");
     }
 
-    geometry::dxf::render_profile_set_dxf(&layout, profile_set)
+    geometry::dxf::render_profile_set_dxf(&layout, profile_set, resolution.accuracy)
 }
 
 #[cfg(test)]

--- a/crates/pcb-ipc2581-tools/src/commands/render.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/render.rs
@@ -20,14 +20,12 @@ pub struct RenderOptions {
 ///
 /// The layer runs through the same normalization Gerber export uses, so a
 /// render and a fabrication file describe the same image.
-pub fn execute(input_file: &Path, options: &RenderOptions) -> Result<()> {
-    let resolution = Resolution::default();
-
+pub fn execute(input_file: &Path, options: &RenderOptions, resolution: Resolution) -> Result<()> {
     let target = resolve_target(options)?;
     let content = file_utils::load_ipc_file(input_file)?;
     let ipc = ipc2581::Ipc2581::parse(&content)?;
     let view = options.layout_target.artwork_scope();
-    let imported = pcb_ir::import::ipc2581::import_design(&ipc)?;
+    let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution)?;
     let geometry = geometry::render::prepare_layer(&imported, &options.layer, view, resolution)?;
 
     match target {

--- a/crates/pcb-ipc2581-tools/src/commands/warp.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/warp.rs
@@ -18,9 +18,7 @@ use crate::warp::WarpAnalysis;
 const SURFACE_MOUNT_LIMIT_PERCENT: f64 = 0.75;
 
 #[cfg(feature = "cli")]
-pub fn execute(file: &Path, report: Option<&Path>) -> Result<()> {
-    let resolution = Resolution::default();
-
+pub fn execute(file: &Path, report: Option<&Path>, resolution: Resolution) -> Result<()> {
     let xml = std::fs::read_to_string(file)
         .with_context(|| format!("failed to read {}", file.display()))?;
     let ipc = Ipc2581::parse(&xml).context("failed to parse IPC-2581 file")?;

--- a/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
+++ b/crates/pcb-ipc2581-tools/src/geometry/dxf.rs
@@ -18,6 +18,7 @@ struct DxfVertex {
 pub fn render_profile_set_dxf<Symbol, LayerFunction>(
     doc: &Document<Symbol, LayerFunction>,
     profile_set: ProfileSet,
+    accuracy: GeometryAccuracy,
 ) -> anyhow::Result<String> {
     let mut dxf = String::new();
     write_header(&mut dxf);
@@ -29,9 +30,10 @@ pub fn render_profile_set_dxf<Symbol, LayerFunction>(
             doc,
             occurrence.profile.outer_path,
             occurrence.transform,
+            accuracy,
         )?;
         for cutout in occurrence.profile.cutouts.slice(&doc.profile_cutouts) {
-            write_path(&mut dxf, doc, cutout.path, occurrence.transform)?;
+            write_path(&mut dxf, doc, cutout.path, occurrence.transform, accuracy)?;
         }
     }
     write_footer(&mut dxf);
@@ -65,9 +67,10 @@ fn write_path<Symbol, LayerFunction>(
     doc: &Document<Symbol, LayerFunction>,
     path_index: u32,
     transform: pcb_ir::geom::Affine2,
+    accuracy: GeometryAccuracy,
 ) -> anyhow::Result<()> {
     for contour in doc.transformed_path_contours(path_index, transform) {
-        let contour = contour.flattened_curves(GeometryAccuracy::default())?;
+        let contour = contour.flattened_curves(accuracy)?;
         write_polyline(dxf, &contour_vertices(&contour));
     }
     Ok(())
@@ -191,7 +194,12 @@ mod tests {
     fn renders_profile_ir_as_mm_dxf_with_closed_outline_layer() {
         let doc = rect_profile_doc();
 
-        let dxf = render_profile_set_dxf(&doc, ProfileSet::FabricationOutlines).unwrap();
+        let dxf = render_profile_set_dxf(
+            &doc,
+            ProfileSet::FabricationOutlines,
+            GeometryAccuracy::default(),
+        )
+        .unwrap();
 
         assert!(dxf.contains("9\n$INSUNITS\n70\n4\n"));
         assert!(dxf.contains("2\nBOARD_OUTLINE\n"));
@@ -218,7 +226,12 @@ mod tests {
             bbox: BBox::empty(),
         });
 
-        let dxf = render_profile_set_dxf(&doc, ProfileSet::FabricationOutlines).unwrap();
+        let dxf = render_profile_set_dxf(
+            &doc,
+            ProfileSet::FabricationOutlines,
+            GeometryAccuracy::default(),
+        )
+        .unwrap();
 
         assert!(dxf.contains("42\n1\n"));
     }

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -1583,7 +1583,7 @@ mod tests {
 
     fn gerber_files(ipc: &Ipc2581, view: ArtworkScope) -> Result<Vec<GerberX2File>> {
         build_gerber_x2_files(
-            &import_design(ipc)?,
+            &import_design(ipc, Resolution::default())?,
             view,
             &GerberExportOptions::default(),
             Resolution::default(),
@@ -1592,7 +1592,7 @@ mod tests {
 
     fn manufacturing_package(ipc: &Ipc2581, view: ArtworkScope) -> Result<ManufacturingPackage> {
         build_manufacturing_package(
-            &import_design(ipc)?,
+            &import_design(ipc, Resolution::default())?,
             &ManufacturingExportOptions {
                 view,
                 relief_debug_dir: None,
@@ -2106,7 +2106,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, Resolution::default()).unwrap();
 
         let filenames = export_layer_plans(&imported, &imported.layer_definitions)
             .into_iter()
@@ -2136,7 +2136,7 @@ mod tests {
         )
         .unwrap();
 
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, Resolution::default()).unwrap();
         let plans = export_layer_plans(&imported, &imported.layer_definitions);
         let outputs = plans
             .iter()
@@ -2267,7 +2267,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, Resolution::default()).unwrap();
 
         let filenames = export_layer_plans(&imported, &imported.layer_definitions)
             .into_iter()
@@ -3246,7 +3246,7 @@ mod tests {
             assert!(svg.contains("<svg"), "{} did not render SVG", file.filename);
         }
 
-        let mut layer = geometry::extract_layer(&ipc, "F.Cu").unwrap();
+        let mut layer = geometry::extract_layer(&ipc, "F.Cu", resolution).unwrap();
         pcb_ir::dialects::ipc::process::compose_for_rendering(&mut layer, resolution).unwrap();
         let artwork = pcb_ir::dialects::ipc::lower_layer_to_artwork(
             &layer,

--- a/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
+++ b/crates/pcb-ipc2581-tools/src/manufacturing/export.rs
@@ -93,7 +93,8 @@ pub fn export_manufacturing_package(
 ) -> Result<ManufacturingPackage> {
     let content = crate::utils::file::load_ipc_file(input_file)?;
     let ipc = ipc::Ipc2581::parse(&content)?;
-    let package = build_manufacturing_package(&import_design(&ipc)?, options, resolution)?;
+    let package =
+        build_manufacturing_package(&import_design(&ipc, resolution)?, options, resolution)?;
     write_manufacturing_package(&package, output)?;
     Ok(package)
 }

--- a/crates/pcb-ipc2581-tools/src/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/placement.rs
@@ -46,7 +46,10 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let placements = extract_single_board_placements(&import_design(&ipc).unwrap()).unwrap();
+        let placements = extract_single_board_placements(
+            &import_design(&ipc, pcb_ir::geom::Resolution::default()).unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(placements.components.len(), 1);
         let component = &placements.components[0];
@@ -61,7 +64,11 @@ mod tests {
         let compressed = include_bytes!("../../ipc2581/tests/data/DM0002-IPC-2518.xml.zst");
         let xml = zstd::decode_all(Cursor::new(compressed)).unwrap();
         let xml = std::str::from_utf8(&xml).unwrap();
-        let imported = import_design(&Ipc2581::parse(xml).unwrap()).unwrap();
+        let imported = import_design(
+            &Ipc2581::parse(xml).unwrap(),
+            pcb_ir::geom::Resolution::default(),
+        )
+        .unwrap();
 
         let placements = extract_single_board_placements(&imported).unwrap();
         assert_eq!(placements.components.len(), 59);
@@ -115,7 +122,10 @@ mod tests {
         )
         .unwrap();
 
-        let error = extract_single_board_placements(&import_design(&ipc).unwrap()).unwrap_err();
+        let error = extract_single_board_placements(
+            &import_design(&ipc, pcb_ir::geom::Resolution::default()).unwrap(),
+        )
+        .unwrap_err();
 
         assert!(
             error

--- a/crates/pcb-ipc2581-tools/src/warp.rs
+++ b/crates/pcb-ipc2581-tools/src/warp.rs
@@ -60,7 +60,7 @@ pub struct WarpAnalysis {
 /// Requires a stackup carrying a thickness for every layer: without it there is
 /// no neutral axis, no lever arms, and nothing to estimate.
 pub fn analyze(ipc: &Ipc2581, resolution: Resolution) -> Result<WarpAnalysis> {
-    let imported = import_design(ipc)?;
+    let imported = import_design(ipc, resolution)?;
     let (stack, copper_names) = physical_stack(ipc)?;
     let conductors = stack.conductor_weights();
     let bounds = panel_bounds(ipc, &imported, resolution)?;

--- a/crates/pcb-ir/src/dialects/ipc/relief.rs
+++ b/crates/pcb-ir/src/dialects/ipc/relief.rs
@@ -49,11 +49,15 @@ pub struct VScoreReliefInput {
 }
 
 impl VScoreReliefInput {
-    pub fn new(board_boundaries: Vec<ContourBuf>, score_lines: Vec<VScoreLine>) -> Self {
+    pub fn new(
+        board_boundaries: Vec<ContourBuf>,
+        score_lines: Vec<VScoreLine>,
+        resolution: Resolution,
+    ) -> Self {
         Self::with_resolution(
             board_boundaries,
             score_lines,
-            Resolution::default().with_tolerance(DEFAULT_RELIEF_TOLERANCE_MM),
+            resolution.with_tolerance(DEFAULT_RELIEF_TOLERANCE_MM),
         )
     }
 
@@ -730,6 +734,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 5.0),
+            Resolution::default(),
         );
 
         let output = vscore_route_reliefs_with_debug(&input).unwrap();
@@ -812,6 +817,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 5.0),
+            Resolution::default(),
         );
         input.score_blockers = vec![rectangle_payload(BBox {
             min: Point::new(0.0, 2.0),
@@ -835,6 +841,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 5.0),
+            Resolution::default(),
         );
         input.score_blockers = vec![rectangle_payload(BBox {
             min: Point::new(4.0, 2.0),
@@ -861,6 +868,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 5.0),
+            Resolution::default(),
         );
 
         let output = vscore_route_reliefs_with_debug(&input).unwrap();
@@ -899,7 +907,11 @@ mod tests {
         ]);
         let mut board_boundary = boundary.clone();
         board_boundary.extend(boundary);
-        let input = VScoreReliefInput::new(board_boundary, rectangle_score_lines(10.0, 5.0));
+        let input = VScoreReliefInput::new(
+            board_boundary,
+            rectangle_score_lines(10.0, 5.0),
+            Resolution::default(),
+        );
 
         let output = vscore_route_reliefs_with_debug(&input).unwrap();
 
@@ -925,6 +937,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             score_lines,
+            Resolution::default(),
         );
 
         assert!(vscore_route_reliefs(&input).unwrap().is_empty());
@@ -932,6 +945,7 @@ mod tests {
 
     #[test]
     fn curved_boundary_creates_closed_dead_space_pocket() {
+        let resolution = Resolution::new(1.0, crate::geom::GeometryAccuracy::micrometres(1));
         let input = VScoreReliefInput::new(
             path(vec![
                 PathCmd::move_to(Point::new(0.0, 0.0)),
@@ -943,12 +957,19 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 10.0),
+            resolution,
         );
 
+        assert_eq!(input.resolution.tolerance_mm, DEFAULT_RELIEF_TOLERANCE_MM);
         let output = vscore_route_reliefs_with_debug(&input).unwrap();
         let relief_contours = &output.relief_contours;
 
         assert!(!relief_contours.is_empty());
+        assert!(
+            relief_contours
+                .iter()
+                .all(|contour| contour.uncertainty_mm <= resolution.accuracy.max_error_mm())
+        );
         assert!(
             relief_contours
                 .iter()
@@ -976,6 +997,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 10.0),
+            Resolution::default(),
         );
 
         let output = vscore_route_reliefs_with_debug(&input).unwrap();
@@ -1015,6 +1037,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 5.0),
+            Resolution::default(),
         );
 
         let output = vscore_route_reliefs_with_debug(&input).unwrap();
@@ -1036,6 +1059,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 10.0),
+            Resolution::default(),
         );
 
         let output = vscore_route_reliefs_with_debug(&input).unwrap();
@@ -1057,6 +1081,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 10.0),
+            Resolution::default(),
         );
 
         let output = vscore_route_reliefs_with_debug(&input).unwrap();
@@ -1084,6 +1109,7 @@ mod tests {
                 PathCmd::close(),
             ]),
             rectangle_score_lines(10.0, 10.0),
+            Resolution::default(),
         );
 
         let output = vscore_route_reliefs_with_debug(&input).unwrap();
@@ -1108,6 +1134,7 @@ mod tests {
                 PathCmd::line_to(Point::new(10.0, 5.0)),
             ]),
             Vec::new(),
+            Resolution::default(),
         );
 
         assert_eq!(

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -739,7 +739,7 @@ fn plating_kind(status: PlatingStatus) -> PlatingKind {
 }
 
 /// Import the complete source design once, retaining step-local geometry.
-pub fn import_design(ipc: &Ipc2581) -> Result<ImportedDesign> {
+pub fn import_design(ipc: &Ipc2581, resolution: Resolution) -> Result<ImportedDesign> {
     let ecad = ipc.ecad().context("IPC-2581 file has no ECAD section")?;
     let mut geometry = extract_layout(ipc)?;
 
@@ -766,6 +766,7 @@ pub fn import_design(ipc: &Ipc2581) -> Result<ImportedDesign> {
                 &ecad.cad_data.layers,
                 source_layer,
                 layer_name,
+                resolution,
             )?;
             if local.features.is_empty() {
                 continue;
@@ -1459,16 +1460,21 @@ impl ImportedDesign {
     }
 }
 
-pub fn extract_layer(ipc: &Ipc2581, layer_name: &str) -> Result<GeometryDocument> {
-    extract_layer_for_view(ipc, layer_name, ArtworkScope::ArrayFlattened)
+pub fn extract_layer(
+    ipc: &Ipc2581,
+    layer_name: &str,
+    resolution: Resolution,
+) -> Result<GeometryDocument> {
+    extract_layer_for_view(ipc, layer_name, ArtworkScope::ArrayFlattened, resolution)
 }
 
 pub fn extract_layer_for_view(
     ipc: &Ipc2581,
     layer_name: &str,
     view: ArtworkScope,
+    resolution: Resolution,
 ) -> Result<GeometryDocument> {
-    let design = import_design(ipc)?;
+    let design = import_design(ipc, resolution)?;
     let layer = design
         .layer_id(layer_name)
         .with_context(|| format!("IPC-2581 layer '{layer_name}' was not found"))?;
@@ -1497,6 +1503,7 @@ pub fn extract_step_layer_local(
     layers: &[Layer],
     layer: &Layer,
     layer_name: &str,
+    resolution: Resolution,
 ) -> Result<GeometryDocument> {
     let content = ipc.content();
     let context = ExtractContext {
@@ -1582,7 +1589,13 @@ pub fn extract_step_layer_local(
                     set_feature,
                     &mut doc,
                 )?;
-                validate_copper_balance_structure(copper_balance, set_feature, &features, &doc)?;
+                validate_copper_balance_structure(
+                    copper_balance,
+                    set_feature,
+                    &features,
+                    &doc,
+                    resolution,
+                )?;
 
                 for mut feature in features {
                     feature.source_step_ref = Some(step.name);
@@ -1825,6 +1838,7 @@ fn validate_copper_balance_structure(
     set_feature: &SetFeature,
     features: &[GeometryFeature],
     doc: &GeometryDocument,
+    resolution: Resolution,
 ) -> Result<()> {
     let Some(void) = metadata.and_then(|metadata| metadata.void) else {
         return Ok(());
@@ -1845,7 +1859,7 @@ fn validate_copper_balance_structure(
     if group.placements.len() != source_group.locations.len() {
         bail!("copper-balance lattice locations did not produce matching placements");
     }
-    validate_copper_balance_void_shape(doc, feature, void)?;
+    validate_copper_balance_void_shape(doc, feature, void, resolution)?;
 
     let lattice = crate::geom::copper_balance::DenseCopperLattice {
         origin: void.lattice_origin,
@@ -1875,6 +1889,7 @@ fn validate_copper_balance_void_shape(
     doc: &GeometryDocument,
     feature: &GeometryFeature,
     metadata: CopperBalanceVoidMetadata,
+    resolution: Resolution,
 ) -> Result<()> {
     let actual = crate::dialects::ipc::contour_flash_aperture(doc, feature)
         .context("copper-balance void is not one filled rigid contour")?;
@@ -1884,7 +1899,7 @@ fn validate_copper_balance_void_shape(
     let expected =
         crate::geom::shapes::rounded_hexagon(metadata.radius_mm, metadata.corner_radius_mm, 0.0)
             .context("copper-balance rounded-hex dimensions are invalid")?;
-    let resolution = Resolution::default().with_tolerance(1e-5);
+    let resolution = resolution.with_tolerance(1e-5);
     let actual = ContourSet::from_contours(&[outline], fill_rule, resolution)?;
     let expected = ContourSet::from_contours(&[expected], FillRule::NonZero, resolution)?;
     let mismatch = actual.difference(&expected)?.area() + expected.difference(&actual)?.area();
@@ -3897,6 +3912,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn void_verification_inherits_accuracy_but_keeps_its_significance() {
+        let metadata = CopperBalanceVoidMetadata {
+            lattice_origin: Point::new(0.0, 0.0),
+            lattice_pitch_mm: 3.0,
+            radius_mm: 1.0,
+            corner_radius_mm: 0.0001,
+        };
+        let outline = shapes::rounded_hexagon(metadata.radius_mm, metadata.corner_radius_mm, 0.0)
+            .unwrap()
+            .with_uncertainty(0.02);
+        let mut doc = GeometryDocument::new();
+        let path = doc.push_path(
+            Paint::Fill {
+                rule: FillRule::NonZero,
+            },
+            [outline],
+        );
+        let mut feature = GeometryFeature::new(FeatureKind::Primitive, GeometryPolarity::Dark);
+        feature.paths = Span::single(path);
+
+        let coarse = Resolution::new(10.0, crate::geom::GeometryAccuracy::micrometres(30));
+        validate_copper_balance_void_shape(&doc, &feature, metadata, coarse).unwrap();
+        let fine = coarse.with_accuracy(crate::geom::GeometryAccuracy::micrometres(10));
+        let error = validate_copper_balance_void_shape(&doc, &feature, metadata, fine).unwrap_err();
+        assert!(error.downcast_ref::<crate::geom::AccuracyError>().is_some());
+    }
+
+    #[test]
     fn maps_all_ipc_line_properties_to_ir_patterns() {
         assert_eq!(map_line_pattern(None), LinePattern::Solid);
         assert_eq!(
@@ -3956,7 +3999,8 @@ mod tests {
         )
         .unwrap();
 
-        let layer = extract_layer_for_view(&ipc, "TOP", ArtworkScope::Board).unwrap();
+        let layer = extract_layer_for_view(&ipc, "TOP", ArtworkScope::Board, Resolution::default())
+            .unwrap();
         let path = &layer.arena.paths[layer.features[0].paths.start as usize];
 
         assert_eq!(path.stroke().unwrap().pattern, LinePattern::Phantom);
@@ -4016,7 +4060,13 @@ mod tests {
         )
         .unwrap();
 
-        let top = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened).unwrap();
+        let top = extract_layer_for_view(
+            &ipc,
+            "TOP",
+            ArtworkScope::ArrayFlattened,
+            Resolution::default(),
+        )
+        .unwrap();
         assert_eq!(top.specs.len(), 1);
         assert_eq!(top.layers[0].spec_refs.count, 1);
         assert_eq!(top.feature_sets.len(), 1);
@@ -4035,7 +4085,13 @@ mod tests {
         assert_eq!(top.features[0].pin_refs.count, 1);
         assert_eq!(ipc.resolve(top.pin_refs[0].pin), "1");
 
-        let vcut = extract_layer_for_view(&ipc, "VCUT", ArtworkScope::ArrayFlattened).unwrap();
+        let vcut = extract_layer_for_view(
+            &ipc,
+            "VCUT",
+            ArtworkScope::ArrayFlattened,
+            Resolution::default(),
+        )
+        .unwrap();
         assert_eq!(vcut.layers[0].spec_refs.count, 1);
         assert_eq!(vcut.feature_sets[0].spec_refs.count, 1);
         assert_eq!(vcut.features[0].intent.domain, FeatureDomain::VCut);
@@ -4602,7 +4658,8 @@ mod tests {
     fn extracts_panel_and_repeated_layer_instances() {
         let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
             .expect("synthetic panel fixture should parse");
-        let doc = extract_layer(&ipc, "TOP").expect("panel layer should extract");
+        let doc =
+            extract_layer(&ipc, "TOP", Resolution::default()).expect("panel layer should extract");
         let layer = &doc.layers[0];
         let features = layer.features.slice(&doc.features);
 
@@ -4652,7 +4709,7 @@ mod tests {
         let imported = {
             let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
                 .expect("synthetic panel fixture should parse");
-            import_design(&ipc).expect("complete design should import")
+            import_design(&ipc, Resolution::default()).expect("complete design should import")
         };
 
         let top = imported.layer_id("TOP").unwrap();
@@ -4771,7 +4828,7 @@ mod tests {
         ipc2581::validate(xml).expect("association fixture conforms to IPC-2581C");
         let ipc = Ipc2581::parse(xml).unwrap();
 
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, Resolution::default()).unwrap();
         assert_eq!(imported.boms.len(), 3);
         assert!(imported.logistic_header.is_some());
         assert!(imported.avl.is_some());
@@ -4903,7 +4960,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, Resolution::default()).unwrap();
         let top = imported.layer_id("TOP").unwrap();
 
         let error = imported
@@ -4952,7 +5009,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, Resolution::default()).unwrap();
         let top = imported.layer_id("TOP").unwrap();
         let document = imported
             .materialize_layer(top, ArtworkScope::ArrayFlattened)
@@ -5000,7 +5057,7 @@ mod tests {
 </IPC-2581>"#,
         )
         .unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, Resolution::default()).unwrap();
 
         let occurrences = imported
             .component_occurrences(ArtworkScope::ArrayFlattened)
@@ -5022,7 +5079,7 @@ mod tests {
         let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
             .expect("synthetic panel fixture should parse");
 
-        let board = extract_layer_for_view(&ipc, "TOP", ArtworkScope::Board)
+        let board = extract_layer_for_view(&ipc, "TOP", ArtworkScope::Board, Resolution::default())
             .expect("board layer should extract");
         let board_layer = &board.layers[0];
         let board_features = board_layer.features.slice(&board.features);
@@ -5038,8 +5095,13 @@ mod tests {
             1
         );
 
-        let panel = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened)
-            .expect("panel layer should extract");
+        let panel = extract_layer_for_view(
+            &ipc,
+            "TOP",
+            ArtworkScope::ArrayFlattened,
+            Resolution::default(),
+        )
+        .expect("panel layer should extract");
         let panel_layer = &panel.layers[0];
         let panel_features = panel_layer.features.slice(&panel.features);
 
@@ -5059,8 +5121,9 @@ mod tests {
     fn step_only_panel_extraction_omits_repeat_graph_expansion() {
         let ipc = ipc2581::Ipc2581::parse(panel_layer_fixture())
             .expect("synthetic panel fixture should parse");
-        let doc = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayLocal)
-            .expect("panel layer should extract");
+        let doc =
+            extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayLocal, Resolution::default())
+                .expect("panel layer should extract");
         let layer = &doc.layers[0];
         let features = layer.features.slice(&doc.features);
 
@@ -5168,8 +5231,13 @@ mod tests {
     fn nested_panel_layer_extraction_materializes_descendant_board_features() {
         let ipc = ipc2581::Ipc2581::parse(nested_panel_fixture())
             .expect("synthetic nested panel fixture should parse");
-        let doc = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened)
-            .expect("nested panel layer should extract");
+        let doc = extract_layer_for_view(
+            &ipc,
+            "TOP",
+            ArtworkScope::ArrayFlattened,
+            Resolution::default(),
+        )
+        .expect("nested panel layer should extract");
         let layer = &doc.layers[0];
         let features = layer.features.slice(&doc.features);
         let centers = features
@@ -5196,8 +5264,13 @@ mod tests {
     fn nested_panel_render_draws_every_descendant_board_instance() {
         let ipc = ipc2581::Ipc2581::parse(nested_panel_fixture())
             .expect("synthetic nested panel fixture should parse");
-        let mut doc = extract_layer_for_view(&ipc, "TOP", ArtworkScope::ArrayFlattened)
-            .expect("nested panel layer should extract");
+        let mut doc = extract_layer_for_view(
+            &ipc,
+            "TOP",
+            ArtworkScope::ArrayFlattened,
+            Resolution::default(),
+        )
+        .expect("nested panel layer should extract");
         crate::dialects::ipc::process::normalize_for_artwork(&mut doc, Resolution::default())
             .unwrap();
 
@@ -5232,7 +5305,7 @@ mod tests {
     fn repeated_panel_traces_keep_distinct_source_sets_after_processing() {
         let ipc = ipc2581::Ipc2581::parse(panel_trace_fixture())
             .expect("synthetic panel fixture should parse");
-        let imported = import_design(&ipc).expect("panel should import");
+        let imported = import_design(&ipc, Resolution::default()).expect("panel should import");
         let mut doc = imported
             .materialize_layer(
                 imported.layer_id("TOP").unwrap(),
@@ -5271,7 +5344,8 @@ mod tests {
     fn extracts_step_profile_and_cutouts_as_physical_board_profiles() {
         let ipc = ipc2581::Ipc2581::parse(profile_fixture())
             .expect("synthetic profile fixture should parse");
-        let doc = extract_layer(&ipc, "TOP").expect("profile outline should extract");
+        let doc = extract_layer(&ipc, "TOP", Resolution::default())
+            .expect("profile outline should extract");
 
         assert_eq!(doc.profiles.len(), 1);
         assert_eq!(doc.profile_cutouts.len(), 1);
@@ -5447,7 +5521,7 @@ mod tests {
         )
         .unwrap();
 
-        let doc = extract_layer(&ipc, "F.Cu_B.Cu_1").unwrap();
+        let doc = extract_layer(&ipc, "F.Cu_B.Cu_1", Resolution::default()).unwrap();
         assert_eq!(doc.features.len(), 1);
 
         let slot = &doc.features[0];
@@ -5511,7 +5585,7 @@ mod tests {
         )
         .unwrap();
 
-        let doc = extract_layer(&ipc, "TOP").unwrap();
+        let doc = extract_layer(&ipc, "TOP", Resolution::default()).unwrap();
         assert_eq!(doc.features.len(), 2);
 
         let unrotated = doc.features[0].bbox;
@@ -5564,7 +5638,7 @@ mod tests {
         )
         .unwrap();
 
-        let doc = extract_layer(&ipc, "F.Mask").unwrap();
+        let doc = extract_layer(&ipc, "F.Mask", Resolution::default()).unwrap();
 
         assert_eq!(doc.features.len(), 1);
         let feature = &doc.features[0];

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -1302,7 +1302,7 @@ mod tests {
     #[test]
     fn domain_queries_do_not_materialize_unrelated_layers() {
         let ipc = Ipc2581::parse(physical_fixture()).unwrap();
-        let mut imported = import_design(&ipc).unwrap();
+        let mut imported = import_design(&ipc, Resolution::default()).unwrap();
         make_paste_artwork_invalid(&mut imported);
 
         assert_eq!(
@@ -1335,7 +1335,7 @@ mod tests {
             "<Layer name=\"PASTE\" layerFunction=\"HOLEFILL\" side=\"TOP\" polarity=\"POSITIVE\"/>",
         );
         let ipc = Ipc2581::parse(&xml).unwrap();
-        let mut imported = import_design(&ipc).unwrap();
+        let mut imported = import_design(&ipc, Resolution::default()).unwrap();
         make_paste_artwork_invalid(&mut imported);
 
         let holes = imported
@@ -1361,7 +1361,7 @@ mod tests {
         );
         Ipc2581::validate(&xml).expect("one-ended drill span conforms to IPC-2581C");
         let ipc = Ipc2581::parse(&xml).unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, Resolution::default()).unwrap();
         let holes = imported
             .physical_holes(ArtworkScope::Board, Resolution::default())
             .unwrap();
@@ -1396,7 +1396,8 @@ mod tests {
                 &format!("<SlotCavity name=\"S1\" platingStatus=\"PLATED\" plusTol=\"0\" minusTol=\"0\"><Location x=\"5\" y=\"5\"/><Oval width=\"2\" height=\"{height}\"/></SlotCavity>"),
             );
             Ipc2581::validate(&xml).unwrap();
-            let imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
+            let imported =
+                import_design(&Ipc2581::parse(&xml).unwrap(), Resolution::default()).unwrap();
             let holes = imported
                 .physical_holes(ArtworkScope::Board, Resolution::default())
                 .unwrap();
@@ -1473,9 +1474,9 @@ mod tests {
   </CadData></Ecad>
 </IPC-2581>"#
             );
-            let imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
             let accuracy = crate::geom::GeometryAccuracy::new(0.001).unwrap();
             let resolution = Resolution::default().with_accuracy(accuracy);
+            let imported = import_design(&Ipc2581::parse(&xml).unwrap(), resolution).unwrap();
             for (scope, count) in [(ArtworkScope::Board, 4), (ArtworkScope::ArrayFlattened, 8)] {
                 let view = imported.physical_view(scope, resolution).unwrap();
                 assert!(view.lands.is_empty(), "all final copper must stay removed");
@@ -1557,7 +1558,8 @@ mod tests {
     fn hole_land_links_follow_physical_order_under_declaration_permutations() {
         for order in [["L0", "L1", "L2"], ["L2", "L0", "L1"], ["L1", "L2", "L0"]] {
             let xml = spanned_slot_fixture(order, true);
-            let imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
+            let imported =
+                import_design(&Ipc2581::parse(&xml).unwrap(), Resolution::default()).unwrap();
             let holes = imported
                 .physical_holes(ArtworkScope::Board, Resolution::default())
                 .unwrap();
@@ -1590,7 +1592,8 @@ mod tests {
         let mut reference = None;
         for order in [["L0", "L1", "L2"], ["L2", "L0", "L1"], ["L1", "L2", "L0"]] {
             let xml = spanned_slot_fixture(order, false);
-            let imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
+            let imported =
+                import_design(&Ipc2581::parse(&xml).unwrap(), Resolution::default()).unwrap();
             let holes = imported
                 .physical_holes(ArtworkScope::Board, Resolution::default())
                 .unwrap();
@@ -1646,12 +1649,13 @@ mod tests {
             ),
         ] {
             let invalid = Ipc2581::parse(&xml.replace(from, to)).unwrap();
-            let error = import_design(&invalid).unwrap_err();
+            let error = import_design(&invalid, Resolution::default()).unwrap_err();
             assert!(error.to_string().contains(message), "{error}");
 
             // The association query must also reject unusable ordering, even when
             // no slot extraction is needed to construct the canonical design.
-            let mut imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
+            let mut imported =
+                import_design(&Ipc2581::parse(&xml).unwrap(), Resolution::default()).unwrap();
             imported.stackups = invalid.ecad().unwrap().cad_data.stackups.clone();
             let error = imported
                 .physical_holes(ArtworkScope::Board, Resolution::default())
@@ -1688,6 +1692,7 @@ mod tests {
                     &cad.layers,
                     layer,
                     name,
+                    Resolution::default(),
                 );
                 if name == "L1" && !z_axis {
                     assert!(
@@ -1727,7 +1732,8 @@ mod tests {
         ] {
             let mut xml = xml.clone();
             xml.replace_range(start..end, stackup);
-            let imported = import_design(&Ipc2581::parse(&xml).unwrap()).unwrap();
+            let imported =
+                import_design(&Ipc2581::parse(&xml).unwrap(), Resolution::default()).unwrap();
             let holes = imported
                 .physical_holes(ArtworkScope::Board, Resolution::default())
                 .unwrap();
@@ -1755,7 +1761,7 @@ mod tests {
     fn derives_exact_physical_terminations_separately_from_paste() {
         Ipc2581::validate(physical_fixture()).expect("fixture conforms to IPC-2581C");
         let ipc = Ipc2581::parse(physical_fixture()).unwrap();
-        let imported = import_design(&ipc).unwrap();
+        let imported = import_design(&ipc, Resolution::default()).unwrap();
         let physical = imported
             .physical_view(ArtworkScope::Board, Resolution::default())
             .unwrap();
@@ -1919,7 +1925,7 @@ mod tests {
     #[test]
     fn physical_preparation_can_refine_retained_source_geometry() {
         let ipc = Ipc2581::parse(physical_fixture()).unwrap();
-        let imported = crate::import::ipc2581::import_design(&ipc).unwrap();
+        let imported = crate::import::ipc2581::import_design(&ipc, Resolution::default()).unwrap();
         let coarse = imported
             .physical_view(ArtworkScope::Board, Resolution::default())
             .unwrap();
@@ -1953,7 +1959,8 @@ mod tests {
     #[test]
     fn headless_preparation_rejects_already_coarse_feature_commands() {
         let ipc = Ipc2581::parse(physical_fixture()).unwrap();
-        let mut imported = crate::import::ipc2581::import_design(&ipc).unwrap();
+        let mut imported =
+            crate::import::ipc2581::import_design(&ipc, Resolution::default()).unwrap();
         let layer = imported.layer_id("TOP").unwrap();
         let occurrence = imported
             .feature_occurrences(layer, ArtworkScope::Board)

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -349,10 +349,10 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             file,
             format,
             units,
-        } => commands::info::execute(&file, format, units),
+        } => commands::info::execute(&file, format, units, resolution),
         Commands::Assembly { file, scope } => {
             let ipc = pcb_ipc2581_tools::ipc2581::Ipc2581::parse_file(&file)?;
-            let imported = pcb_ir::import::ipc2581::import_design(&ipc)?;
+            let imported = pcb_ir::import::ipc2581::import_design(&ipc, resolution)?;
             let report = pcb_ipc2581_tools::assembly::build_report(&imported, scope, resolution)?;
             let output = serde_json::to_vec_pretty(&report)?;
             pcb_ui::write_stdout(|stdout| {
@@ -432,9 +432,11 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             }
             Ok(())
         }
-        Commands::Ict { file, output, side } => {
-            commands::ict::execute(&file, &commands::ict::IctOptions { output, side })
-        }
+        Commands::Ict { file, output, side } => commands::ict::execute(
+            &file,
+            &commands::ict::IctOptions { output, side },
+            resolution,
+        ),
         Commands::Cpl {
             file,
             output,
@@ -447,6 +449,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 side,
                 exclude_dnp,
             },
+            resolution,
         ),
         Commands::Edit { command } => match command {
             EditCommands::Bom {
@@ -509,6 +512,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                             edge_rail_mm,
                         },
                         copper_balance,
+                        resolution,
                     )
                 }
             }
@@ -534,7 +538,13 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                     spec.panel_gap_mm = panel_gap;
                 }
                 spec.emit_usable_area = emit_usable_area;
-                commands::fab_panel::execute(&inputs, &output, spec, copper_balance.resolve(false))
+                commands::fab_panel::execute(
+                    &inputs,
+                    &output,
+                    spec,
+                    copper_balance.resolve(false),
+                    resolution,
+                )
             }
         },
         Commands::View {
@@ -546,7 +556,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
             file,
             output,
             units,
-        } => commands::html_export::execute(&file, output.as_deref(), units),
+        } => commands::html_export::execute(&file, output.as_deref(), units, resolution),
         Commands::Outline {
             file,
             layout_target,
@@ -559,6 +569,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 layout_target,
                 nested_outlines,
             },
+            resolution,
         ),
         Commands::Render {
             file,
@@ -574,6 +585,7 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 format,
                 layout_target,
             },
+            resolution,
         ),
         Commands::Dfm { command } => match command {
             DfmCommands::Check {
@@ -596,7 +608,9 @@ pub fn execute(args: Ipc2581Args) -> anyhow::Result<()> {
                 commands::dfm::CheckOutcome::Failed(error) => Err(error),
             },
         },
-        Commands::Warp { file, report } => commands::warp::execute(&file, report.as_deref()),
+        Commands::Warp { file, report } => {
+            commands::warp::execute(&file, report.as_deref(), resolution)
+        }
         Commands::Gerber {
             file,
             layout_target,

--- a/crates/pcbc/tests/dfm.rs
+++ b/crates/pcbc/tests/dfm.rs
@@ -617,6 +617,7 @@ fn ipc_dfm_geometry_distinguishes_canonical_board_arrays_and_mixed_fab_scope() {
         &sandbox.default_cwd().join("fab.xml"),
         spec,
         false,
+        pcb_ir::geom::Resolution::default(),
     )
     .unwrap();
 


### PR DESCRIPTION
Pass caller resolution through IPC import, relief, rendering, and export helpers so library code does not reset the accuracy budget. Keep significance tolerances, default CLI and wasm behavior, and the copper-balance profile unchanged. Update callers and add coverage for inherited accuracy and fixed copper balancing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1234" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->