### PR TITLE
Add constrained region analysis meshes and attachments (ENG-1431)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Preserve sheet graphics and text annotations when updating KiCad schematics.
+- Add constrained region analysis meshes with boundary provenance, refinement diagnostics, and element-sided barycentric attachments to `pcb-ir`.
 - Group `pcb bom` rows by selected offer.
 - Upgrade bundled symbols to KiCad 10 format.
 - Create a starter `spec.md` when scaffolding a new board repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Preserve sheet graphics and text annotations when updating KiCad schematics.
-- Add constrained region analysis meshes with boundary provenance, refinement diagnostics, and element-sided barycentric attachments to `pcb-ir`.
+- Add constrained region analysis meshes with boundary provenance, refinement diagnostics, and robust element-sided barycentric attachments to `pcb-ir`.
 - Group `pcb bom` rows by selected offer.
 - Upgrade bundled symbols to KiCad 10 format.
 - Create a starter `spec.md` when scaffolding a new board repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Changed
 
 - Preserve sheet graphics and text annotations when updating KiCad schematics.
-- Add constrained region analysis meshes with boundary provenance, refinement diagnostics, and robust element-sided barycentric attachments to `pcb-ir`.
+- Add constrained region analysis meshes with boundary provenance, validated input accuracy, refinement diagnostics, and robust element-sided barycentric attachments to `pcb-ir`.
 - Group `pcb bom` rows by selected offer.
 - Upgrade bundled symbols to KiCad 10 format.
 - Create a starter `spec.md` when scaffolding a new board repository.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4330,6 +4330,7 @@ dependencies = [
  "libm",
  "pcb-sexpr",
  "resvg",
+ "spade",
  "terminal_size",
 ]
 
