### PR TITLE
Add standalone elastic support analysis

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: '24'
 
       - name: Check portable Rust libraries
-        run: cargo check --locked --target wasm32-unknown-unknown -p ipc2581 -p pcb-ir -p gerberx2 -p pcb-ipc2581-tools --no-default-features
+        run: cargo check --locked --target wasm32-unknown-unknown -p ipc2581 -p pcb-ir -p gerberx2 -p pcb-ipc2581-tools -p pcb-elastic --no-default-features
 
       - name: Build IPC WASM package
         run: ./bin/build-wasm-bundle.sh ipc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Add `--accuracy-um` to set the geometry accuracy for Gerber, IPC-2581, and release output.
 - Keep circles and ellipses exact in exports and rendering.
 - Add reusable polygon-boundary, attachment clearance, cutter reachability, and break-removal connectivity queries to `pcb-ir`, with explicit uncertainty and model limitations.
+- Add standalone elastic support analysis with beam and triangular plate elements, explicit stiffness and constraints, and singular-mode diagnostics.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4236,6 +4236,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcb-elastic"
+version = "0.4.51"
+dependencies = [
+ "nalgebra",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "pcb-fmt"
 version = "0.4.51"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,6 +194,11 @@ opt-level = 2
 [profile.dev.package.ipc2581]
 opt-level = 2
 
+# Dense elastic validation/solves must stay practical on refinement fixtures.
+# Keep debug assertions and full checks; optimize only this numerical crate.
+[profile.dev.package.pcb-elastic]
+opt-level = 2
+
 # Test binaries are short-lived and do not need the full debug information that
 # made this workspace's integration-test artifacts hundreds of megabytes each.
 [profile.test]

--- a/crates/pcb-elastic/Cargo.toml
+++ b/crates/pcb-elastic/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "pcb-elastic"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
+description = "Deterministic small-system linear elastic support analysis"
+
+[dependencies]
+nalgebra = { version = "0.35", default-features = false, features = ["std"] }
+thiserror.workspace = true

--- a/crates/pcb-elastic/README.md
+++ b/crates/pcb-elastic/README.md
@@ -1,0 +1,109 @@
+# pcb-elastic
+
+Small deterministic dense linear-elastic analysis, separate from PCB geometry,
+meshing, import, fixtures, materials, support selection and manufacturing limits.
+`pcb-sim` owns SPICE/process integration; `pcb-ir` owns geometry. This crate takes
+only numerical element coordinates and indexed contributions. It does not invent
+another outline, mesh, attachment-search or manufacturing representation.
+
+## Contract
+
+`Model::new(scales, base, tolerances)` assembles immutable base stiffness.
+`evaluate(optional_supports, loads, prescribed)` returns displacement, fᵀu
+compliance, strain energy, Dirichlet reactions, optional support restoring forces,
+free residuals and unsupported eigenmodes with effective-load projections.
+Repeated calls do not accumulate supports. The solver always assembles and solves
+the full system; there is no condensed approximation to validate or hidden pin.
+Contributions must be symmetric positive semidefinite within the caller's explicit
+numerical tolerance. Negative stiffness, invalid input and arithmetic failure are
+errors. Small eigenvalues are reported as unsupported, not replaced by stiffness.
+
+Let S contain the supplied characteristic DOF displacements. On free DOFs solve
+`A q = b`, with `A = S K_ff S`, `b = S (f_f - K_fc u_c)`, `u_f = S q`.
+Use the symmetric eigendecomposition and divide only by supported eigenvalues.
+Rank cutoff is `rank_absolute + rank_relative * max(abs(eigenvalue))`.
+Null-space solutions are minimum-norm in q, **not physical constraints**.
+`SingularCompatible` still means nonunique deformation; `SingularIncompatible`
+means no static equilibrium, and its displacement/compliance are only projected
+diagnostics, never a feasible response. `Inaccurate` means the requested residual
+accuracy was not met; inspect modes even with that status.
+
+Residual norm is measured in scaled free coordinates; relative residual is
+`||Aq-b|| / (||A||_F ||q|| + ||b||)` (zero for the zero system).
+Compatibility separately checks the unsupported load norm against the explicit
+absolute plus relative load tolerance, so soft directions cannot hide imbalance.
+Original-unit free residuals and Dirichlet reactions are returned separately.
+Prescribed nonzero displacements can do work, so fᵀu need not equal twice energy.
+The same ordered finite input is deterministic; eigenbasis signs/rotations within
+repeated eigenspaces are not a portable identity for comparing modes.
+
+Use consistent units, for example N/mm: vertex w in mm, slope dimensionless,
+beam EI in N·mm², plate bending tensor in N·mm, compliance in N·mm. Characteristic
+scales for w and slopes must be explicit and physically coherent. Numerical
+tolerances are not material properties or manufacturing acceptance thresholds.
+
+## Elements and mesh integration
+
+- Euler–Bernoulli bending beam: `[w0, slope0, w1, slope1]`, explicit length/EI.
+- Classical Morley nonconforming Kirchhoff triangle: quadratic w, three vertex
+  displacements followed by normal slopes at midpoints of edges `(0,1),(1,2),(2,0)`.
+  This is the six-DOF nonconforming triangular plate of Morley (1968), implemented
+  directly by interpolation of the complete quadratic polynomial and exact
+  constant-curvature energy. There is no rectangular production alternative.
+
+References: [Morley's original element](https://doi.org/10.1017/S0001925900004546),
+the [DOF definition](https://defelement.org/elements/morley.html), and
+[Li, Guan & Mao's convergence analysis](https://doi.org/10.1016/j.cam.2013.12.024).
+The basis is built in physical coordinates (shifted/scaled for arithmetic), not
+by an incorrect scalar affine pullback of reference normal-derivative DOFs.
+
+For each CCW pcb-ir mesh triangle, pass its three point coordinates. Number one w
+per mesh vertex and one normal-slope DOF per mesh edge, separately within physical
+components. Pick a canonical normal per edge. Pass +1 or -1 relative to the local
+outward normal; neighboring triangles must share the DOF with opposite signs.
+No DOF knowledge belongs in pcb-ir. Boundary vertex displacement and edge slope
+constraints are caller-selected physical boundary conditions.
+
+`MorleyTriangle::attachment(barycentric)` uses barycentric coordinates **only to
+locate** a point, returning the element's quadratic shape rows for `[w, wx, wy]`.
+Kirchhoff rotations about x/y are `[wy, -wx]`. For an explicit support stiffness C
+on those channels and attachment rows H, assemble `Hᵀ C H`; apply generalized
+forces as `Hᵀ f`. Coupling two elements uses the relative-displacement rows from
+both elements in one contribution. This preserves virtual work and includes edge
+slope DOFs; P1 weights are not bending shape functions.
+
+Morley is nonconforming: only vertex w and midpoint normal slopes are shared,
+not complete edge traces. Edge/vertex gradient attachments must name their element
+side; no averaging or hidden attachment policy is supplied. Finite attachment
+footprints require caller-specified integration and physical modeling. Point
+rotational loads/supports can be mesh-sensitive; do not infer physical convergence
+from a single point evaluation. Arbitrary triangular outlines are supported, but
+the material/fixture model and its response convergence remain ENG-1434's work.
+
+## Verification and limitations
+
+`cargo nextest run -p pcb-elastic` runs hand-built matrices/meshes only. Tests cover
+beam analytical tip response and uniform-load refinement; triangle rigid modes,
+quadratic curvature/attachment patch and pressure resultant; manufactured clamped
+plate refinement on perturbed triangles; thickness scaling; optional supports
+against independent full Cholesky solves; prescribed motion, singular compatible
+and incompatible loads, invalid stiffness, and coordinate-unit scaling.
+
+The manufactured solution is `w=x²(1-x)²y²(1-y)²`, with prescribed zero boundary
+w/normal slope, explicit `q=Δ²w`, unit isotropic rigidity and Poisson ratio 0.3
+(test data only). Its exact compliance is `8/3150 + 8/11025`. On perturbed square
+triangulations with 2, 4, 8 and 16 subdivisions per side, absolute compliance
+errors are 0.00887360, 0.00391602, 0.00118878 and 0.000318664. Final vertex RMS
+displacement error is 0.000150938. These demonstrate convergence, not fine-mesh
+engineering accuracy. The beam uniform-load compliance error falls by about 16×
+per halving of mesh size, reaching 3.39084e-7 at eight elements.
+
+The Morley element has no transverse shear variable and therefore no shear
+locking in the thin limit. It is a low-order nonconforming discretization, not a
+thick-plate, shell, membrane, torsion, nonlinear fracture or separation model.
+Coarse meshes can be substantially too compliant. Shape-regular refinement and
+independent physical validation are necessary. Dense O(n²) memory/O(n³) solves
+are intended for small foundation models, not a scalable general FEM platform.
+Pure-Rust nalgebra requires no BLAS, native process, GPU or platform solver.
+Native tests and WASM compilation establish numerical/software behavior only,
+not manufacturing physics or mouse-bite breaking safety.

--- a/crates/pcb-elastic/README.md
+++ b/crates/pcb-elastic/README.md
@@ -15,8 +15,12 @@ free residuals and unsupported eigenmodes with effective-load projections.
 Repeated calls do not accumulate supports. The solver always assembles and solves
 the full system; there is no condensed approximation to validate or hidden pin.
 Contributions must be symmetric positive semidefinite within the caller's explicit
-numerical tolerance. Negative stiffness, invalid input and arithmetic failure are
-errors. Small eigenvalues are reported as unsupported, not replaced by stiffness.
+numerical tolerance. The assembled base and each support-updated matrix are also
+checked before applying constraints: local negative roundoff allowances cannot
+accumulate beyond the global cutoff, even in an all-fixed evaluation. An unchanged
+base is not checked again. Negative stiffness, invalid input and arithmetic failure
+(including overflow of tolerance limits) are errors. Small eigenvalues are reported
+as unsupported, not replaced by stiffness.
 
 Let S contain the supplied characteristic DOF displacements. On free DOFs solve
 `A q = b`, with `A = S K_ff S`, `b = S (f_f - K_fc u_c)`, `u_f = S q`.
@@ -105,5 +109,8 @@ Coarse meshes can be substantially too compliant. Shape-regular refinement and
 independent physical validation are necessary. Dense O(n²) memory/O(n³) solves
 are intended for small foundation models, not a scalable general FEM platform.
 Pure-Rust nalgebra requires no BLAS, native process, GPU or platform solver.
+PSD validation uses its bounded spectral routine; the public eigenvalues-only
+routine has no iteration bound. The workspace optimizes this crate in dev/test
+builds, retaining debug assertions and all validation on refinement fixtures.
 Native tests and WASM compilation establish numerical/software behavior only,
 not manufacturing physics or mouse-bite breaking safety.

--- a/crates/pcb-elastic/src/elements.rs
+++ b/crates/pcb-elastic/src/elements.rs
@@ -1,0 +1,212 @@
+//! Small-deflection bending elements; no material or attachment policy.
+use crate::{DMatrix, DVector, Error};
+
+/// Euler–Bernoulli beam on a local axis, ordered [w₀, dw/dx₀, w₁, dw/dx₁].
+/// `rigidity` is EI (force × length²). No axial or torsional stiffness.
+pub fn beam(length: f64, rigidity: f64) -> Result<DMatrix<f64>, Error> {
+    if !length.is_finite() || length <= 0.0 || !rigidity.is_finite() || rigidity <= 0.0 {
+        return Err(Error::InvalidInput);
+    }
+    let l = length;
+    finite(
+        DMatrix::from_row_slice(
+            4,
+            4,
+            &[
+                12.0,
+                6.0 * l,
+                -12.0,
+                6.0 * l,
+                6.0 * l,
+                4.0 * l * l,
+                -6.0 * l,
+                2.0 * l * l,
+                -12.0,
+                -6.0 * l,
+                12.0,
+                -6.0 * l,
+                6.0 * l,
+                2.0 * l * l,
+                -6.0 * l,
+                4.0 * l * l,
+            ],
+        ) * (rigidity / l.powi(3)),
+    )
+}
+
+/// Morley nonconforming Kirchhoff triangle: quadratic transverse displacement,
+/// three vertex w DOFs followed by three edge-midpoint normal slope DOFs.
+/// Edges are (0,1), (1,2), (2,0). Vertices must be CCW. `normal_signs` are ±1
+/// relative to each directed edge's outward unit normal (dy,-dx)/length.
+/// Adjacent elements MUST use the same global normal and share the edge DOF.
+/// Clamping sets boundary vertex w and boundary edge normal slopes to zero.
+/// Simply supported edges set only boundary vertex w to zero.
+///
+/// This is a nonconforming plate, not a C1 triangle: edge traces of w and
+/// gradient can differ. Attachments evaluate the chosen element's quadratic
+/// field, NOT barycentric/P1 interpolation. A model must explicitly choose a
+/// trace for an attachment on a shared edge. No shear stiffness, hence no
+/// transverse-shear locking; thin-plate assumptions still require validation.
+pub struct MorleyTriangle {
+    vertices: [[f64; 2]; 3],
+    length: f64,
+    area: f64,
+    coefficients: DMatrix<f64>,
+}
+
+/// Rows mapping element DOFs to [w, dw/dx, dw/dy]. Kirchhoff physical rotation
+/// about x is dw/dy, about y is -dw/dx. These are NOT independent rotations.
+pub struct Attachment {
+    pub rows: DMatrix<f64>,
+}
+
+impl MorleyTriangle {
+    pub fn new(vertices: [[f64; 2]; 3], normal_signs: [f64; 3]) -> Result<Self, Error> {
+        if vertices.iter().flatten().any(|x| !x.is_finite())
+            || normal_signs.iter().any(|s| *s != 1.0 && *s != -1.0)
+        {
+            return Err(Error::InvalidInput);
+        }
+        let [a, b, c] = vertices;
+        let twice_area = (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0]);
+        if !twice_area.is_finite() || twice_area <= 0.0 {
+            return Err(Error::InvalidInput);
+        }
+        let length = twice_area.sqrt();
+        let mut matrix = DMatrix::zeros(6, 6);
+        for i in 0..3 {
+            let x = (vertices[i][0] - a[0]) / length;
+            let y = (vertices[i][1] - a[1]) / length;
+            matrix.row_mut(i).copy_from(&basis(x, y).row(0));
+            let j = (i + 1) % 3;
+            let dx = vertices[j][0] - vertices[i][0];
+            let dy = vertices[j][1] - vertices[i][1];
+            let edge_length = dx.hypot(dy);
+            let normal = [
+                normal_signs[i] * dy / edge_length,
+                -normal_signs[i] * dx / edge_length,
+            ];
+            let midpoint = basis(x + dx / (2.0 * length), y + dy / (2.0 * length));
+            matrix
+                .row_mut(3 + i)
+                .copy_from(&((midpoint.row(1) * normal[0] + midpoint.row(2) * normal[1]) / length));
+        }
+        let coefficients = finite(matrix.try_inverse().ok_or(Error::NumericalFailure)?)?;
+        Ok(Self {
+            vertices,
+            length,
+            area: twice_area / 2.0,
+            coefficients,
+        })
+    }
+
+    /// Explicit SPD constitutive tensor for [w,xx, w,yy, 2w,xy], units force
+    /// × length. Isotropic: D·[[1,ν,0],[ν,1,0],[0,0,(1-ν)/2]],
+    /// where D=Et³/(12(1-ν²)). Integration is exact (constant curvatures).
+    pub fn stiffness(&self, bending: &DMatrix<f64>) -> Result<DMatrix<f64>, Error> {
+        if bending.shape() != (3, 3)
+            || bending.iter().any(|x| !x.is_finite())
+            || bending != &bending.transpose()
+            || bending.clone().cholesky().is_none()
+        {
+            return Err(Error::InvalidInput);
+        }
+        let mut curvature = DMatrix::zeros(3, 6);
+        curvature[(0, 3)] = 2.0 / self.length.powi(2);
+        curvature[(1, 5)] = 2.0 / self.length.powi(2);
+        curvature[(2, 4)] = 2.0 / self.length.powi(2);
+        let b = curvature * &self.coefficients;
+        let k = b.transpose() * bending * b * self.area;
+        finite((&k + k.transpose()) * 0.5)
+    }
+
+    /// Element-sided field at an explicit barycentric location. Barycentric
+    /// coordinates locate the point only; the returned shape functions are P2.
+    pub fn attachment(&self, barycentric: [f64; 3]) -> Result<Attachment, Error> {
+        if barycentric
+            .iter()
+            .any(|x| !x.is_finite() || *x < 0.0 || *x > 1.0)
+            || (barycentric.iter().sum::<f64>() - 1.0).abs() > 16.0 * f64::EPSILON
+        {
+            return Err(Error::InvalidInput);
+        }
+        let x = (barycentric[1] * (self.vertices[1][0] - self.vertices[0][0])
+            + barycentric[2] * (self.vertices[2][0] - self.vertices[0][0]))
+            / self.length;
+        let y = (barycentric[1] * (self.vertices[1][1] - self.vertices[0][1])
+            + barycentric[2] * (self.vertices[2][1] - self.vertices[0][1]))
+            / self.length;
+        let mut rows = basis(x, y) * &self.coefficients;
+        rows.row_mut(1).scale_mut(1.0 / self.length);
+        rows.row_mut(2).scale_mut(1.0 / self.length);
+        Ok(Attachment {
+            rows: finite(rows)?,
+        })
+    }
+
+    /// Consistent nodal force from explicit pressure evaluated at global x,y.
+    /// 4×4 Gauss/Duffy rule is exact for pressure polynomials through degree 4
+    /// (P2 shape functions). For other loads the caller owns quadrature error.
+    pub fn pressure_load(&self, pressure: impl Fn([f64; 2]) -> f64) -> Result<DVector<f64>, Error> {
+        let gauss = [
+            (-0.8611363115940526, 0.3478548451374538),
+            (-0.3399810435848563, 0.6521451548625461),
+            (0.3399810435848563, 0.6521451548625461),
+            (0.8611363115940526, 0.3478548451374538),
+        ];
+        let mut force = DVector::<f64>::zeros(6);
+        for (u, wu) in gauss {
+            for (v, wv) in gauss {
+                let (u, v) = ((u + 1.0) / 2.0, (v + 1.0) / 2.0);
+                let bary = [(1.0 - u) * (1.0 - v), u, (1.0 - u) * v];
+                let point =
+                    [0, 1].map(|axis| (0..3).map(|i| bary[i] * self.vertices[i][axis]).sum());
+                let load = pressure(point);
+                if !load.is_finite() {
+                    return Err(Error::InvalidInput);
+                }
+                force += self.attachment(bary)?.rows.row(0).transpose()
+                    * (load * wu * wv * (1.0 - u) * self.area / 2.0);
+            }
+        }
+        if force.iter().any(|x| !x.is_finite()) {
+            return Err(Error::NumericalFailure);
+        }
+        Ok(force)
+    }
+}
+
+fn basis(x: f64, y: f64) -> DMatrix<f64> {
+    DMatrix::from_row_slice(
+        3,
+        6,
+        &[
+            1.0,
+            x,
+            y,
+            x * x,
+            x * y,
+            y * y,
+            0.0,
+            1.0,
+            0.0,
+            2.0 * x,
+            y,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+            0.0,
+            x,
+            2.0 * y,
+        ],
+    )
+}
+
+fn finite(matrix: DMatrix<f64>) -> Result<DMatrix<f64>, Error> {
+    if matrix.iter().any(|x| !x.is_finite()) {
+        Err(Error::NumericalFailure)
+    } else {
+        Ok(matrix)
+    }
+}

--- a/crates/pcb-elastic/src/lib.rs
+++ b/crates/pcb-elastic/src/lib.rs
@@ -1,0 +1,309 @@
+//! Small, dense, linear elastic systems. No geometry, fixture or material policy.
+//!
+//! All quantities use caller-consistent units. With N and mm, displacements are
+//! mm, slopes dimensionless, and compliance is N·mm. Mixed DOFs MUST be scaled
+//! by explicit characteristic displacements for meaningful rank detection.
+//! Singular solutions are minimum-norm representatives in those scaled
+//! coordinates, not physically restrained solutions. Inspect status and modes.
+
+pub mod elements;
+pub use nalgebra::{DMatrix, DVector};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("invalid dimensions, indices, finite values, symmetry, or solver options")]
+    InvalidInput,
+    #[error("stiffness is not positive semidefinite (scaled eigenvalue {0})")]
+    Indefinite(f64),
+    #[error("eigendecomposition did not converge or arithmetic overflowed")]
+    NumericalFailure,
+}
+
+/// An element or optional support in global DOF indices. Repeated indices
+/// within one block are invalid; separate blocks may share any DOFs.
+#[derive(Clone, Debug)]
+pub struct Contribution {
+    pub dofs: Vec<usize>,
+    pub stiffness: DMatrix<f64>,
+}
+
+/// Explicit numerical (not manufacturing) tolerances in scaled coordinates.
+#[derive(Clone, Copy, Debug)]
+pub struct Tolerances {
+    /// Relative eigenvalue cutoff, also used to validate matrix symmetry/PSD.
+    pub rank_relative: f64,
+    /// Absolute eigenvalue cutoff; zero is allowed. No stiffness is added.
+    pub rank_absolute: f64,
+    /// Relative/absolute free equilibrium residual acceptance.
+    pub residual_relative: f64,
+    pub residual_absolute: f64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Status {
+    Stable,
+    SingularCompatible,
+    SingularIncompatible,
+    /// Requested equilibrium accuracy was not achieved. Inspect modes too.
+    Inaccurate,
+}
+
+#[derive(Debug)]
+pub struct Mode {
+    /// Global displacement vector, unit norm before characteristic scaling.
+    pub displacement: DVector<f64>,
+    pub eigenvalue: f64,
+    /// Work of the effective load against this mode.
+    pub load_projection: f64,
+}
+
+#[derive(Debug)]
+pub struct Analysis {
+    pub status: Status,
+    pub displacement: DVector<f64>,
+    /// fᵀu (not twice stored energy when prescribed displacement is nonzero).
+    pub compliance: f64,
+    pub strain_energy: f64,
+    /// Ku-f at prescribed DOFs, zero at all free DOFs.
+    pub reactions: DVector<f64>,
+    /// Restoring forces -K_support u, in each optional contribution's local
+    /// DOF order, in the same order as the input supports.
+    pub support_reactions: Vec<DVector<f64>>,
+    /// Ku-f at free DOFs, zero at prescribed DOFs, in original units.
+    pub residual: DVector<f64>,
+    pub scaled_residual_norm: f64,
+    pub relative_residual: f64,
+    pub unsupported_modes: Vec<Mode>,
+}
+
+/// Immutable assembled base; each evaluation assembles only the additional
+/// supports then performs a full dense solve. O(n²) storage / O(n³) solve;
+/// deliberately no condensation, caching of singular inverses, or hidden pins.
+pub struct Model {
+    stiffness: DMatrix<f64>,
+    scales: DVector<f64>,
+    tolerances: Tolerances,
+}
+
+impl Model {
+    pub fn new(
+        scales: Vec<f64>,
+        base: &[Contribution],
+        tolerances: Tolerances,
+    ) -> Result<Self, Error> {
+        let t = tolerances;
+        if scales.is_empty()
+            || scales.iter().any(|x| !x.is_finite() || *x <= 0.0)
+            || [
+                t.rank_relative,
+                t.rank_absolute,
+                t.residual_relative,
+                t.residual_absolute,
+            ]
+            .iter()
+            .any(|x| !x.is_finite() || *x < 0.0)
+            || t.rank_relative <= 0.0
+            || t.rank_relative >= 1.0
+        {
+            return Err(Error::InvalidInput);
+        }
+        let mut model = Self {
+            stiffness: DMatrix::zeros(scales.len(), scales.len()),
+            scales: DVector::from_vec(scales),
+            tolerances,
+        };
+        assemble(&mut model.stiffness, base, &model.scales, t)?;
+        Ok(model)
+    }
+
+    /// Prescribed displacement pairs are physical Dirichlet conditions.
+    /// Optional supports are elastic contributions, not implicit constraints.
+    pub fn evaluate(
+        &self,
+        supports: &[Contribution],
+        loads: &[f64],
+        prescribed: &[(usize, f64)],
+    ) -> Result<Analysis, Error> {
+        let n = self.scales.len();
+        if loads.len() != n || loads.iter().any(|x| !x.is_finite()) {
+            return Err(Error::InvalidInput);
+        }
+        let mut k = self.stiffness.clone();
+        assemble(&mut k, supports, &self.scales, self.tolerances)?;
+        let mut fixed = vec![false; n];
+        let mut u = DVector::zeros(n);
+        for &(i, value) in prescribed {
+            if i >= n || fixed[i] || !value.is_finite() {
+                return Err(Error::InvalidInput);
+            }
+            fixed[i] = true;
+            u[i] = value;
+        }
+        let free: Vec<_> = (0..n).filter(|&i| !fixed[i]).collect();
+        let f = DVector::from_column_slice(loads);
+        let effective = &f - &k * &u;
+        let a = DMatrix::from_fn(free.len(), free.len(), |i, j| {
+            k[(free[i], free[j])] * self.scales[free[i]] * self.scales[free[j]]
+        });
+        let b = DVector::from_iterator(
+            free.len(),
+            free.iter().map(|&i| effective[i] * self.scales[i]),
+        );
+        let mut modes = Vec::new();
+        let mut q = DVector::zeros(free.len());
+        if !free.is_empty() {
+            let eigen = spectrum(a.clone())?;
+            let cutoff = cutoff(&eigen.eigenvalues, self.tolerances);
+            for j in 0..free.len() {
+                let value = eigen.eigenvalues[j];
+                let v = eigen.eigenvectors.column(j);
+                let projection = v.dot(&b);
+                if value < -cutoff {
+                    return Err(Error::Indefinite(value));
+                }
+                if value <= cutoff {
+                    let mut displacement = DVector::zeros(n);
+                    for (i, &dof) in free.iter().enumerate() {
+                        displacement[dof] = v[i] * self.scales[dof];
+                    }
+                    modes.push(Mode {
+                        displacement,
+                        eigenvalue: value,
+                        load_projection: projection,
+                    });
+                } else {
+                    q.axpy(projection / value, &v, 1.0);
+                }
+            }
+        }
+        for (i, &dof) in free.iter().enumerate() {
+            u[dof] = q[i] * self.scales[dof];
+        }
+        let imbalance = &k * &u - &f;
+        let reactions = DVector::from_fn(n, |i, _| if fixed[i] { imbalance[i] } else { 0.0 });
+        let residual = DVector::from_fn(n, |i, _| if fixed[i] { 0.0 } else { imbalance[i] });
+        let scaled_residual_norm = (&a * &q - &b).norm();
+        let denominator = a.norm() * q.norm() + b.norm();
+        let relative_residual = if denominator == 0.0 {
+            0.0
+        } else {
+            scaled_residual_norm / denominator
+        };
+        let accurate = scaled_residual_norm
+            <= self.tolerances.residual_absolute + self.tolerances.residual_relative * denominator;
+        // Compatibility uses load scale, not ||A||||q||: a soft supported
+        // direction must not hide a finite load on an unsupported direction.
+        let unsupported_load =
+            DVector::from_iterator(modes.len(), modes.iter().map(|m| m.load_projection)).norm();
+        let compatible = unsupported_load
+            <= self.tolerances.residual_absolute + self.tolerances.residual_relative * b.norm();
+        let status = match (modes.is_empty(), compatible, accurate) {
+            (false, false, _) => Status::SingularIncompatible,
+            (_, _, false) => Status::Inaccurate,
+            (true, _, true) => Status::Stable,
+            (false, true, true) => Status::SingularCompatible,
+        };
+        let support_reactions: Vec<_> = supports
+            .iter()
+            .map(|s| {
+                let local = DVector::from_iterator(s.dofs.len(), s.dofs.iter().map(|&i| u[i]));
+                -((&s.stiffness + s.stiffness.transpose()) * 0.5) * local
+            })
+            .collect();
+        let compliance = f.dot(&u);
+        let strain_energy = 0.5 * u.dot(&(&k * &u));
+        if u.iter()
+            .chain(reactions.iter())
+            .chain(residual.iter())
+            .chain(support_reactions.iter().flat_map(|r| r.iter()))
+            .any(|x| !x.is_finite())
+            || [
+                compliance,
+                strain_energy,
+                scaled_residual_norm,
+                relative_residual,
+                denominator,
+            ]
+            .iter()
+            .any(|x| !x.is_finite())
+        {
+            return Err(Error::NumericalFailure);
+        }
+        Ok(Analysis {
+            status,
+            displacement: u,
+            compliance,
+            strain_energy,
+            reactions,
+            support_reactions,
+            residual,
+            scaled_residual_norm,
+            relative_residual,
+            unsupported_modes: modes,
+        })
+    }
+}
+
+fn spectrum(
+    a: DMatrix<f64>,
+) -> Result<nalgebra::linalg::SymmetricEigen<f64, nalgebra::Dyn>, Error> {
+    if a.iter().any(|x| !x.is_finite()) {
+        return Err(Error::NumericalFailure);
+    }
+    nalgebra::linalg::SymmetricEigen::try_new(a, f64::EPSILON, 100_000)
+        .filter(|e| {
+            e.eigenvalues
+                .iter()
+                .chain(e.eigenvectors.iter())
+                .all(|x| x.is_finite())
+        })
+        .ok_or(Error::NumericalFailure)
+}
+
+fn cutoff(values: &DVector<f64>, t: Tolerances) -> f64 {
+    t.rank_absolute + t.rank_relative * values.amax()
+}
+
+fn assemble(
+    k: &mut DMatrix<f64>,
+    blocks: &[Contribution],
+    scales: &DVector<f64>,
+    t: Tolerances,
+) -> Result<(), Error> {
+    for block in blocks {
+        let m = block.dofs.len();
+        if m == 0
+            || block.stiffness.shape() != (m, m)
+            || block
+                .dofs
+                .iter()
+                .enumerate()
+                .any(|(i, &d)| d >= k.nrows() || block.dofs[..i].contains(&d))
+            || block.stiffness.iter().any(|x| !x.is_finite())
+        {
+            return Err(Error::InvalidInput);
+        }
+        let scaled = DMatrix::from_fn(m, m, |i, j| {
+            block.stiffness[(i, j)] * scales[block.dofs[i]] * scales[block.dofs[j]]
+        });
+        if (&scaled - scaled.transpose()).amax() > t.rank_absolute + t.rank_relative * scaled.amax()
+        {
+            return Err(Error::InvalidInput);
+        }
+        let eigen = spectrum((&scaled + scaled.transpose()) * 0.5)?;
+        let min = eigen.eigenvalues.min();
+        if min < -cutoff(&eigen.eigenvalues, t) {
+            return Err(Error::Indefinite(min));
+        }
+        for (i, &di) in block.dofs.iter().enumerate() {
+            for (j, &dj) in block.dofs.iter().enumerate() {
+                k[(di, dj)] += (block.stiffness[(i, j)] + block.stiffness[(j, i)]) * 0.5;
+            }
+        }
+    }
+    if k.iter().any(|x| !x.is_finite()) {
+        return Err(Error::NumericalFailure);
+    }
+    Ok(())
+}

--- a/crates/pcb-elastic/src/lib.rs
+++ b/crates/pcb-elastic/src/lib.rs
@@ -154,7 +154,7 @@ impl Model {
         let mut q = DVector::zeros(free.len());
         if !free.is_empty() {
             let eigen = spectrum(a.clone())?;
-            let cutoff = cutoff(&eigen.eigenvalues, self.tolerances);
+            let cutoff = cutoff(eigen.eigenvalues.amax(), self.tolerances)?;
             for j in 0..free.len() {
                 let value = eigen.eigenvalues[j];
                 let v = eigen.eigenvectors.column(j);
@@ -191,13 +191,21 @@ impl Model {
             scaled_residual_norm / denominator
         };
         let accurate = scaled_residual_norm
-            <= self.tolerances.residual_absolute + self.tolerances.residual_relative * denominator;
+            <= tolerance_limit(
+                self.tolerances.residual_absolute,
+                self.tolerances.residual_relative,
+                denominator,
+            )?;
         // Compatibility uses load scale, not ||A||||q||: a soft supported
         // direction must not hide a finite load on an unsupported direction.
         let unsupported_load =
             DVector::from_iterator(modes.len(), modes.iter().map(|m| m.load_projection)).norm();
         let compatible = unsupported_load
-            <= self.tolerances.residual_absolute + self.tolerances.residual_relative * b.norm();
+            <= tolerance_limit(
+                self.tolerances.residual_absolute,
+                self.tolerances.residual_relative,
+                b.norm(),
+            )?;
         let status = match (modes.is_empty(), compatible, accurate) {
             (false, false, _) => Status::SingularIncompatible,
             (_, _, false) => Status::Inaccurate,
@@ -261,8 +269,27 @@ fn spectrum(
         .ok_or(Error::NumericalFailure)
 }
 
-fn cutoff(values: &DVector<f64>, t: Tolerances) -> f64 {
-    t.rank_absolute + t.rank_relative * values.amax()
+fn tolerance_limit(absolute: f64, relative: f64, scale: f64) -> Result<f64, Error> {
+    let limit = absolute + relative * scale;
+    if limit.is_finite() {
+        Ok(limit)
+    } else {
+        Err(Error::NumericalFailure)
+    }
+}
+
+fn cutoff(scale: f64, t: Tolerances) -> Result<f64, Error> {
+    tolerance_limit(t.rank_absolute, t.rank_relative, scale)
+}
+
+fn validate_psd(matrix: DMatrix<f64>, t: Tolerances) -> Result<(), Error> {
+    let eigen = spectrum(matrix)?;
+    let min = eigen.eigenvalues.min();
+    if min < -cutoff(eigen.eigenvalues.amax(), t)? {
+        Err(Error::Indefinite(min))
+    } else {
+        Ok(())
+    }
 }
 
 fn assemble(
@@ -287,15 +314,10 @@ fn assemble(
         let scaled = DMatrix::from_fn(m, m, |i, j| {
             block.stiffness[(i, j)] * scales[block.dofs[i]] * scales[block.dofs[j]]
         });
-        if (&scaled - scaled.transpose()).amax() > t.rank_absolute + t.rank_relative * scaled.amax()
-        {
+        if (&scaled - scaled.transpose()).amax() > cutoff(scaled.amax(), t)? {
             return Err(Error::InvalidInput);
         }
-        let eigen = spectrum((&scaled + scaled.transpose()) * 0.5)?;
-        let min = eigen.eigenvalues.min();
-        if min < -cutoff(&eigen.eigenvalues, t) {
-            return Err(Error::Indefinite(min));
-        }
+        validate_psd((&scaled + scaled.transpose()) * 0.5, t)?;
         for (i, &di) in block.dofs.iter().enumerate() {
             for (j, &dj) in block.dofs.iter().enumerate() {
                 k[(di, dj)] += (block.stiffness[(i, j)] + block.stiffness[(j, i)]) * 0.5;
@@ -304,6 +326,17 @@ fn assemble(
     }
     if k.iter().any(|x| !x.is_finite()) {
         return Err(Error::NumericalFailure);
+    }
+    // Block-local roundoff allowances can accumulate beyond the global
+    // tolerance. Validate before imposing any physical constraints, including
+    // all-fixed evaluations. An unchanged, already validated base needs no work.
+    if !blocks.is_empty() {
+        validate_psd(
+            DMatrix::from_fn(k.nrows(), k.ncols(), |i, j| {
+                k[(i, j)] * scales[i] * scales[j]
+            }),
+            t,
+        )?;
     }
     Ok(())
 }

--- a/crates/pcb-elastic/tests/analysis.rs
+++ b/crates/pcb-elastic/tests/analysis.rs
@@ -454,3 +454,53 @@ fn rank_cutoff_reports_soft_modes_and_never_masks_unsupported_load() {
     assert_eq!(r.displacement.norm(), 0.0);
     close(r.scaled_residual_norm, 1.0, 1e-15);
 }
+
+#[test]
+fn accumulated_negative_stiffness_is_rejected_before_constraints() {
+    let first = block(DMatrix::from_diagonal(&DVector::from_vec(vec![
+        1.0, -6e-12, 0.0,
+    ])));
+    let second = block(DMatrix::from_diagonal(&DVector::from_vec(vec![
+        0.0, -6e-12, 1.0,
+    ])));
+    // Each negative direction is within the explicit 1e-11 relative cutoff,
+    // but their sum exceeds the cutoff of the complete assembled matrix.
+    let model = Model::new(vec![1.0; 3], std::slice::from_ref(&first), tolerances()).unwrap();
+    Model::new(vec![1.0; 3], std::slice::from_ref(&second), tolerances()).unwrap();
+    assert!(matches!(
+        Model::new(vec![1.0; 3], &[first, second.clone()], tolerances()),
+        Err(Error::Indefinite(_))
+    ));
+    for prescribed in [vec![], vec![(0, 0.0), (1, 0.0), (2, 0.0)]] {
+        assert!(matches!(
+            model.evaluate(std::slice::from_ref(&second), &[0.0; 3], &prescribed),
+            Err(Error::Indefinite(_))
+        ));
+    }
+}
+
+#[test]
+fn finite_tolerance_overflow_is_a_numerical_failure() {
+    let mut t = tolerances();
+    t.rank_absolute = f64::MAX;
+    t.rank_relative = 0.75;
+    let k = block(DMatrix::from_element(1, 1, 1e307));
+    assert!(matches!(
+        Model::new(vec![1.0], std::slice::from_ref(&k), t),
+        Err(Error::NumericalFailure)
+    ));
+    let model = Model::new(vec![1.0], &[], t).unwrap();
+    assert!(matches!(
+        model.evaluate(&[k], &[0.0], &[(0, 0.0)]),
+        Err(Error::NumericalFailure)
+    ));
+
+    let mut t = tolerances();
+    t.residual_absolute = f64::MAX;
+    t.residual_relative = f64::MAX;
+    let model = Model::new(vec![1.0], &[block(DMatrix::identity(1, 1))], t).unwrap();
+    assert!(matches!(
+        model.evaluate(&[], &[1.0], &[]),
+        Err(Error::NumericalFailure)
+    ));
+}

--- a/crates/pcb-elastic/tests/analysis.rs
+++ b/crates/pcb-elastic/tests/analysis.rs
@@ -1,0 +1,456 @@
+use pcb_elastic::{Contribution, DMatrix, DVector, Error, Model, Status, Tolerances, elements};
+
+fn tolerances() -> Tolerances {
+    Tolerances {
+        rank_relative: 1e-11,
+        rank_absolute: 0.0,
+        residual_relative: 1e-11,
+        residual_absolute: 1e-12,
+    }
+}
+fn block(k: DMatrix<f64>) -> Contribution {
+    Contribution {
+        dofs: (0..k.nrows()).collect(),
+        stiffness: k,
+    }
+}
+fn close(a: f64, b: f64, tolerance: f64) {
+    assert!(
+        (a - b).abs() < tolerance,
+        "{a} != {b}; error {}",
+        (a - b).abs()
+    );
+}
+fn isotropic() -> DMatrix<f64> {
+    DMatrix::from_row_slice(3, 3, &[1.0, 0.3, 0.0, 0.3, 1.0, 0.0, 0.0, 0.0, 0.35])
+}
+
+#[test]
+fn beam_cantilever_tip_load_and_rigid_modes() {
+    let k = elements::beam(3.0, 7.0).unwrap();
+    for v in [[1.0, 0.0, 1.0, 0.0], [0.0, 1.0, 3.0, 1.0]] {
+        assert!((&k * DVector::from_column_slice(&v)).norm() < 1e-13);
+    }
+    let model = Model::new(vec![3.0, 1.0, 3.0, 1.0], &[block(k)], tolerances()).unwrap();
+    let result = model
+        .evaluate(&[], &[0.0, 0.0, 2.0, 0.0], &[(0, 0.0), (1, 0.0)])
+        .unwrap();
+    assert_eq!(result.status, Status::Stable);
+    close(result.displacement[2], 2.0 * 27.0 / 21.0, 1e-12);
+    close(result.displacement[3], 2.0 * 9.0 / 14.0, 1e-12);
+    close(result.reactions[0], -2.0, 1e-12);
+    close(result.reactions[1], -6.0, 1e-12);
+    close(result.compliance, 2.0 * result.strain_energy, 1e-12);
+    assert!(result.relative_residual < 1e-14);
+    let free = model.evaluate(&[], &[0.0; 4], &[]).unwrap();
+    assert_eq!(free.status, Status::SingularCompatible);
+    assert_eq!(free.unsupported_modes.len(), 2);
+}
+
+#[test]
+fn beam_uniform_load_energy_converges_to_analytical_solution() {
+    let mut previous = f64::INFINITY;
+    for count in [1, 2, 4, 8] {
+        let l = 1.0 / count as f64;
+        let mut blocks = Vec::new();
+        let mut loads = vec![0.0; 2 * (count + 1)];
+        for i in 0..count {
+            blocks.push(Contribution {
+                dofs: (2 * i..2 * i + 4).collect(),
+                stiffness: elements::beam(l, 1.0).unwrap(),
+            });
+            for (j, v) in [l / 2.0, l * l / 12.0, l / 2.0, -l * l / 12.0]
+                .iter()
+                .enumerate()
+            {
+                loads[2 * i + j] += v;
+            }
+        }
+        let model = Model::new(vec![1.0; loads.len()], &blocks, tolerances()).unwrap();
+        let r = model.evaluate(&[], &loads, &[(0, 0.0), (1, 0.0)]).unwrap();
+        assert_eq!(r.status, Status::Stable);
+        let error = (r.compliance - 1.0 / 20.0).abs();
+        eprintln!("beam n={count}: compliance={} error={error}", r.compliance);
+        assert!(error < previous / 10.0);
+        previous = error;
+        close(r.displacement[2 * count], 1.0 / 8.0, 2e-10);
+    }
+    assert!(previous < 4e-7);
+}
+
+#[test]
+fn optional_supports_match_independent_full_cholesky_and_do_not_accumulate() {
+    let base = block(DMatrix::from_row_slice(
+        3,
+        3,
+        &[2.0, -2.0, 0.0, -2.0, 5.0, -3.0, 0.0, -3.0, 3.0],
+    ));
+    let model = Model::new(vec![1.0; 3], std::slice::from_ref(&base), tolerances()).unwrap();
+    let supports = [
+        Contribution {
+            dofs: vec![0],
+            stiffness: DMatrix::from_element(1, 1, 4.0),
+        },
+        Contribution {
+            dofs: vec![2],
+            stiffness: DMatrix::from_element(1, 1, 7.0),
+        },
+    ];
+    let load = [1.0, -2.0, 3.0];
+    for mask in [1, 2, 3, 1, 3, 2] {
+        let chosen: Vec<_> = supports
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| mask & (1 << i) != 0)
+            .map(|(_, s)| s.clone())
+            .collect();
+        let mut full = base.stiffness.clone();
+        if mask & 1 != 0 {
+            full[(0, 0)] += 4.0;
+        }
+        if mask & 2 != 0 {
+            full[(2, 2)] += 7.0;
+        }
+        let independent = full
+            .cholesky()
+            .unwrap()
+            .solve(&DVector::from_column_slice(&load));
+        let r = model.evaluate(&chosen, &load, &[]).unwrap();
+        assert_eq!(r.status, Status::Stable);
+        assert!((r.displacement - independent).norm() < 1e-12);
+        close(r.support_reactions.iter().map(|f| f[0]).sum(), -2.0, 1e-12);
+    }
+    let r = model.evaluate(&[], &load, &[]).unwrap();
+    assert_eq!(r.status, Status::SingularIncompatible);
+    assert_eq!(r.unsupported_modes.len(), 1);
+    assert!(r.unsupported_modes[0].load_projection.abs() > 1.0);
+    assert!(r.residual.norm() > 1.0);
+    assert_eq!(r.reactions.norm(), 0.0);
+    let balanced = model.evaluate(&[], &[1.0, 0.0, -1.0], &[]).unwrap();
+    assert_eq!(balanced.status, Status::SingularCompatible);
+    assert!(balanced.residual.norm() < 1e-12);
+}
+
+#[test]
+fn prescribed_motion_reactions_and_disconnected_modes() {
+    let k = DMatrix::from_row_slice(3, 3, &[2.0, -2.0, 0.0, -2.0, 2.0, 0.0, 0.0, 0.0, 0.0]);
+    let model = Model::new(vec![1.0; 3], &[block(k)], tolerances()).unwrap();
+    let r = model.evaluate(&[], &[0.0, 3.0, 0.0], &[(0, 4.0)]).unwrap();
+    close(r.displacement[1], 5.5, 1e-12);
+    close(r.reactions[0], -3.0, 1e-12);
+    assert_eq!(r.status, Status::SingularCompatible);
+    assert_eq!(r.unsupported_modes.len(), 1);
+    let r = model
+        .evaluate(&[], &[1.0, 0.0, 0.0], &[(0, 1.0), (1, 0.0), (2, 0.0)])
+        .unwrap();
+    assert_eq!(r.status, Status::Stable);
+    close(r.reactions[0], 1.0, 1e-12);
+    close(r.reactions[1], -2.0, 1e-12);
+    assert_eq!(r.residual.norm(), 0.0);
+}
+
+#[test]
+fn rejects_invalid_and_indefinite_inputs_without_regularization() {
+    let negative = block(DMatrix::from_element(1, 1, -1.0));
+    assert!(matches!(
+        Model::new(vec![1.0], &[negative], tolerances()),
+        Err(Error::Indefinite(_))
+    ));
+    let asym = block(DMatrix::from_row_slice(2, 2, &[1.0, 0.1, 0.0, 1.0]));
+    assert!(matches!(
+        Model::new(vec![1.0; 2], &[asym], tolerances()),
+        Err(Error::InvalidInput)
+    ));
+    let model = Model::new(vec![1.0; 2], &[], tolerances()).unwrap();
+    assert!(matches!(
+        model.evaluate(&[], &[0.0; 2], &[(0, 0.0), (0, 1.0)]),
+        Err(Error::InvalidInput)
+    ));
+    assert!(model.evaluate(&[], &[f64::NAN, 0.0], &[]).is_err());
+    assert!(elements::beam(0.0, 1.0).is_err());
+    assert!(elements::MorleyTriangle::new([[0.0; 2]; 3], [1.0; 3]).is_err());
+    let r = model.evaluate(&[], &[1.0, 0.0], &[]).unwrap();
+    assert_eq!(r.status, Status::SingularIncompatible);
+    assert_eq!(r.unsupported_modes.len(), 2);
+    assert_eq!(r.displacement.norm(), 0.0);
+    close(r.scaled_residual_norm, 1.0, 1e-15);
+}
+
+#[test]
+fn characteristic_scaling_preserves_solution_across_unit_changes() {
+    let k = elements::beam(3.0, 7.0).unwrap();
+    let f = DVector::from_vec(vec![0.0, 0.0, 2.0, 0.0]);
+    let r = Model::new(vec![3.0, 1.0, 3.0, 1.0], &[block(k.clone())], tolerances())
+        .unwrap()
+        .evaluate(&[], f.as_slice(), &[(0, 0.0), (1, 0.0)])
+        .unwrap();
+    // u_original = S*u_new, energy invariant. New translations in metres.
+    let s = DMatrix::from_diagonal(&DVector::from_vec(vec![1000.0, 1.0, 1000.0, 1.0]));
+    let transformed = &s * &k * &s;
+    let new_f = &s * f;
+    let r2 = Model::new(
+        vec![0.003, 1.0, 0.003, 1.0],
+        &[block(transformed)],
+        tolerances(),
+    )
+    .unwrap()
+    .evaluate(&[], new_f.as_slice(), &[(0, 0.0), (1, 0.0)])
+    .unwrap();
+    assert!((r.displacement - &s * r2.displacement).norm() < 1e-12);
+    close(r.compliance, r2.compliance, 1e-12);
+}
+
+fn interpolate(
+    vertices: [[f64; 2]; 3],
+    signs: [f64; 3],
+    field: impl Fn(f64, f64) -> [f64; 3],
+) -> DVector<f64> {
+    let mut u = DVector::zeros(6);
+    for i in 0..3 {
+        let [x, y] = vertices[i];
+        u[i] = field(x, y)[0];
+        let [xx, yy] = vertices[(i + 1) % 3];
+        let length = (xx - x).hypot(yy - y);
+        let v = field((x + xx) / 2.0, (y + yy) / 2.0);
+        u[3 + i] = signs[i] * (v[1] * (yy - y) - v[2] * (xx - x)) / length;
+    }
+    u
+}
+
+#[test]
+fn morley_rigid_modes_quadratic_patch_and_attachment_virtual_work() {
+    let vertices = [[1.0, 2.0], [3.0, 2.5], [1.5, 5.0]];
+    let signs = [1.0, -1.0, 1.0];
+    let triangle = elements::MorleyTriangle::new(vertices, signs).unwrap();
+    let k = triangle.stiffness(&isotropic()).unwrap();
+    let f = triangle.pressure_load(|_| 5.0).unwrap();
+    let area = 2.875;
+    for (a, b, c) in [(1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)] {
+        let u = interpolate(vertices, signs, |x, y| [a + b * x + c * y, b, c]);
+        assert!((&k * &u).norm() < 1e-12);
+        close(
+            f.dot(&u),
+            5.0 * area * (a + b * 5.5 / 3.0 + c * 9.5 / 3.0),
+            1e-12,
+        );
+    }
+    let field = |x: f64, y: f64| {
+        [
+            x * x + 2.0 * y * y + 3.0 * x * y,
+            2.0 * x + 3.0 * y,
+            4.0 * y + 3.0 * x,
+        ]
+    };
+    let u = interpolate(vertices, signs, field);
+    let curvature = DVector::from_vec(vec![2.0, 4.0, 6.0]);
+    close(
+        u.dot(&(&k * &u)),
+        area * curvature.dot(&(isotropic() * curvature.clone())),
+        1e-10,
+    );
+    let rows = triangle.attachment([0.2, 0.3, 0.5]).unwrap().rows;
+    let expected = field(0.2 + 0.9 + 0.75, 0.4 + 0.75 + 2.5);
+    assert!((&rows * &u - DVector::from_column_slice(&expected)).norm() < 1e-12);
+    let generalized_load = DVector::from_vec(vec![2.0, 3.0, -4.0]);
+    close(
+        (&rows.transpose() * &generalized_load).dot(&u),
+        generalized_load.dot(&DVector::from_column_slice(&expected)),
+        1e-12,
+    );
+    let support =
+        rows.transpose() * DMatrix::from_diagonal(&DVector::from_vec(vec![2.0, 3.0, 4.0])) * &rows;
+    assert!(u.dot(&(&support * &u)) > 0.0);
+    let model = Model::new(vec![1.0; 6], &[block(k.clone())], tolerances()).unwrap();
+    let free = model.evaluate(&[], &[0.0; 6], &[]).unwrap();
+    assert_eq!(free.unsupported_modes.len(), 3);
+    for mode in free.unsupported_modes {
+        assert!((&k * mode.displacement).norm() < 1e-12);
+    }
+    assert_eq!(
+        model
+            .evaluate(&[block(support)], &[0.0; 6], &[])
+            .unwrap()
+            .status,
+        Status::Stable
+    );
+}
+
+// Deterministic hand-built square triangulation, with perturbed interior nodes.
+// No mesher/importer and no production geometry types or policies.
+type PlateFixture = (Model, Vec<f64>, Vec<(usize, f64)>, Vec<[f64; 2]>);
+
+fn plate_mesh(n: usize, thickness: f64) -> PlateFixture {
+    use std::collections::BTreeMap;
+    let mut points = Vec::new();
+    for y in 0..=n {
+        for x in 0..=n {
+            let perturb = if x > 0 && x < n && y > 0 && y < n {
+                0.13 * ((x + y) % 2) as f64
+            } else {
+                0.0
+            };
+            points.push([
+                (x as f64 + perturb) / n as f64,
+                (y as f64 - perturb) / n as f64,
+            ]);
+        }
+    }
+    let nv = points.len();
+    let mut edges = BTreeMap::new();
+    let mut elements = Vec::new();
+    for y in 0..n {
+        for x in 0..n {
+            let a = y * (n + 1) + x;
+            for vertices in [[a, a + 1, a + n + 2], [a, a + n + 2, a + n + 1]] {
+                let mut dofs = vertices.to_vec();
+                let mut signs = [0.0; 3];
+                for i in 0..3 {
+                    let (a, b) = (vertices[i], vertices[(i + 1) % 3]);
+                    let next = nv + edges.len();
+                    dofs.push(*edges.entry((a.min(b), a.max(b))).or_insert(next));
+                    signs[i] = if a < b { 1.0 } else { -1.0 };
+                }
+                let triangle =
+                    elements::MorleyTriangle::new(vertices.map(|i| points[i]), signs).unwrap();
+                elements.push((dofs, triangle));
+            }
+        }
+    }
+    let mut loads = vec![0.0; nv + edges.len()];
+    let mut blocks = Vec::new();
+    for (dofs, triangle) in elements {
+        // Exact clamped solution w=g(x)g(y), g=x²(1-x)², q=Δ²w.
+        let force = triangle
+            .pressure_load(|[x, y]| {
+                let g = |t: f64| t * t * (1.0 - t).powi(2);
+                let ddg = |t: f64| 2.0 - 12.0 * t + 12.0 * t * t;
+                (24.0 * (g(x) + g(y)) + 2.0 * ddg(x) * ddg(y)) * thickness.powi(3)
+            })
+            .unwrap();
+        for (i, &d) in dofs.iter().enumerate() {
+            loads[d] += force[i];
+        }
+        blocks.push(Contribution {
+            dofs,
+            stiffness: triangle
+                .stiffness(&(isotropic() * thickness.powi(3)))
+                .unwrap(),
+        });
+    }
+    let mut prescribed = Vec::new();
+    for (i, &[x, y]) in points.iter().enumerate() {
+        if x == 0.0 || x == 1.0 || y == 0.0 || y == 1.0 {
+            prescribed.push((i, 0.0));
+        }
+    }
+    for ((a, b), dof) in edges {
+        if (0..2).any(|axis| {
+            points[a][axis] == points[b][axis] && (points[a][axis] == 0.0 || points[a][axis] == 1.0)
+        }) {
+            prescribed.push((dof, 0.0));
+        }
+    }
+    let model = Model::new(vec![1.0; loads.len()], &blocks, tolerances()).unwrap();
+    (model, loads, prescribed, points)
+}
+
+#[test]
+fn morley_clamped_manufactured_plate_refinement_and_thin_limit() {
+    // ∫g²=1/630, ∫(g″)²=4/5, ∫(g′)²=2/105.
+    // ∫w Δ²w = 2(4/5)(1/630)+2(2/105)².
+    let exact = 8.0 / 3150.0 + 8.0 / 11025.0;
+    let mut previous = f64::INFINITY;
+    for n in [2, 4, 8, 16] {
+        let (model, loads, prescribed, points) = plate_mesh(n, 1.0);
+        let r = model.evaluate(&[], &loads, &prescribed).unwrap();
+        assert_eq!(r.status, Status::Stable);
+        let error = (r.compliance - exact).abs();
+        let nodal_error = points
+            .iter()
+            .enumerate()
+            .map(|(i, &[x, y])| {
+                (r.displacement[i] - x * x * (1.0 - x).powi(2) * y * y * (1.0 - y).powi(2)).powi(2)
+            })
+            .sum::<f64>()
+            .sqrt()
+            / (points.len() as f64).sqrt();
+        eprintln!(
+            "Morley n={n}: compliance={} error={error}, nodal RMS={nodal_error}",
+            r.compliance
+        );
+        assert!(error < previous / 2.0);
+        previous = error;
+        if n == 16 {
+            assert!(nodal_error < 2e-4);
+        }
+    }
+    assert!(previous < 4e-4);
+    // No parasitic shear term: normalized response is independent of t³.
+    let (model, loads, bc, _) = plate_mesh(2, 1.0);
+    let reference = model.evaluate(&[], &loads, &bc).unwrap();
+    for t in [0.1, 0.001, 0.00001] {
+        let (model, loads, bc, _) = plate_mesh(2, t);
+        let r = model.evaluate(&[], &loads, &bc).unwrap();
+        assert_eq!(r.status, Status::Stable);
+        assert!((&r.displacement - &reference.displacement).norm() < 1e-12);
+        close(r.compliance / t.powi(3), reference.compliance, 1e-12);
+    }
+}
+
+#[test]
+fn morley_two_triangle_patch_shares_oriented_edge_and_has_only_three_rigid_modes() {
+    let points = [[0.0, 0.0], [2.0, 0.0], [1.7, 1.2], [0.0, 1.0]];
+    let field = |x: f64, y: f64| {
+        [
+            x * x + 2.0 * y * y + 3.0 * x * y,
+            2.0 * x + 3.0 * y,
+            4.0 * y + 3.0 * x,
+        ]
+    };
+    let mut exact = DVector::zeros(9);
+    let mut blocks = Vec::new();
+    for (ids, signs, dofs) in [
+        ([0, 1, 2], [1.0, 1.0, -1.0], vec![0, 1, 2, 4, 5, 6]),
+        ([0, 2, 3], [1.0, 1.0, -1.0], vec![0, 2, 3, 6, 7, 8]),
+    ] {
+        let vertices = ids.map(|i| points[i]);
+        let triangle = elements::MorleyTriangle::new(vertices, signs).unwrap();
+        let u = interpolate(vertices, signs, field);
+        for (j, &d) in dofs.iter().enumerate() {
+            exact[d] = u[j];
+        }
+        blocks.push(Contribution {
+            dofs,
+            stiffness: triangle.stiffness(&isotropic()).unwrap(),
+        });
+    }
+    let model = Model::new(vec![1.0; 9], &blocks, tolerances()).unwrap();
+    let free = model.evaluate(&[], &[0.0; 9], &[]).unwrap();
+    assert_eq!(free.unsupported_modes.len(), 3);
+    // Prescribe quadratic field on outer boundary, leave diagonal normal
+    // derivative free. Constant moments balance across that internal edge.
+    let prescribed: Vec<_> = (0..9).filter(|&i| i != 6).map(|i| (i, exact[i])).collect();
+    let r = model.evaluate(&[], &[0.0; 9], &prescribed).unwrap();
+    assert_eq!(r.status, Status::Stable);
+    assert!((&r.displacement - &exact).norm() < 1e-12);
+    close(r.residual[6], 0.0, 1e-12);
+}
+
+#[test]
+fn rank_cutoff_reports_soft_modes_and_never_masks_unsupported_load() {
+    let k = DMatrix::from_diagonal(&DVector::from_vec(vec![1.0, 1e-10, 0.0]));
+    let model = Model::new(vec![1.0; 3], &[block(k.clone())], tolerances()).unwrap();
+    let r = model.evaluate(&[], &[0.0, 1.0, 0.1], &[]).unwrap();
+    assert_eq!(r.status, Status::SingularIncompatible);
+    close(r.displacement[1], 1e10, 1e-4);
+    close(r.residual[2], -0.1, 1e-15);
+    assert_eq!(r.unsupported_modes.len(), 1);
+    let mut t = tolerances();
+    t.rank_relative = 1e-9;
+    let model = Model::new(vec![1.0; 3], &[block(k)], t).unwrap();
+    let r = model.evaluate(&[], &[0.0, 1.0, 0.0], &[]).unwrap();
+    assert_eq!(r.unsupported_modes.len(), 2);
+    assert_eq!(r.status, Status::SingularIncompatible);
+    assert_eq!(r.displacement.norm(), 0.0);
+    close(r.scaled_residual_norm, 1.0, 1e-15);
+}


### PR DESCRIPTION
Add a standalone elastic analysis core with beam and triangular plate elements. Keep stiffness, loads, constraints, and numerical tolerances explicit, and report reactions, residuals, and unsupported modes. Verify analytical response, mesh convergence, optional supports, and WASM compatibility without board imports.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1235" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->