@@ -5623,6 +5624,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
 name = "roxmltree"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6626,6 +6633,18 @@ checksum = "94bf565ee1681b4473aa5a9d71d807347c28021bd1d8947cb626b02f42a0141f"
 dependencies = [
  "itertools 0.14.0",
  "quickcheck",
+]
+
+[[package]]
+name = "spade"
+version = "2.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9699399fd9349b00b184f5635b074f9ec93afffef30c853f8c875b32c0f8c7fa"
+dependencies = [
+ "hashbrown 0.16.1",
+ "num-traits",
+ "robust",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4330,6 +4330,7 @@ dependencies = [
  "libm",
  "pcb-sexpr",
  "resvg",
+ "robust",
  "spade",
  "terminal_size",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,6 +153,7 @@ boostvoronoi = "0.12.1"
 sha2 = "0.11"
 semver = { version = "1.0", features = ["serde"] }
 kurbo = "0.13"
+spade = "2.15.1"
 resvg = { version = "0.48", default-features = false }
 zstd = "0.13"
 jiff = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,6 +154,7 @@ sha2 = "0.11"
 semver = { version = "1.0", features = ["serde"] }
 kurbo = "0.13"
 spade = "2.15.1"
+robust = "1.2"
 resvg = { version = "0.48", default-features = false }
 zstd = "0.13"
 jiff = "0.2"

--- a/crates/pcb-ir/Cargo.toml
+++ b/crates/pcb-ir/Cargo.toml
@@ -21,6 +21,7 @@ ipc2581 = { workspace = true }
 kurbo = { workspace = true }
 libm = { workspace = true }
 resvg = { workspace = true }
+robust = { workspace = true }
 spade = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]

--- a/crates/pcb-ir/Cargo.toml
+++ b/crates/pcb-ir/Cargo.toml
@@ -21,6 +21,7 @@ ipc2581 = { workspace = true }
 kurbo = { workspace = true }
 libm = { workspace = true }
 resvg = { workspace = true }
+spade = { workspace = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 base64 = { workspace = true }

--- a/crates/pcb-ir/src/geom/mesh.rs
+++ b/crates/pcb-ir/src/geom/mesh.rs
@@ -219,14 +219,14 @@ impl AnalysisMesh {
             {
                 let vertices = face.vertices().map(|v| offset + v.fix().index());
                 let [a, b, c] = vertices.map(|v| mesh.vertices[v]);
-                let twice_area = cross(b - a, c - a);
+                let twice_area = orientation(a, b, c);
                 if !twice_area.is_finite() || twice_area <= 0.0 {
                     return Err(MeshError::DegenerateElement);
                 }
                 let lengths = [a.distance_to(b), b.distance_to(c), c.distance_to(a)];
                 let angle = [(b - a, c - a), (a - b, c - b), (a - c, b - c)]
                     .into_iter()
-                    .map(|(u, v)| cross(u, v).abs().atan2(dot(u, v)).to_degrees())
+                    .map(|(u, v)| twice_area.atan2(dot(u, v)).to_degrees())
                     .fold(180.0, f64::min);
                 mesh.quality.min_angle_degrees = mesh.quality.min_angle_degrees.min(angle);
                 mesh.quality.max_area_mm2 = mesh.quality.max_area_mm2.max(twice_area / 2.0);
@@ -355,13 +355,12 @@ impl AnalysisMesh {
         let triangle = self.elements.get(element)?;
         let mut nearest: Option<MeshAttachment> = None;
         let [a, b, c] = triangle.vertices.map(|v| self.vertices[v]);
-        let coord = |p: Point| robust::Coord { x: p.x, y: p.y };
         // Use the triangulator's adaptive orientation predicate for exact signs
         // of represented inputs. An epsilon band would also accept exterior points.
         let areas = [
-            robust::orient2d(coord(b), coord(c), coord(point)),
-            robust::orient2d(coord(c), coord(a), coord(point)),
-            robust::orient2d(coord(a), coord(b), coord(point)),
+            orientation(b, c, point),
+            orientation(c, a, point),
+            orientation(a, b, point),
         ];
         let sum = areas.iter().sum::<f64>();
         if areas.iter().all(|w| w.is_finite() && *w >= 0.0) && sum.is_finite() && sum > 0.0 {
@@ -395,8 +394,9 @@ impl AnalysisMesh {
     }
 }
 
-fn cross(a: Point, b: Point) -> f64 {
-    a.x * b.y - a.y * b.x
+fn orientation(a: Point, b: Point, c: Point) -> f64 {
+    let coord = |p: Point| robust::Coord { x: p.x, y: p.y };
+    robust::orient2d(coord(a), coord(b), coord(c))
 }
 fn dot(a: Point, b: Point) -> f64 {
     a.x * b.x + a.y * b.y

--- a/crates/pcb-ir/src/geom/mesh.rs
+++ b/crates/pcb-ir/src/geom/mesh.rs
@@ -91,6 +91,8 @@ pub struct AnalysisMesh {
 pub enum MeshError {
     InvalidOptions,
     InvalidRegion,
+    /// Invalid or over-budget inherited boundary approximation, not physical infeasibility.
+    Accuracy(String),
     Triangulation(String),
     /// Constraint topology could not be traced back to the input boundaries.
     BoundaryTopology,
@@ -118,6 +120,8 @@ pub struct MeshAttachment {
 impl AnalysisMesh {
     /// Mesh each canonical material component independently, so even touching
     /// components do not share DOFs. Identical inputs/options reproduce ordering.
+    /// The region must have a valid resolution and approximation history within
+    /// its own budget. Meshing cannot repair exhausted source geometry accuracy.
     pub fn new(region: &ContourSet, options: MeshOptions) -> Result<Self, MeshError> {
         if !options.max_area_mm2.is_finite()
             || options.max_area_mm2 <= 0.0
@@ -126,13 +130,18 @@ impl AnalysisMesh {
         {
             return Err(MeshError::InvalidOptions);
         }
-        if region
-            .rings
-            .iter()
-            .any(|r| r.len() < 3 || r.iter().any(|p| !p[0].is_finite() || !p[1].is_finite()))
+        if !region.resolution.is_valid()
+            || region
+                .rings
+                .iter()
+                .any(|r| r.len() < 3 || r.iter().any(|p| !p[0].is_finite() || !p[1].is_finite()))
         {
             return Err(MeshError::InvalidRegion);
         }
+        region
+            .budget()
+            .check(region.uncertainty_mm)
+            .map_err(|error| MeshError::Accuracy(error.to_string()))?;
         let (components, outers) = region.ring_components();
         if components.contains(&usize::MAX) {
             return Err(MeshError::InvalidRegion);

--- a/crates/pcb-ir/src/geom/mesh.rs
+++ b/crates/pcb-ir/src/geom/mesh.rs
@@ -47,11 +47,13 @@ pub struct MeshQuality {
     pub area_mm2: f64,
 }
 
-/// Approximation inherited from a region, not an error bound on source curves.
+/// Approximation inherited from a region, not a topology or Hausdorff certificate.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MeshApproximation {
     pub region_significance_mm: f64,
-    /// Always unknown: ContourSet does not retain flattening/boolean history.
+    /// Prepared boundary uncertainty, with the semantics of `ContourSet::uncertainty_mm`.
+    pub region_boundary_uncertainty_mm: f64,
+    /// Unknown: preparation accounting does not certify final Hausdorff error.
     pub source_curve_error_bound_mm: Option<f64>,
 }
 
@@ -146,7 +148,8 @@ impl AnalysisMesh {
                 area_mm2: 0.0,
             },
             approximation: MeshApproximation {
-                region_significance_mm: region.tolerance,
+                region_significance_mm: region.tolerance(),
+                region_boundary_uncertainty_mm: region.uncertainty_mm,
                 source_curve_error_bound_mm: None,
             },
             refinement: RefinementStatus::TargetsMet,

--- a/crates/pcb-ir/src/geom/mesh.rs
+++ b/crates/pcb-ir/src/geom/mesh.rs
@@ -155,6 +155,7 @@ impl AnalysisMesh {
             refinement: RefinementStatus::TargetsMet,
         };
         let mut budget = options.max_additional_vertices;
+        let mut budget_exhausted = false;
         for component in 0..outers.len() {
             let mut cdt = ConstrainedDelaunayTriangulation::<Point2<f64>>::new();
             let mut segments = Vec::new();
@@ -192,9 +193,7 @@ impl AnalysisMesh {
                     .with_max_additional_vertices(budget),
             );
             budget = budget.saturating_sub(cdt.num_vertices() - initial);
-            if !result.refinement_complete {
-                mesh.refinement = RefinementStatus::VertexBudgetExhausted;
-            }
+            budget_exhausted |= !result.refinement_complete;
             let excluded: BTreeSet<_> = result
                 .excluded_faces
                 .into_iter()
@@ -282,12 +281,18 @@ impl AnalysisMesh {
                 }
             }
         }
-        if mesh.refinement == RefinementStatus::TargetsMet
-            && (mesh.quality.max_area_mm2 > options.max_area_mm2 * (1.0 + 32.0 * f64::EPSILON)
-                || mesh.quality.min_angle_degrees + 1e-10 < options.min_angle_degrees)
+        // Spade can hit its cap before checking an already satisfactory mesh.
+        // Actual quality takes precedence over how the refinement loop stopped.
+        mesh.refinement = if mesh.quality.max_area_mm2
+            <= options.max_area_mm2 * (1.0 + 32.0 * f64::EPSILON)
+            && mesh.quality.min_angle_degrees + 1e-10 >= options.min_angle_degrees
         {
-            mesh.refinement = RefinementStatus::QualityLimited;
-        }
+            RefinementStatus::TargetsMet
+        } else if budget_exhausted {
+            RefinementStatus::VertexBudgetExhausted
+        } else {
+            RefinementStatus::QualityLimited
+        };
         Ok(mesh)
     }
 

--- a/crates/pcb-ir/src/geom/mesh.rs
+++ b/crates/pcb-ir/src/geom/mesh.rs
@@ -1,0 +1,382 @@
+//! Constrained, planar P1 analysis meshes of canonical regularized regions.
+//!
+//! Spade supplies constrained Delaunay triangulation and Delaunay refinement;
+//! region topology belongs to `ContourSet`, not to this module. All distances
+//! are mm. Constraints may split, but are never replaced by staircase cells.
+//! This is a polygon mesh: refinement cannot recover curves or features lost
+//! upstream during flattening/regularization. No constitutive law, mechanical
+//! feasibility decision, or plate-element shape function is implied.
+//!
+//! Remeshing with a smaller `max_area_mm2` refines the same polygon domain;
+//! compare downstream responses across such meshes separately from geometric
+//! approximation error. IDs do not persist across remeshing or region booleans.
+//! Consumers of nonconforming elements should use `attachments` or
+//! `attach_to_element` to select a physical element side explicitly.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use spade::{
+    AngleLimit, ConstrainedDelaunayTriangulation, Point2, RefinementParameters, Triangulation,
+};
+
+use super::{ContourSet, Point};
+
+/// Explicit refinement targets. The vertex budget is shared by all components.
+#[derive(Debug, Clone, Copy)]
+pub struct MeshOptions {
+    pub max_area_mm2: f64,
+    /// Must be in [0, 30]. Input corners can prevent this target being met.
+    pub min_angle_degrees: f64,
+    pub max_additional_vertices: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefinementStatus {
+    TargetsMet,
+    /// A valid partial mesh, not evidence of physical infeasibility.
+    VertexBudgetExhausted,
+    /// Refinement stopped, but input constraints prevent the requested quality.
+    QualityLimited,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeshQuality {
+    pub max_area_mm2: f64,
+    pub min_angle_degrees: f64,
+    pub max_edge_mm: f64,
+    pub area_mm2: f64,
+}
+
+/// Approximation inherited from a region, not an error bound on source curves.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeshApproximation {
+    pub region_significance_mm: f64,
+    /// Always unknown: ContourSet does not retain flattening/boolean history.
+    pub source_curve_error_bound_mm: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MeshElement {
+    /// Counterclockwise vertex indices; no mechanical DOFs are prescribed.
+    pub vertices: [usize; 3],
+    /// Snapshot-local identity from the input region's ring components.
+    pub component: usize,
+}
+
+/// One oriented subedge of an original input ring segment.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeshBoundaryEdge {
+    pub vertices: [usize; 2],
+    pub component: usize,
+    /// Original index into `ContourSet::rings`, not a reordered ring index.
+    pub ring: usize,
+    pub segment: usize,
+    /// Fractions along that original segment, in its original orientation.
+    pub parameters: [f64; 2],
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AnalysisMesh {
+    pub vertices: Vec<Point>,
+    pub elements: Vec<MeshElement>,
+    pub boundary: Vec<MeshBoundaryEdge>,
+    pub quality: MeshQuality,
+    pub approximation: MeshApproximation,
+    pub refinement: RefinementStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MeshError {
+    InvalidOptions,
+    InvalidRegion,
+    Triangulation(String),
+    /// Constraint topology could not be traced back to the input boundaries.
+    BoundaryTopology,
+    DegenerateElement,
+}
+
+impl std::fmt::Display for MeshError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "analysis meshing failed: {self:?}")
+    }
+}
+
+impl std::error::Error for MeshError {}
+
+/// Location in the polygon mesh. Weights are linear scalar interpolation only,
+/// not the shape functions of a bending element. IDs are mesh-snapshot-local.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MeshAttachment {
+    pub element: usize,
+    pub weights: [f64; 3],
+    /// Distance from the query to the represented point (zero for interior).
+    pub distance_mm: f64,
+}
+
+impl AnalysisMesh {
+    /// Mesh each canonical material component independently, so even touching
+    /// components do not share DOFs. Identical inputs/options reproduce ordering.
+    pub fn new(region: &ContourSet, options: MeshOptions) -> Result<Self, MeshError> {
+        if !options.max_area_mm2.is_finite()
+            || options.max_area_mm2 <= 0.0
+            || !options.min_angle_degrees.is_finite()
+            || !(0.0..=30.0).contains(&options.min_angle_degrees)
+        {
+            return Err(MeshError::InvalidOptions);
+        }
+        if region
+            .rings
+            .iter()
+            .any(|r| r.len() < 3 || r.iter().any(|p| !p[0].is_finite() || !p[1].is_finite()))
+        {
+            return Err(MeshError::InvalidRegion);
+        }
+        let (components, outers) = region.ring_components();
+        if components.contains(&usize::MAX) {
+            return Err(MeshError::InvalidRegion);
+        }
+        let mut mesh = Self {
+            vertices: Vec::new(),
+            elements: Vec::new(),
+            boundary: Vec::new(),
+            quality: MeshQuality {
+                max_area_mm2: 0.0,
+                min_angle_degrees: 180.0,
+                max_edge_mm: 0.0,
+                area_mm2: 0.0,
+            },
+            approximation: MeshApproximation {
+                region_significance_mm: region.tolerance,
+                source_curve_error_bound_mm: None,
+            },
+            refinement: RefinementStatus::TargetsMet,
+        };
+        let mut budget = options.max_additional_vertices;
+        for component in 0..outers.len() {
+            let mut cdt = ConstrainedDelaunayTriangulation::<Point2<f64>>::new();
+            let mut segments = Vec::new();
+            let mut original = BTreeSet::new();
+            for (ring, points) in region
+                .rings
+                .iter()
+                .enumerate()
+                .filter(|(r, _)| components[*r] == component)
+            {
+                let handles = points
+                    .iter()
+                    .map(|&[x, y]| cdt.insert(Point2::new(x, y)))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| MeshError::Triangulation(e.to_string()))?;
+                for (segment, &a) in handles.iter().enumerate() {
+                    let b = handles[(segment + 1) % handles.len()];
+                    if a == b || !cdt.can_add_constraint(a, b) || cdt.exists_constraint(a, b) {
+                        return Err(MeshError::InvalidRegion);
+                    }
+                    cdt.add_constraint(a, b);
+                    original.insert(a.index());
+                    segments.push((ring, segment, a.index(), b.index()));
+                }
+            }
+            let initial = cdt.num_vertices();
+            initial
+                .checked_add(budget)
+                .ok_or(MeshError::InvalidOptions)?;
+            let result = cdt.refine(
+                RefinementParameters::new()
+                    .exclude_outer_faces(true)
+                    .with_angle_limit(AngleLimit::from_deg(options.min_angle_degrees))
+                    .with_max_allowed_area(options.max_area_mm2)
+                    .with_max_additional_vertices(budget),
+            );
+            budget = budget.saturating_sub(cdt.num_vertices() - initial);
+            if !result.refinement_complete {
+                mesh.refinement = RefinementStatus::VertexBudgetExhausted;
+            }
+            let excluded: BTreeSet<_> = result
+                .excluded_faces
+                .into_iter()
+                .map(|f| f.index())
+                .collect();
+            let offset = mesh.vertices.len();
+            mesh.vertices.extend(cdt.vertices().map(|v| {
+                let p = v.position();
+                Point::new(p.x, p.y)
+            }));
+            for face in cdt
+                .inner_faces()
+                .filter(|f| !excluded.contains(&f.fix().index()))
+            {
+                let vertices = face.vertices().map(|v| offset + v.fix().index());
+                let [a, b, c] = vertices.map(|v| mesh.vertices[v]);
+                let twice_area = cross(b - a, c - a);
+                if !twice_area.is_finite() || twice_area <= 0.0 {
+                    return Err(MeshError::DegenerateElement);
+                }
+                let lengths = [a.distance_to(b), b.distance_to(c), c.distance_to(a)];
+                let angle = [(b - a, c - a), (a - b, c - b), (a - c, b - c)]
+                    .into_iter()
+                    .map(|(u, v)| cross(u, v).abs().atan2(dot(u, v)).to_degrees())
+                    .fold(180.0, f64::min);
+                mesh.quality.min_angle_degrees = mesh.quality.min_angle_degrees.min(angle);
+                mesh.quality.max_area_mm2 = mesh.quality.max_area_mm2.max(twice_area / 2.0);
+                mesh.quality.area_mm2 += twice_area / 2.0;
+                mesh.quality.max_edge_mm =
+                    lengths.into_iter().fold(mesh.quality.max_edge_mm, f64::max);
+                mesh.elements.push(MeshElement {
+                    vertices,
+                    component,
+                });
+            }
+            // Refinement inserts degree-two constraint vertices. Trace these
+            // chains between original endpoints: identity is topological, not
+            // inferred by nearest-boundary tolerances (which fail on thin webs).
+            let mut adjacency: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+            for edge in cdt.undirected_edges().filter(|e| e.is_constraint_edge()) {
+                let [a, b] = edge.vertices().map(|v| v.fix().index());
+                adjacency.entry(a).or_default().push(b);
+                adjacency.entry(b).or_default().push(a);
+            }
+            for (ring, segment, start, end) in segments {
+                let mut found = None;
+                for &next in adjacency.get(&start).ok_or(MeshError::BoundaryTopology)? {
+                    let mut chain = vec![start, next];
+                    while !original.contains(chain.last().unwrap()) {
+                        let current = *chain.last().unwrap();
+                        let neighbours =
+                            adjacency.get(&current).ok_or(MeshError::BoundaryTopology)?;
+                        if neighbours.len() != 2 || chain.len() > cdt.num_vertices() {
+                            return Err(MeshError::BoundaryTopology);
+                        }
+                        let previous = chain[chain.len() - 2];
+                        chain.push(
+                            *neighbours
+                                .iter()
+                                .find(|&&v| v != previous)
+                                .ok_or(MeshError::BoundaryTopology)?,
+                        );
+                    }
+                    if chain.last() == Some(&end) {
+                        if found.is_some() {
+                            return Err(MeshError::BoundaryTopology);
+                        }
+                        found = Some(chain);
+                    }
+                }
+                let chain = found.ok_or(MeshError::BoundaryTopology)?;
+                let a = mesh.vertices[offset + start];
+                let delta = mesh.vertices[offset + end] - a;
+                for pair in chain.windows(2) {
+                    let vertices = [offset + pair[0], offset + pair[1]];
+                    let parameters =
+                        vertices.map(|v| dot(mesh.vertices[v] - a, delta) / dot(delta, delta));
+                    mesh.boundary.push(MeshBoundaryEdge {
+                        vertices,
+                        component,
+                        ring,
+                        segment,
+                        parameters,
+                    });
+                }
+            }
+        }
+        if mesh.refinement == RefinementStatus::TargetsMet
+            && (mesh.quality.max_area_mm2 > options.max_area_mm2 * (1.0 + 32.0 * f64::EPSILON)
+                || mesh.quality.min_angle_degrees + 1e-10 < options.min_angle_degrees)
+        {
+            mesh.refinement = RefinementStatus::QualityLimited;
+        }
+        Ok(mesh)
+    }
+
+    /// Locate a point, optionally restricted to one component. Exact interior
+    /// hits take precedence. For shared edges/vertices the lowest element index
+    /// wins. Otherwise project to the nearest triangle within `tolerance_mm`;
+    /// the returned distance exposes snapping, including across a polygon's
+    /// approximation band. Zero tolerance never intentionally snaps. Invalid
+    /// queries and points outside that band return None.
+    pub fn attach(
+        &self,
+        point: Point,
+        component: Option<usize>,
+        tolerance_mm: f64,
+    ) -> Option<MeshAttachment> {
+        self.attachments(point, component, tolerance_mm)
+            .min_by(|a, b| {
+                a.distance_mm
+                    .total_cmp(&b.distance_mm)
+                    .then(a.element.cmp(&b.element))
+            })
+    }
+
+    /// All incident elements (or elements within the explicit snapping band),
+    /// ordered by element index. Nonconforming mechanical elements must choose
+    /// a physical side rather than infer continuity from the default tie break.
+    pub fn attachments(
+        &self,
+        point: Point,
+        component: Option<usize>,
+        tolerance_mm: f64,
+    ) -> impl Iterator<Item = MeshAttachment> + '_ {
+        self.elements
+            .iter()
+            .enumerate()
+            .filter(move |(_, t)| component.is_none_or(|c| c == t.component))
+            .filter_map(move |(element, _)| self.attach_to_element(point, element, tolerance_mm))
+    }
+
+    /// Validate a caller-selected element side and compute its interpolation.
+    pub fn attach_to_element(
+        &self,
+        point: Point,
+        element: usize,
+        tolerance_mm: f64,
+    ) -> Option<MeshAttachment> {
+        if !point.is_finite() || !tolerance_mm.is_finite() || tolerance_mm < 0.0 {
+            return None;
+        }
+        let triangle = self.elements.get(element)?;
+        let mut nearest: Option<MeshAttachment> = None;
+        let [a, b, c] = triangle.vertices.map(|v| self.vertices[v]);
+        let denominator = cross(b - a, c - a);
+        let weights = [
+            cross(b - point, c - point) / denominator,
+            cross(c - point, a - point) / denominator,
+            cross(a - point, b - point) / denominator,
+        ];
+        if weights.iter().all(|w| w.is_finite() && *w >= 0.0) {
+            return Some(MeshAttachment {
+                element,
+                weights,
+                distance_mm: 0.0,
+            });
+        }
+        for (i, j) in [(0, 1), (1, 2), (2, 0)] {
+            let vertices = [a, b, c];
+            let (distance, projection) =
+                super::dist::point_segment(point, vertices[i], vertices[j]);
+            if distance <= tolerance_mm && nearest.is_none_or(|n| distance < n.distance_mm) {
+                let delta = vertices[j] - vertices[i];
+                let t = (dot(projection - vertices[i], delta) / dot(delta, delta)).clamp(0.0, 1.0);
+                let mut weights = [0.0; 3];
+                weights[i] = 1.0 - t;
+                weights[j] = t;
+                nearest = Some(MeshAttachment {
+                    element,
+                    weights,
+                    distance_mm: distance,
+                });
+            }
+        }
+        nearest
+    }
+}
+
+fn cross(a: Point, b: Point) -> f64 {
+    a.x * b.y - a.y * b.x
+}
+fn dot(a: Point, b: Point) -> f64 {
+    a.x * b.x + a.y * b.y
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pcb-ir/src/geom/mesh.rs
+++ b/crates/pcb-ir/src/geom/mesh.rs
@@ -300,7 +300,8 @@ impl AnalysisMesh {
     /// hits take precedence. For shared edges/vertices the lowest element index
     /// wins. Otherwise project to the nearest triangle within `tolerance_mm`;
     /// the returned distance exposes snapping, including across a polygon's
-    /// approximation band. Zero tolerance never intentionally snaps. Invalid
+    /// approximation band. Zero tolerance uses robust orientation of the supplied
+    /// floating-point coordinates, not a numerical snapping band. Invalid
     /// queries and points outside that band return None.
     pub fn attach(
         &self,
@@ -345,18 +346,24 @@ impl AnalysisMesh {
         let triangle = self.elements.get(element)?;
         let mut nearest: Option<MeshAttachment> = None;
         let [a, b, c] = triangle.vertices.map(|v| self.vertices[v]);
-        let denominator = cross(b - a, c - a);
-        let weights = [
-            cross(b - point, c - point) / denominator,
-            cross(c - point, a - point) / denominator,
-            cross(a - point, b - point) / denominator,
+        let coord = |p: Point| robust::Coord { x: p.x, y: p.y };
+        // Use the triangulator's adaptive orientation predicate for exact signs
+        // of represented inputs. An epsilon band would also accept exterior points.
+        let areas = [
+            robust::orient2d(coord(b), coord(c), coord(point)),
+            robust::orient2d(coord(c), coord(a), coord(point)),
+            robust::orient2d(coord(a), coord(b), coord(point)),
         ];
-        if weights.iter().all(|w| w.is_finite() && *w >= 0.0) {
+        let sum = areas.iter().sum::<f64>();
+        if areas.iter().all(|w| w.is_finite() && *w >= 0.0) && sum.is_finite() && sum > 0.0 {
             return Some(MeshAttachment {
                 element,
-                weights,
+                weights: areas.map(|w| w / sum),
                 distance_mm: 0.0,
             });
+        }
+        if tolerance_mm == 0.0 {
+            return None;
         }
         for (i, j) in [(0, 1), (1, 2), (2, 0)] {
             let vertices = [a, b, c];

--- a/crates/pcb-ir/src/geom/mesh/tests.rs
+++ b/crates/pcb-ir/src/geom/mesh/tests.rs
@@ -207,6 +207,26 @@ fn refinement_converges_for_quadratic_interpolation_on_square_and_annulus() {
 }
 
 #[test]
+fn zero_budget_classifies_measured_quality_across_components() {
+    let region = rect(0.0, 0.0, 2.0, 2.0)
+        .union(&rect(3.0, 0.0, 1.0, 1.0))
+        .unwrap();
+    let mut initial_only = options(2.0);
+    initial_only.max_additional_vertices = 0;
+    let mesh = AnalysisMesh::new(&region, initial_only).unwrap();
+    verify(&region, &mesh);
+    assert!(mesh.quality.max_area_mm2 <= initial_only.max_area_mm2);
+    assert!(mesh.quality.min_angle_degrees >= initial_only.min_angle_degrees);
+    assert_eq!(mesh.refinement, RefinementStatus::TargetsMet);
+
+    initial_only.max_area_mm2 = 0.25;
+    let mesh = AnalysisMesh::new(&region, initial_only).unwrap();
+    verify(&region, &mesh);
+    assert!(mesh.quality.max_area_mm2 > initial_only.max_area_mm2);
+    assert_eq!(mesh.refinement, RefinementStatus::VertexBudgetExhausted);
+}
+
+#[test]
 fn exhaustion_is_a_valid_partial_mesh_and_quality_limits_are_explicit() {
     let region = rect(0.0, 0.0, 4.0, 4.0)
         .difference(&rect(1.0, 1.0, 2.0, 2.0))
@@ -224,7 +244,7 @@ fn exhaustion_is_a_valid_partial_mesh_and_quality_limits_are_explicit() {
     .unwrap();
     let mesh = AnalysisMesh::new(&acute, options(1.0)).unwrap();
     verify(&acute, &mesh);
-    assert_ne!(mesh.refinement, RefinementStatus::TargetsMet);
+    assert_eq!(mesh.refinement, RefinementStatus::QualityLimited);
     assert!(mesh.quality.min_angle_degrees < 1.0);
 }
 

--- a/crates/pcb-ir/src/geom/mesh/tests.rs
+++ b/crates/pcb-ir/src/geom/mesh/tests.rs
@@ -1,6 +1,10 @@
 use super::*;
 use crate::geom::{Affine2, BBox, FillRule, Mirror, Resolution, shapes};
 
+fn cross(a: Point, b: Point) -> f64 {
+    a.x * b.y - a.y * b.x
+}
+
 fn options(area: f64) -> MeshOptions {
     MeshOptions {
         max_area_mm2: area,
@@ -386,5 +390,39 @@ fn restored_regions_must_have_valid_resolution_and_accuracy_history() {
                 uncertainty
             );
         }
+    }
+}
+
+#[test]
+fn constructor_preserves_cancellation_prone_thin_triangles() {
+    let points = [
+        [-3.656357558875988, 3.4743373693723267],
+        [2.6377461897661405, -2.449309742605783],
+        [-0.5380377200017632, 0.5395547465475277],
+    ];
+    // Exact rational determinant of the represented binary coordinates, rounded
+    // to f64. Ordinary translated determinants give either zero or 3.55e-15.
+    let expected_area = 6.649046188380301e-16 / 2.0;
+    for scale in [0.25, 1.0, 4.0] {
+        // Start at the vertex for which upstream polygon area remains positive.
+        let ring = (0..3)
+            .map(|i| points[(i + 1) % 3].map(|x| x * scale))
+            .collect();
+        let region = ContourSet::from_regularized(vec![ring], Resolution::default().strict(), 0.0);
+        assert_eq!(region.rings.len(), 1);
+        let mesh = AnalysisMesh::new(
+            &region,
+            MeshOptions {
+                max_area_mm2: 1.0,
+                min_angle_degrees: 0.0,
+                max_additional_vertices: 0,
+            },
+        )
+        .unwrap();
+        assert_eq!(mesh.elements.len(), 1);
+        assert_eq!(mesh.boundary.len(), 3);
+        assert!((mesh.quality.area_mm2 / (expected_area * scale * scale) - 1.0).abs() < 1e-14);
+        assert!(mesh.quality.min_angle_degrees > 0.0);
+        assert_eq!(mesh.refinement, RefinementStatus::TargetsMet);
     }
 }

--- a/crates/pcb-ir/src/geom/mesh/tests.rs
+++ b/crates/pcb-ir/src/geom/mesh/tests.rs
@@ -300,3 +300,57 @@ fn empty_and_invalid_queries_and_options() {
         Err(MeshError::InvalidOptions)
     );
 }
+
+#[test]
+fn exact_oblique_boundary_attachment_survives_cancellation() {
+    // Exactly collinear binary inputs; ordinary cross products round negative.
+    // Power-of-two scaling preserves that relation at different physical sizes.
+    for scale in [2.0_f64.powi(-42), 2.0_f64.powi(-40), 2.0_f64.powi(-38)] {
+        let a = Point::new(3109757648896.0, 20809216.0) * scale;
+        let b = Point::new(-29.376953125, -825439027200.0) * scale;
+        let p = Point::new(388719706086.29517, -722256547648.0) * scale;
+        assert!(cross(a - p, b - p) < 0.0);
+        let mut mesh = AnalysisMesh::new(&rect(0.0, 0.0, 1.0, 1.0), options(1.0)).unwrap();
+        mesh.vertices = vec![
+            a,
+            b,
+            Point::new(4398046511104.0, 0.0) * scale,
+            Point::new(-1099511627776.0, 0.0) * scale,
+        ];
+        mesh.elements = vec![
+            MeshElement {
+                vertices: [0, 1, 2],
+                component: 0,
+            },
+            MeshElement {
+                vertices: [1, 0, 3],
+                component: 0,
+            },
+        ];
+        let hits: Vec<_> = mesh.attachments(p, None, 0.0).collect();
+        assert_eq!(hits.len(), 2, "both physical sides must be available");
+        for hit in &hits {
+            assert_eq!(hit.distance_mm, 0.0);
+            let expected = if hit.element == 0 {
+                [0.125, 0.875]
+            } else {
+                [0.875, 0.125]
+            };
+            for (actual, expected) in hit.weights.iter().zip(expected) {
+                assert!((actual - expected).abs() <= 2.0 * f64::EPSILON);
+            }
+            assert_eq!(hit.weights[2], 0.0);
+            assert!(
+                hit.weights
+                    .iter()
+                    .all(|w| w.is_finite() && (0.0..=1.0).contains(w))
+            );
+            assert!((hit.weights.iter().sum::<f64>() - 1.0).abs() <= 16.0 * f64::EPSILON);
+        }
+        assert_eq!(mesh.attach(p, None, 0.0).unwrap().element, 0);
+        // One representable step outside must not become implicit snapping.
+        let outside = Point::new(p.x, p.y.next_up());
+        assert!(mesh.attach_to_element(outside, 0, 0.0).is_none());
+        assert!(mesh.attach_to_element(outside, 0, 1e-12).is_some());
+    }
+}

--- a/crates/pcb-ir/src/geom/mesh/tests.rs
+++ b/crates/pcb-ir/src/geom/mesh/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::geom::{Affine2, BBox, FillRule, Mirror, path::transform_cmds, shapes, tol};
+use crate::geom::{Affine2, BBox, FillRule, Mirror, Resolution, shapes};
 
 fn options(area: f64) -> MeshOptions {
     MeshOptions {
@@ -12,7 +12,7 @@ fn options(area: f64) -> MeshOptions {
 fn rect(x: f64, y: f64, w: f64, h: f64) -> ContourSet {
     ContourSet::rectangle(
         BBox::new(Point::new(x, y), Point::new(x + w, y + h)),
-        tol::REGION_MM,
+        Resolution::default(),
     )
 }
 
@@ -80,8 +80,11 @@ fn verify(region: &ContourSet, mesh: &AnalysisMesh) {
 fn holes_nested_islands_and_thin_features_preserve_topology() {
     let region = rect(0.0, 0.0, 4.0, 3.0)
         .difference(&rect(1.0, 0.1, 2.0, 2.8))
+        .unwrap()
         .union(&rect(1.5, 1.0, 1.0, 1.0))
-        .union(&rect(5.0, 0.0, 2.0, 0.01));
+        .unwrap()
+        .union(&rect(5.0, 0.0, 2.0, 0.01))
+        .unwrap();
     let mesh = AnalysisMesh::new(&region, options(0.05)).unwrap();
     verify(&region, &mesh);
     assert_eq!(mesh.refinement, RefinementStatus::TargetsMet);
@@ -142,15 +145,21 @@ fn curves_and_transforms_preserve_the_canonical_polygon_not_an_invented_curve() 
         let transform = Affine2::placement(Point::new(20.0, -7.0), 37.0, mirror, 1.7);
         let region = ContourSet::from_contours(
             &[
-                transform_cmds(circle.cmds.clone(), transform),
-                transform_cmds(hole.cmds.clone(), transform),
+                circle.clone().transformed(transform),
+                hole.clone().transformed(transform),
             ],
             FillRule::EvenOdd,
-            tol::REGION_MM,
-        );
+            Resolution::default(),
+        )
+        .unwrap();
         let mesh = AnalysisMesh::new(&region, options(0.1)).unwrap();
         verify(&region, &mesh);
         assert_eq!(mesh.approximation.source_curve_error_bound_mm, None);
+        assert!(region.uncertainty_mm > 0.0);
+        assert_eq!(
+            mesh.approximation.region_boundary_uncertainty_mm,
+            region.uncertainty_mm
+        );
         assert!(
             mesh.attach(transform.transform_point(Point::ZERO), None, 0.0)
                 .is_none()
@@ -171,8 +180,9 @@ fn refinement_converges_for_quadratic_interpolation_on_square_and_annulus() {
     let annulus = ContourSet::from_contours(
         &[shapes::circle(4.0).unwrap(), shapes::circle(2.0).unwrap()],
         FillRule::EvenOdd,
-        tol::REGION_MM,
-    );
+        Resolution::default(),
+    )
+    .unwrap();
     for region in [rect(-2.0, -2.0, 4.0, 4.0), annulus] {
         let mut errors = Vec::new();
         // Begin below the area scale already imposed by the curved boundary.
@@ -198,17 +208,20 @@ fn refinement_converges_for_quadratic_interpolation_on_square_and_annulus() {
 
 #[test]
 fn exhaustion_is_a_valid_partial_mesh_and_quality_limits_are_explicit() {
-    let region = rect(0.0, 0.0, 4.0, 4.0).difference(&rect(1.0, 1.0, 2.0, 2.0));
+    let region = rect(0.0, 0.0, 4.0, 4.0)
+        .difference(&rect(1.0, 1.0, 2.0, 2.0))
+        .unwrap();
     let mut limited = options(0.001);
     limited.max_additional_vertices = 0;
     let mesh = AnalysisMesh::new(&region, limited).unwrap();
     assert_eq!(mesh.refinement, RefinementStatus::VertexBudgetExhausted);
     verify(&region, &mesh);
-    let acute = ContourSet::new(
+    let acute = ContourSet::from_rings(
         vec![vec![[0.0, 0.0], [10.0, 0.0], [0.0, 0.1]]],
         FillRule::NonZero,
-        tol::REGION_MM,
-    );
+        Resolution::default(),
+    )
+    .unwrap();
     let mesh = AnalysisMesh::new(&acute, options(1.0)).unwrap();
     verify(&acute, &mesh);
     assert_ne!(mesh.refinement, RefinementStatus::TargetsMet);
@@ -217,7 +230,9 @@ fn exhaustion_is_a_valid_partial_mesh_and_quality_limits_are_explicit() {
 
 #[test]
 fn concave_neck_and_touching_components_keep_separate_nodes() {
-    let concave = rect(0.0, 0.0, 4.0, 3.0).difference(&rect(1.0, 0.1, 2.0, 3.0));
+    let concave = rect(0.0, 0.0, 4.0, 3.0)
+        .difference(&rect(1.0, 0.1, 2.0, 3.0))
+        .unwrap();
     let mesh = AnalysisMesh::new(&concave, options(0.03)).unwrap();
     verify(&concave, &mesh);
     assert!(mesh.attach(Point::new(2.0, 2.0), None, 0.0).is_none());
@@ -229,7 +244,8 @@ fn concave_neck_and_touching_components_keep_separate_nodes() {
             .into_iter()
             .chain(rect(1.0, 1.0, 1.0, 1.0).rings)
             .collect(),
-        tol::REGION_MM,
+        Resolution::default(),
+        0.0,
     );
     let mesh = AnalysisMesh::new(&region, options(0.03)).unwrap();
     verify(&region, &mesh);
@@ -245,7 +261,7 @@ fn concave_neck_and_touching_components_keep_separate_nodes() {
 
 #[test]
 fn empty_and_invalid_queries_and_options() {
-    let empty = AnalysisMesh::new(&ContourSet::empty(tol::REGION_MM), options(1.0)).unwrap();
+    let empty = AnalysisMesh::new(&ContourSet::empty(Resolution::default()), options(1.0)).unwrap();
     assert!(empty.elements.is_empty());
     assert!(empty.attach(Point::ZERO, None, 0.0).is_none());
     for area in [0.0, -1.0, f64::NAN, f64::INFINITY] {

--- a/crates/pcb-ir/src/geom/mesh/tests.rs
+++ b/crates/pcb-ir/src/geom/mesh/tests.rs
@@ -1,0 +1,266 @@
+use super::*;
+use crate::geom::{Affine2, BBox, FillRule, Mirror, path::transform_cmds, shapes, tol};
+
+fn options(area: f64) -> MeshOptions {
+    MeshOptions {
+        max_area_mm2: area,
+        min_angle_degrees: 25.0,
+        max_additional_vertices: 20_000,
+    }
+}
+
+fn rect(x: f64, y: f64, w: f64, h: f64) -> ContourSet {
+    ContourSet::rectangle(
+        BBox::new(Point::new(x, y), Point::new(x + w, y + h)),
+        tol::REGION_MM,
+    )
+}
+
+// Independent topological and geometric invariants, not triangulator snapshots.
+fn verify(region: &ContourSet, mesh: &AnalysisMesh) {
+    assert!((mesh.quality.area_mm2 - region.area()).abs() < 1e-8 * region.area().max(1.0));
+    let mut incidence = BTreeMap::<[usize; 2], usize>::new();
+    let mut owners = BTreeMap::new();
+    for t in &mesh.elements {
+        let [a, b, c] = t.vertices.map(|v| mesh.vertices[v]);
+        assert!(cross(b - a, c - a) > 0.0);
+        assert!(region.contains_point((a + b + c) / 3.0));
+        for &v in &t.vertices {
+            assert_eq!(*owners.entry(v).or_insert(t.component), t.component);
+        }
+        for mut edge in [
+            [t.vertices[0], t.vertices[1]],
+            [t.vertices[1], t.vertices[2]],
+            [t.vertices[2], t.vertices[0]],
+        ] {
+            edge.sort();
+            *incidence.entry(edge).or_default() += 1;
+        }
+    }
+    assert_eq!(
+        owners.len(),
+        mesh.vertices.len(),
+        "no orphan analysis nodes"
+    );
+    let mut intervals = BTreeMap::<(usize, usize), Vec<[f64; 2]>>::new();
+    for edge in &mesh.boundary {
+        let mut key = edge.vertices;
+        key.sort();
+        assert_eq!(incidence.remove(&key), Some(1));
+        let ring = &region.rings[edge.ring];
+        let [x, y] = ring[edge.segment];
+        let a = Point::new(x, y);
+        let [x, y] = ring[(edge.segment + 1) % ring.len()];
+        let b = Point::new(x, y);
+        for (v, t) in edge.vertices.into_iter().zip(edge.parameters) {
+            assert!(mesh.vertices[v].distance_to(a + (b - a) * t) < 1e-9);
+            assert_eq!(owners[&v], edge.component);
+        }
+        intervals
+            .entry((edge.ring, edge.segment))
+            .or_default()
+            .push(edge.parameters);
+    }
+    assert!(
+        incidence.values().all(|&n| n == 2),
+        "conforming interior edges"
+    );
+    for (ring, r) in region.rings.iter().enumerate() {
+        for segment in 0..r.len() {
+            let spans = &intervals[&(ring, segment)];
+            assert_eq!(spans.first().unwrap()[0], 0.0);
+            assert_eq!(spans.last().unwrap()[1], 1.0);
+            assert!(spans.iter().all(|s| s[0] < s[1]));
+            assert!(spans.windows(2).all(|s| s[0][1] == s[1][0]));
+        }
+    }
+}
+
+#[test]
+fn holes_nested_islands_and_thin_features_preserve_topology() {
+    let region = rect(0.0, 0.0, 4.0, 3.0)
+        .difference(&rect(1.0, 0.1, 2.0, 2.8))
+        .union(&rect(1.5, 1.0, 1.0, 1.0))
+        .union(&rect(5.0, 0.0, 2.0, 0.01));
+    let mesh = AnalysisMesh::new(&region, options(0.05)).unwrap();
+    verify(&region, &mesh);
+    assert_eq!(mesh.refinement, RefinementStatus::TargetsMet);
+    assert_eq!(
+        mesh.elements
+            .iter()
+            .map(|t| t.component)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        3
+    );
+    assert!(mesh.attach(Point::new(1.1, 1.0), None, 0.0).is_none());
+    assert!(mesh.attach(Point::new(6.0, 0.005), None, 0.0).is_some());
+    assert_eq!(mesh, AnalysisMesh::new(&region, options(0.05)).unwrap());
+}
+
+#[test]
+fn attachments_reproduce_affine_fields_and_expose_sides_and_snapping() {
+    let mesh = AnalysisMesh::new(&rect(0.0, 0.0, 2.0, 2.0), options(4.0)).unwrap();
+    let p = Point::new(1.0, 1.0);
+    let sides: Vec<_> = mesh.attachments(p, None, 0.0).collect();
+    assert_eq!(sides.len(), 2);
+    assert_eq!(mesh.attach(p, None, 0.0), Some(sides[0]));
+    for hit in sides {
+        assert_eq!(mesh.attach_to_element(p, hit.element, 0.0), Some(hit));
+    }
+    for p in [
+        Point::ZERO,
+        Point::new(0.0, 0.7),
+        Point::new(0.3, 1.7),
+        Point::new(2.0, 2.0),
+    ] {
+        let hit = mesh.attach(p, None, 1e-12).unwrap();
+        let nodes = mesh.elements[hit.element]
+            .vertices
+            .map(|v| mesh.vertices[v]);
+        let value: f64 = nodes
+            .into_iter()
+            .zip(hit.weights)
+            .map(|(q, w)| (2.0 + 3.0 * q.x - 5.0 * q.y) * w)
+            .sum();
+        assert!((value - (2.0 + 3.0 * p.x - 5.0 * p.y)).abs() < 1e-12);
+        assert!((hit.weights.iter().sum::<f64>() - 1.0).abs() < 1e-12);
+    }
+    let outside = Point::new(-0.001, 1.0);
+    assert!(mesh.attach(outside, None, 0.0).is_none());
+    let snapped = mesh.attach(outside, None, 0.002).unwrap();
+    assert!((snapped.distance_mm - 0.001).abs() < 1e-12);
+    assert!(mesh.attach(p, Some(10), 1.0).is_none());
+    assert!(mesh.attach_to_element(p, usize::MAX, 0.0).is_none());
+}
+
+#[test]
+fn curves_and_transforms_preserve_the_canonical_polygon_not_an_invented_curve() {
+    let circle = shapes::circle(4.0).unwrap();
+    let hole = shapes::circle(2.0).unwrap();
+    for mirror in [Mirror::NONE, Mirror::X] {
+        let transform = Affine2::placement(Point::new(20.0, -7.0), 37.0, mirror, 1.7);
+        let region = ContourSet::from_contours(
+            &[
+                transform_cmds(circle.cmds.clone(), transform),
+                transform_cmds(hole.cmds.clone(), transform),
+            ],
+            FillRule::EvenOdd,
+            tol::REGION_MM,
+        );
+        let mesh = AnalysisMesh::new(&region, options(0.1)).unwrap();
+        verify(&region, &mesh);
+        assert_eq!(mesh.approximation.source_curve_error_bound_mm, None);
+        assert!(
+            mesh.attach(transform.transform_point(Point::ZERO), None, 0.0)
+                .is_none()
+        );
+        let hit = mesh
+            .attach(transform.transform_point(Point::new(1.5, 0.0)), None, 1e-10)
+            .unwrap();
+        assert!(hit.weights.iter().all(|w| *w >= 0.0));
+        for edge in &mesh.boundary {
+            let p = mesh.vertices[edge.vertices[0]].midpoint(mesh.vertices[edge.vertices[1]]);
+            assert!(mesh.attach(p, Some(edge.component), 1e-10).is_some());
+        }
+    }
+}
+
+#[test]
+fn refinement_converges_for_quadratic_interpolation_on_square_and_annulus() {
+    let annulus = ContourSet::from_contours(
+        &[shapes::circle(4.0).unwrap(), shapes::circle(2.0).unwrap()],
+        FillRule::EvenOdd,
+        tol::REGION_MM,
+    );
+    for region in [rect(-2.0, -2.0, 4.0, 4.0), annulus] {
+        let mut errors = Vec::new();
+        // Begin below the area scale already imposed by the curved boundary.
+        for area in [0.1, 0.025, 0.00625] {
+            let mesh = AnalysisMesh::new(&region, options(area)).unwrap();
+            verify(&region, &mesh);
+            assert_eq!(mesh.refinement, RefinementStatus::TargetsMet);
+            let mut error = 0.0;
+            for t in &mesh.elements {
+                let [a, b, c] = t.vertices.map(|v| mesh.vertices[v]);
+                let p = (a + b + c) / 3.0;
+                let interpolated = (dot(a, a) + dot(b, b) + dot(c, c)) / 3.0;
+                error += cross(b - a, c - a) / 2.0 * (interpolated - dot(p, p)).powi(2);
+            }
+            errors.push((error / region.area()).sqrt());
+        }
+        assert!(
+            errors.windows(2).all(|e| e[1] < 0.5 * e[0]),
+            "quadratic interpolation error: {errors:?}"
+        );
+    }
+}
+
+#[test]
+fn exhaustion_is_a_valid_partial_mesh_and_quality_limits_are_explicit() {
+    let region = rect(0.0, 0.0, 4.0, 4.0).difference(&rect(1.0, 1.0, 2.0, 2.0));
+    let mut limited = options(0.001);
+    limited.max_additional_vertices = 0;
+    let mesh = AnalysisMesh::new(&region, limited).unwrap();
+    assert_eq!(mesh.refinement, RefinementStatus::VertexBudgetExhausted);
+    verify(&region, &mesh);
+    let acute = ContourSet::new(
+        vec![vec![[0.0, 0.0], [10.0, 0.0], [0.0, 0.1]]],
+        FillRule::NonZero,
+        tol::REGION_MM,
+    );
+    let mesh = AnalysisMesh::new(&acute, options(1.0)).unwrap();
+    verify(&acute, &mesh);
+    assert_ne!(mesh.refinement, RefinementStatus::TargetsMet);
+    assert!(mesh.quality.min_angle_degrees < 1.0);
+}
+
+#[test]
+fn concave_neck_and_touching_components_keep_separate_nodes() {
+    let concave = rect(0.0, 0.0, 4.0, 3.0).difference(&rect(1.0, 0.1, 2.0, 3.0));
+    let mesh = AnalysisMesh::new(&concave, options(0.03)).unwrap();
+    verify(&concave, &mesh);
+    assert!(mesh.attach(Point::new(2.0, 2.0), None, 0.0).is_none());
+    // Supply exactly touching canonical rings, without a boolean operation's
+    // coordinate quantization turning contact into a tiny gap or overlap.
+    let region = ContourSet::from_regularized(
+        rect(0.0, 0.0, 1.0, 1.0)
+            .rings
+            .into_iter()
+            .chain(rect(1.0, 1.0, 1.0, 1.0).rings)
+            .collect(),
+        tol::REGION_MM,
+    );
+    let mesh = AnalysisMesh::new(&region, options(0.03)).unwrap();
+    verify(&region, &mesh);
+    let hits: Vec<_> = mesh.attachments(Point::new(1.0, 1.0), None, 0.0).collect();
+    assert_eq!(
+        hits.iter()
+            .map(|h| mesh.elements[h.element].component)
+            .collect::<BTreeSet<_>>()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn empty_and_invalid_queries_and_options() {
+    let empty = AnalysisMesh::new(&ContourSet::empty(tol::REGION_MM), options(1.0)).unwrap();
+    assert!(empty.elements.is_empty());
+    assert!(empty.attach(Point::ZERO, None, 0.0).is_none());
+    for area in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+        assert_eq!(
+            AnalysisMesh::new(&rect(0.0, 0.0, 1.0, 1.0), options(area)),
+            Err(MeshError::InvalidOptions)
+        );
+    }
+    let mesh = AnalysisMesh::new(&rect(0.0, 0.0, 1.0, 1.0), options(1.0)).unwrap();
+    assert!(mesh.attach(Point::new(f64::NAN, 0.0), None, 1.0).is_none());
+    assert!(mesh.attach(Point::ZERO, None, -1.0).is_none());
+    let mut overflow = options(1.0);
+    overflow.max_additional_vertices = usize::MAX;
+    assert_eq!(
+        AnalysisMesh::new(&rect(0.0, 0.0, 1.0, 1.0), overflow),
+        Err(MeshError::InvalidOptions)
+    );
+}

--- a/crates/pcb-ir/src/geom/mesh/tests.rs
+++ b/crates/pcb-ir/src/geom/mesh/tests.rs
@@ -354,3 +354,37 @@ fn exact_oblique_boundary_attachment_survives_cancellation() {
         assert!(mesh.attach_to_element(outside, 0, 1e-12).is_some());
     }
 }
+
+#[test]
+fn restored_regions_must_have_valid_resolution_and_accuracy_history() {
+    let resolution = Resolution::default();
+    let budget = resolution.accuracy.max_error_mm();
+    for rings in [vec![], rect(0.0, 0.0, 1.0, 1.0).rings] {
+        for uncertainty in [budget.next_up(), f64::INFINITY, f64::NAN, -1.0] {
+            let region = ContourSet::from_regularized(rings.clone(), resolution, uncertainty);
+            let error = AnalysisMesh::new(&region, options(1.0)).unwrap_err();
+            assert!(matches!(error, MeshError::Accuracy(_)));
+            assert!(error.to_string().contains("accuracy budget"));
+        }
+        for tolerance in [-0.001, f64::NAN, f64::INFINITY] {
+            let region = ContourSet::from_regularized(
+                rings.clone(),
+                resolution.with_tolerance(tolerance),
+                0.0,
+            );
+            assert_eq!(
+                AnalysisMesh::new(&region, options(1.0)),
+                Err(MeshError::InvalidRegion)
+            );
+        }
+        // Triangulating the already-prepared polygon spends no new boundary budget.
+        for uncertainty in [0.0, budget] {
+            let region = ContourSet::from_regularized(rings.clone(), resolution, uncertainty);
+            let mesh = AnalysisMesh::new(&region, options(1.0)).unwrap();
+            assert_eq!(
+                mesh.approximation.region_boundary_uncertainty_mm,
+                uncertainty
+            );
+        }
+    }
+}

--- a/crates/pcb-ir/src/geom/mod.rs
+++ b/crates/pcb-ir/src/geom/mod.rs
@@ -13,6 +13,7 @@ pub mod copper_balance;
 pub mod dfm;
 pub mod dist;
 mod grid;
+pub mod mesh;
 pub mod path;
 pub mod pattern;
 mod point;


### PR DESCRIPTION
Add constrained region meshes and element-sided barycentric attachments to pcb-ir for ENG-1431. Preserve polygon boundaries and component identity, and report mesh quality and refinement limits without making physical feasibility claims. Reuse canonical region geometry and carry its preparation uncertainty.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->