### PR TITLE
ENG-1435: Select elastic supports with explicit compliance constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Add `--accuracy-um` to set the geometry accuracy for Gerber, IPC-2581, and release output.
 - Keep circles and ellipses exact in exports and rendering.
 - Add reusable polygon-boundary, attachment clearance, cutter reachability, and break-removal connectivity queries to `pcb-ir`, with explicit uncertainty and model limitations.
+- Add deterministic elastic support selection with explicit compliance limits, conflict constraints, exhaustive proof status, work budgets, and independent full-system response checks.
 - Add standalone elastic support analysis with beam and triangular plate elements, explicit stiffness and constraints, and singular-mode diagnostics.
 
 ### Changed

--- a/crates/pcb-elastic/README.md
+++ b/crates/pcb-elastic/README.md
@@ -1,7 +1,8 @@
 # pcb-elastic
 
 Small deterministic dense linear-elastic analysis, separate from PCB geometry,
-meshing, import, fixtures, materials, support selection and manufacturing limits.
+meshing, import, fixtures, materials and manufacturing limits. Pure support
+selection over caller-supplied stiffness contributions lives in `selection`.
 `pcb-sim` owns SPICE/process integration; `pcb-ir` owns geometry. This crate takes
 only numerical element coordinates and indexed contributions. It does not invent
 another outline, mesh, attachment-search or manufacturing representation.
@@ -45,6 +46,107 @@ Use consistent units, for example N/mm: vertex w in mm, slope dimensionless,
 beam EI in N·mm², plate bending tensor in N·mm, compliance in N·mm. Characteristic
 scales for w and slopes must be explicit and physically coherent. Numerical
 tolerances are not material properties or manufacturing acceptance thresholds.
+
+## Support selection (ENG-1435)
+
+`selection::select(model, candidates, conflicts, cases, fixed, max_subsets)`
+returns candidate IDs, not geometry. A candidate contains an ID and any number
+of stiffness contributions; selecting it counts as one support. Conflicts are
+unordered pairs of candidate IDs. IDs must be unique; input candidate ordering
+does not affect traversal. All inputs, including unreached candidates, are
+validated before searching. Validation errors return `Err`, never infeasibility.
+Each load case supplies its own finite positive compliance limit. `fixed` names
+homogeneous Dirichlet DOFs: moving fixtures are intentionally outside this
+objective, since their work changes the interpretation of fᵀu.
+
+The lexicographic objective is exactly:
+
+1. Minimize the number of selected candidates.
+2. At that count, minimize the worst normalized compliance
+   `max_l (f_lᵀ u_l / compliance_limit_l)`.
+3. For exactly equal computed objectives, choose lexicographically smaller IDs.
+
+The case limits therefore explicitly set both feasibility and relative response
+importance. There are no inferred loads, physical defaults, distribution rules,
+support margins, default 0.05 N·mm limit, or epsilon tie window. Feasibility uses
+`compliance <= limit` with no added acceptance tolerance. Tolerances on the
+`Model` control numerical rank/residuals, not compliance requirements.
+
+**Admissibility:** require stable, unique static equilibrium for every load case.
+Compatible singular systems are not admitted: their minimum-norm displacement
+is nonunique and is not a physical restraint. Conservatively, *all* nonstable
+statuses (compatible/incompatible singular and inaccurate), evaluation errors,
+and independent verification failures remain unresolved, not certified
+infeasible. Reports retain subset IDs, load-case indices and failure reasons.
+Even when another case exceeds its limit, a numerical failure is retained and
+withholds proof. Unsupported models may consequently have a verified feasible
+incumbent but no minimum-count certificate.
+
+Search enumerates combinations in increasing cardinality and sorted-ID order,
+rejects conflicts, and completes the first layer containing a verified feasible
+set. This considers arbitrary coupled replacements, not just single-site moves.
+`max_subsets` caps visited subsets, including conflict rejections; it is not a
+wall-clock limit and does not include input validation. No heuristic pruning or
+local-optimum claim is involved. A call restarts from the beginning; no resumable
+state is exposed. Budget exhaustion retains any incumbent and all diagnostics.
+
+**Certificate argument:** the combination iterator visits each subset of a
+cardinality once. Every smaller layer is exhausted before the first feasible
+layer, and every set in that layer is compared before declaring an optimum.
+Conflict rejection is exact. Without unresolved analyses this proves minimum
+count and minimum *computed* response at that count. `count_lower_bound` advances
+only over completely classified infeasible layers; `n+1` denotes exhaustive
+infeasibility. The incumbent count/objective provide achievable upper values.
+No response lower bound, numerical error interval, or exact-arithmetic/global
+physical optimality certificate is claimed. Near thresholds/ties or poorly
+conditioned models require separate numerical scrutiny. `Proof::Unresolved`
+means the relevant traversal completed but certification failed;
+`Proof::BudgetExhausted` means traversal is unfinished, with numerical failures
+reported independently. Absence of an incumbent alone never proves infeasibility.
+
+Every spectrally admissible case also takes an independent full Cholesky path
+before a set can become an incumbent. It assembles selected contributions anew
+onto the immutable base matrix, eliminates explicit fixed DOFs, factors the full
+scaled free system and checks residuals and the original compliance limit.
+Both displacement/compliance responses and residuals are returned. This checks
+assembly of optional supports and a different solve algorithm; it shares the
+already assembled base and input stiffness/scales, and cannot validate those
+physical inputs. It is not a second call to `Model::evaluate` or condensation.
+The objective uses spectral compliance; Cholesky is an independent admissibility
+check, not an averaged objective or a hidden margin. This is a backward residual
+check, not a forward-error bound. At PCB integration, reassemble the selected
+complete mechanical model independently of candidate generation and verify it;
+that integration acceptance remains ENG-1434/ENG-591 work.
+
+**Cost and evidence:** with m candidates, n DOFs and L cases, worst-case traversal
+is 2^m subsets and each full solve costs O(n³). Contribution validation also uses
+dense spectra. No large-model scalability is claimed. Live numerical storage is
+O(L n²) plus candidate data; failure diagnostics can grow as O(B L m) for budget
+B. Tests compare 32 independent 8-candidate/4-DOF problems against a separately
+assembled bitmask/Cholesky exhaustive oracle, with coupled off-diagonal stiffness,
+multiple contributions, two load cases, conflicts, nonunit scales and fixed
+DOFs. Tests also cover two-support replacement traps, count priority, ties,
+budget boundaries, infeasibility, singularity, overflow and inaccurate solves.
+
+Run the reproducible synthetic benchmark (seed 1435):
+
+```sh
+cargo test -p pcb-elastic --release --test selection benchmark_synthetic_stiffness -- --ignored --nocapture
+```
+
+Measured in an x86_64 Linux orb, optimized native Rust, two loads per case:
+
+| DOFs | Candidates | Subset budget | Visited / spectral solves | Seconds | Result |
+| ---: | ---: | ---: | ---: | ---: | --- |
+| 12 | 20 | 2000 | 211 / 422 | 0.012094 | Exhaustive optimum: IDs [23,26], count 2, objective 0.8932730213381614 |
+| 32 | 32 | 2000 | 529 / 1058 | 0.221149 | Exhaustive optimum: IDs [41,92], count 2, objective 0.9348780279410369 |
+| 64 | 48 | 500 | 500 / 1000 | 1.204119 | Budget exhausted, no incumbent; count lower bound 2 |
+
+All three runs report zero unresolved analyses. Times include selector input
+validation, assembled global PSD validation and independent checks, but exclude fixture/base construction and
+compilation; these are single-run measurements, not latency guarantees. The
+64-DOF run does not prove infeasibility or optimality. Benchmark limits and
+rank-one synthetic supports are test data, not manufacturing assumptions.
 
 ## Elements and mesh integration
 

--- a/crates/pcb-elastic/src/lib.rs
+++ b/crates/pcb-elastic/src/lib.rs
@@ -7,6 +7,7 @@
 //! coordinates, not physically restrained solutions. Inspect status and modes.
 
 pub mod elements;
+pub mod selection;
 pub use nalgebra::{DMatrix, DVector};
 use thiserror::Error;
 

--- a/crates/pcb-elastic/src/selection.rs
+++ b/crates/pcb-elastic/src/selection.rs
@@ -1,0 +1,286 @@
+//! Exhaustive, budgeted support selection. See the crate README for proof scope.
+use crate::{Analysis, Contribution, DMatrix, DVector, Error, Model, Status};
+
+#[derive(Clone, Debug)]
+pub struct Candidate {
+    pub id: usize,
+    pub contributions: Vec<Contribution>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LoadCase {
+    pub loads: Vec<f64>,
+    /// Strictly positive, finite, in the same units as fᵀu. No default limit.
+    pub compliance_limit: f64,
+}
+
+#[derive(Debug)]
+pub struct Selection {
+    pub ids: Vec<usize>,
+    /// Minimize max(case compliance / case limit), after support count.
+    pub objective: f64,
+    pub analyses: Vec<Analysis>,
+    /// Independently assembled full-system Cholesky responses, not condensation.
+    pub verification: Vec<VerifiedResponse>,
+}
+
+#[derive(Debug)]
+pub struct VerifiedResponse {
+    pub displacement: DVector<f64>,
+    pub compliance: f64,
+    pub scaled_residual_norm: f64,
+}
+
+#[derive(Debug)]
+pub enum Failure {
+    AnalysisStatus(Status),
+    AnalysisError(Error),
+    IndependentVerification,
+}
+
+#[derive(Debug)]
+pub struct Unresolved {
+    pub ids: Vec<usize>,
+    pub load_case: usize,
+    pub failure: Failure,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Proof {
+    /// Exhaustive optimum of the stated numerical predicate, not real arithmetic.
+    ExhaustiveOptimum,
+    ExhaustiveInfeasible,
+    /// Relevant subsets could not be classified numerically.
+    Unresolved,
+    BudgetExhausted,
+}
+
+#[derive(Debug)]
+pub struct Report {
+    /// None means no verified feasible set found, not necessarily infeasibility.
+    pub selected: Option<Selection>,
+    pub proof: Proof,
+    /// Includes conflict-rejected subsets; independent of wall-clock speed.
+    pub visited_subsets: usize,
+    /// Counts all full spectral load-case evaluations (not independent checks).
+    pub analyses: usize,
+    /// Every smaller cardinality was completely classified infeasible.
+    /// Can be n+1 when no subset is feasible. No response lower bound is claimed.
+    pub count_lower_bound: usize,
+    pub unresolved: Vec<Unresolved>,
+}
+
+/// Enumerate increasing cardinalities, then lexicographic sorted IDs. Complete
+/// the first feasible layer before stopping. Conflicts are unordered ID pairs.
+/// `fixed` prescribes zero displacement; moving fixtures are deliberately outside
+/// this compliance objective. Only stable, unique equilibrium is admissible.
+/// Nonstable analyses remain unresolved (even compatible singular ones); they
+/// cannot certify exclusion or optimality. `max_subsets` is an explicit work cap,
+/// including conflict checks, not a hidden convergence heuristic.
+pub fn select(
+    model: &Model,
+    candidates: &[Candidate],
+    conflicts: &[(usize, usize)],
+    cases: &[LoadCase],
+    fixed: &[usize],
+    max_subsets: usize,
+) -> Result<Report, Error> {
+    let n = model.scales.len();
+    let mut candidates: Vec<_> = candidates.iter().collect();
+    candidates.sort_by_key(|c| c.id);
+    if candidates.windows(2).any(|c| c[0].id == c[1].id)
+        || cases.is_empty()
+        || cases.iter().any(|c| {
+            !c.compliance_limit.is_finite()
+                || c.compliance_limit <= 0.0
+                || c.loads.len() != n
+                || c.loads.iter().any(|f| !f.is_finite())
+        })
+        || fixed
+            .iter()
+            .enumerate()
+            .any(|(i, d)| *d >= n || fixed[..i].contains(d))
+        || conflicts.iter().any(|(a, b)| {
+            a == b
+                || !candidates.iter().any(|c| c.id == *a)
+                || !candidates.iter().any(|c| c.id == *b)
+        })
+    {
+        return Err(Error::InvalidInput);
+    }
+    // Validate even candidates never reached by a short budget or conflicts.
+    // Failure here invalidates the input, rather than proving any set infeasible.
+    for c in &candidates {
+        Model::new(
+            model.scales.as_slice().to_vec(),
+            &c.contributions,
+            model.tolerances,
+        )?;
+    }
+    let prescribed: Vec<_> = fixed.iter().map(|&d| (d, 0.0)).collect();
+    let mut report = Report {
+        selected: None,
+        proof: Proof::BudgetExhausted,
+        visited_subsets: 0,
+        analyses: 0,
+        count_lower_bound: 0,
+        unresolved: Vec::new(),
+    };
+    for count in 0..=candidates.len() {
+        let mut subset: Vec<_> = (0..count).collect();
+        loop {
+            if report.visited_subsets == max_subsets {
+                return Ok(report);
+            }
+            report.visited_subsets += 1;
+            let ids: Vec<_> = subset.iter().map(|&i| candidates[i].id).collect();
+            if !conflicts
+                .iter()
+                .any(|(a, b)| ids.contains(a) && ids.contains(b))
+            {
+                let supports: Vec<_> = subset
+                    .iter()
+                    .flat_map(|&i| candidates[i].contributions.iter().cloned())
+                    .collect();
+                let mut analyses = Vec::new();
+                let mut verification = Vec::new();
+                let mut objective = f64::NEG_INFINITY;
+                let mut infeasible = false;
+                let mut unresolved = Vec::new();
+                for (load_case, case) in cases.iter().enumerate() {
+                    report.analyses += 1;
+                    let result = model.evaluate(&supports, &case.loads, &prescribed);
+                    match result {
+                        Ok(a) if a.status == Status::Stable => {
+                            let ratio = a.compliance / case.compliance_limit;
+                            if a.compliance > case.compliance_limit {
+                                infeasible = true;
+                            } else {
+                                match verify(model, &supports, case, fixed) {
+                                    Some(v) => verification.push(v),
+                                    None => unresolved.push(Unresolved {
+                                        ids: ids.clone(),
+                                        load_case,
+                                        failure: Failure::IndependentVerification,
+                                    }),
+                                }
+                            }
+                            objective = objective.max(ratio);
+                            analyses.push(a);
+                        }
+                        other => unresolved.push(Unresolved {
+                            ids: ids.clone(),
+                            load_case,
+                            failure: match other {
+                                Ok(a) => Failure::AnalysisStatus(a.status),
+                                Err(e) => Failure::AnalysisError(e),
+                            },
+                        }),
+                    }
+                }
+                // Retain every diagnostic, even if another case proves violation.
+                // Conservatively withhold proof whenever any relevant solve failed.
+                let resolved = unresolved.is_empty();
+                report.unresolved.extend(unresolved);
+                if !infeasible
+                    && resolved
+                    && report
+                        .selected
+                        .as_ref()
+                        .is_none_or(|s| objective < s.objective)
+                {
+                    report.selected = Some(Selection {
+                        ids,
+                        objective,
+                        analyses,
+                        verification,
+                    });
+                }
+            }
+            if !next_combination(&mut subset, candidates.len()) {
+                break;
+            }
+        }
+        if report.selected.is_some() {
+            report.proof = if report.unresolved.is_empty() {
+                Proof::ExhaustiveOptimum
+            } else {
+                Proof::Unresolved
+            };
+            return Ok(report);
+        }
+        if report.unresolved.is_empty() {
+            report.count_lower_bound = count + 1;
+        }
+    }
+    report.proof = if report.unresolved.is_empty() {
+        Proof::ExhaustiveInfeasible
+    } else {
+        Proof::Unresolved
+    };
+    Ok(report)
+}
+
+fn next_combination(subset: &mut [usize], n: usize) -> bool {
+    for i in (0..subset.len()).rev() {
+        if subset[i] < n - subset.len() + i {
+            subset[i] += 1;
+            for j in i + 1..subset.len() {
+                subset[j] = subset[j - 1] + 1;
+            }
+            return true;
+        }
+    }
+    false
+}
+
+// Separate assembly and direct SPD factorization, without Model::evaluate,
+// spectrum, or cached/reduced support operators. Homogeneous Dirichlet only.
+fn verify(
+    model: &Model,
+    supports: &[Contribution],
+    case: &LoadCase,
+    fixed: &[usize],
+) -> Option<VerifiedResponse> {
+    let mut k = model.stiffness.clone();
+    for s in supports {
+        for (i, &a) in s.dofs.iter().enumerate() {
+            for (j, &b) in s.dofs.iter().enumerate() {
+                k[(a, b)] += 0.5 * (s.stiffness[(i, j)] + s.stiffness[(j, i)]);
+            }
+        }
+    }
+    let free: Vec<_> = (0..k.nrows()).filter(|d| !fixed.contains(d)).collect();
+    let a = DMatrix::from_fn(free.len(), free.len(), |i, j| {
+        k[(free[i], free[j])] * model.scales[free[i]] * model.scales[free[j]]
+    });
+    let b = DVector::from_iterator(
+        free.len(),
+        free.iter().map(|&d| case.loads[d] * model.scales[d]),
+    );
+    let q = if free.is_empty() {
+        DVector::zeros(0)
+    } else {
+        a.clone().cholesky()?.solve(&b)
+    };
+    let residual = (&a * &q - &b).norm();
+    let denominator = a.norm() * q.norm() + b.norm();
+    let mut displacement = DVector::zeros(k.nrows());
+    for (i, &d) in free.iter().enumerate() {
+        displacement[d] = q[i] * model.scales[d];
+    }
+    let compliance = DVector::from_column_slice(&case.loads).dot(&displacement);
+    (displacement.iter().all(|x| x.is_finite())
+        && compliance.is_finite()
+        && residual.is_finite()
+        && denominator.is_finite()
+        && residual
+            <= model.tolerances.residual_absolute
+                + model.tolerances.residual_relative * denominator
+        && compliance <= case.compliance_limit)
+        .then_some(VerifiedResponse {
+            displacement,
+            compliance,
+            scaled_residual_norm: residual,
+        })
+}

--- a/crates/pcb-elastic/tests/selection.rs
+++ b/crates/pcb-elastic/tests/selection.rs
@@ -1,0 +1,340 @@
+use pcb_elastic::selection::{Candidate, Failure, LoadCase, Proof, select};
+use pcb_elastic::{Contribution, DMatrix, DVector, Error, Model, Status, Tolerances};
+
+fn tolerances() -> Tolerances {
+    Tolerances {
+        rank_relative: 1e-11,
+        rank_absolute: 0.0,
+        residual_relative: 1e-11,
+        residual_absolute: 1e-12,
+    }
+}
+fn block(k: DMatrix<f64>) -> Contribution {
+    Contribution {
+        dofs: (0..k.nrows()).collect(),
+        stiffness: k,
+    }
+}
+fn diagonal(id: usize, values: &[f64]) -> Candidate {
+    Candidate {
+        id,
+        contributions: vec![block(DMatrix::from_diagonal(&DVector::from_column_slice(
+            values,
+        )))],
+    }
+}
+fn case(loads: &[f64], compliance_limit: f64) -> LoadCase {
+    LoadCase {
+        loads: loads.to_vec(),
+        compliance_limit,
+    }
+}
+
+// Independent enumeration (bitmask, no cardinality iterator), assembly and SPD
+// solve. Does not invoke select or Model for the reference answer.
+fn oracle(
+    base: &DMatrix<f64>,
+    candidates: &[Candidate],
+    conflicts: &[(usize, usize)],
+    cases: &[LoadCase],
+    fixed: &[usize],
+) -> Option<(Vec<usize>, f64, Vec<DVector<f64>>)> {
+    let mut best: Option<(Vec<usize>, f64, Vec<DVector<f64>>)> = None;
+    for mask in 0usize..1 << candidates.len() {
+        let mut ids: Vec<_> = candidates
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| mask & (1 << i) != 0)
+            .map(|(_, c)| c.id)
+            .collect();
+        ids.sort();
+        if conflicts
+            .iter()
+            .any(|(a, b)| ids.contains(a) && ids.contains(b))
+        {
+            continue;
+        }
+        let mut k = base.clone();
+        for c in candidates.iter().filter(|c| ids.contains(&c.id)) {
+            for s in &c.contributions {
+                for i in 0..s.dofs.len() {
+                    for j in 0..s.dofs.len() {
+                        k[(s.dofs[i], s.dofs[j])] += s.stiffness[(i, j)];
+                    }
+                }
+            }
+        }
+        // Eliminate homogeneous Dirichlet rows by replacing them with identity.
+        for &i in fixed {
+            k.row_mut(i).fill(0.0);
+            k.column_mut(i).fill(0.0);
+            k[(i, i)] = 1.0;
+        }
+        let factor = k.cholesky().unwrap();
+        let mut responses = Vec::new();
+        let mut objective = 0.0_f64;
+        for c in cases {
+            let mut f = DVector::from_column_slice(&c.loads);
+            for &i in fixed {
+                f[i] = 0.0;
+            }
+            let u = factor.solve(&f);
+            objective = objective.max(f.dot(&u) / c.compliance_limit);
+            responses.push(u);
+        }
+        if objective <= 1.0
+            && best.as_ref().is_none_or(|(b, o, _)| {
+                ids.len() < b.len()
+                    || (ids.len() == b.len() && (objective < *o || (objective == *o && ids < *b)))
+            })
+        {
+            best = Some((ids, objective, responses));
+        }
+    }
+    best
+}
+
+fn random(seed: &mut u64) -> f64 {
+    *seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+    ((*seed >> 32) as u32 as f64) / u32::MAX as f64 - 0.5
+}
+fn synthetic(n: usize, m: usize, seed: &mut u64) -> (DMatrix<f64>, Vec<Candidate>, Vec<LoadCase>) {
+    let a = DMatrix::from_fn(n, n, |_, _| random(seed));
+    let base = a.transpose() * a + DMatrix::identity(n, n);
+    let candidates = (0..m)
+        .map(|id| {
+            let v = DVector::from_fn(n, |_, _| random(seed));
+            Candidate {
+                id: 3 * id + 2,
+                contributions: vec![block(&v * v.transpose() * 4.0)],
+            }
+        })
+        .collect();
+    let cases = (0..2)
+        .map(|_| {
+            let f = DVector::from_fn(n, |_, _| random(seed));
+            let limit = f.dot(&base.clone().cholesky().unwrap().solve(&f)) * 0.85;
+            case(f.as_slice(), limit)
+        })
+        .collect();
+    (base, candidates, cases)
+}
+
+#[test]
+fn exhaustive_independent_oracle_on_dense_coupled_systems() {
+    let mut seed = 1435;
+    let mut feasible = 0;
+    for trial in 0..32 {
+        let (base, mut candidates, cases) = synthetic(4, 8, &mut seed);
+        // Distinct global DOF indexing and multiple blocks per candidate.
+        candidates[0].contributions.push(Contribution {
+            dofs: vec![3, 1],
+            stiffness: DMatrix::from_row_slice(2, 2, &[0.2, -0.1, -0.1, 0.3]),
+        });
+        let conflicts = [(2, 5), (8, 14), (11, 20)];
+        let fixed = if trial % 2 == 0 { vec![0] } else { vec![] };
+        let expected = oracle(&base, &candidates, &conflicts, &cases, &fixed);
+        candidates.reverse(); // input ordering must not choose tie/search order
+        let model = Model::new(vec![1.0, 2.0, 0.5, 3.0], &[block(base)], tolerances()).unwrap();
+        let result = select(&model, &candidates, &conflicts, &cases, &fixed, usize::MAX).unwrap();
+        assert!(result.unresolved.is_empty());
+        match expected {
+            Some((ids, objective, responses)) => {
+                feasible += 1;
+                assert_eq!(result.proof, Proof::ExhaustiveOptimum);
+                let selected = result.selected.unwrap();
+                assert_eq!(selected.ids, ids, "trial {trial}");
+                assert_eq!(result.count_lower_bound, ids.len());
+                assert!((selected.objective - objective).abs() < 1e-10);
+                for ((a, v), u) in selected
+                    .analyses
+                    .iter()
+                    .zip(&selected.verification)
+                    .zip(responses)
+                {
+                    assert!((&a.displacement - &u).norm() < 1e-10);
+                    assert!((&v.displacement - &u).norm() < 1e-10);
+                    assert!((a.compliance - v.compliance).abs() < 1e-10);
+                }
+            }
+            None => {
+                assert_eq!(result.proof, Proof::ExhaustiveInfeasible);
+                assert!(result.selected.is_none());
+            }
+        }
+    }
+    assert!(feasible > 0);
+}
+
+#[test]
+fn coupled_replacements_escape_single_exchange_trap_and_count_wins() {
+    let model = Model::new(
+        vec![1.0; 2],
+        &[block(DMatrix::identity(2, 2))],
+        tolerances(),
+    )
+    .unwrap();
+    let candidates = [
+        diagonal(0, &[2.0, 0.0]),
+        diagonal(1, &[0.0, 2.0]),
+        diagonal(2, &[4.0, 0.0]),
+        diagonal(3, &[0.0, 4.0]),
+    ];
+    let cases = [case(&[1.0, 0.0], 0.4), case(&[0.0, 1.0], 0.4)];
+    // {0,1} is feasible, every one-site exchange violates a conflict, while
+    // the coupled move to {2,3} strictly improves both physical responses.
+    let conflicts = [(0, 2), (0, 3), (1, 2), (1, 3)];
+    let r = select(&model, &candidates, &conflicts, &cases, &[], 100).unwrap();
+    assert_eq!(r.proof, Proof::ExhaustiveOptimum);
+    assert_eq!(r.selected.unwrap().ids, [2, 3]);
+    assert_eq!(r.visited_subsets, 11);
+    let mut more = candidates.to_vec();
+    more.push(diagonal(4, &[1.6, 1.6]));
+    let r = select(&model, &more, &conflicts, &cases, &[], 100).unwrap();
+    assert_eq!(r.selected.unwrap().ids, [4]); // worse response, fewer supports
+}
+
+#[test]
+fn budgets_bounds_ties_and_infeasibility_are_distinct() {
+    let model = Model::new(vec![1.0], &[block(DMatrix::identity(1, 1))], tolerances()).unwrap();
+    let candidates = [diagonal(9, &[2.0]), diagonal(3, &[2.0])];
+    let cases = [case(&[1.0], 0.5)];
+    for budget in 0..=3 {
+        let r = select(&model, &candidates, &[], &cases, &[], budget).unwrap();
+        assert_eq!(r.visited_subsets, budget);
+        assert_eq!(r.count_lower_bound, usize::from(budget > 0));
+        assert_eq!(
+            r.proof,
+            if budget == 3 {
+                Proof::ExhaustiveOptimum
+            } else {
+                Proof::BudgetExhausted
+            }
+        );
+        assert_eq!(r.selected.map(|s| s.ids), (budget >= 2).then_some(vec![3]));
+    }
+    let r = select(&model, &candidates, &[], &[case(&[1.0], 0.1)], &[], 4).unwrap();
+    assert_eq!(r.proof, Proof::ExhaustiveInfeasible);
+    assert_eq!(r.count_lower_bound, 3);
+    let r = select(&model, &[], &[], &[case(&[1.0], 1.0)], &[], 1).unwrap();
+    assert_eq!(r.proof, Proof::ExhaustiveOptimum);
+    assert_eq!(r.selected.unwrap().ids, []);
+}
+
+#[test]
+fn singular_statuses_never_prove_exclusion_or_use_projected_compliance() {
+    let model = Model::new(vec![1.0; 2], &[], tolerances()).unwrap();
+    for loads in [&[0.0, 0.0][..], &[1.0, 0.0][..]] {
+        let r = select(
+            &model,
+            &[diagonal(1, &[2.0, 2.0])],
+            &[],
+            &[case(loads, 1.0)],
+            &[],
+            10,
+        )
+        .unwrap();
+        assert_eq!(r.proof, Proof::Unresolved);
+        assert_eq!(r.count_lower_bound, 0);
+        assert_eq!(r.selected.unwrap().ids, [1]);
+        assert_eq!(r.unresolved.len(), 1);
+        assert!(matches!(
+            r.unresolved[0].failure,
+            Failure::AnalysisStatus(Status::SingularCompatible | Status::SingularIncompatible)
+        ));
+    }
+}
+
+#[test]
+fn numerical_failure_and_inaccuracy_are_not_infeasibility() {
+    let model = Model::new(
+        vec![1.0],
+        &[block(DMatrix::from_element(1, 1, 4e307))],
+        tolerances(),
+    )
+    .unwrap();
+    let r = select(
+        &model,
+        &[diagonal(1, &[4e307])],
+        &[],
+        &[case(&[1e308], 1.0)],
+        &[],
+        10,
+    )
+    .unwrap();
+    assert_eq!(r.proof, Proof::Unresolved);
+    assert!(r.selected.is_none());
+    assert!(
+        r.unresolved
+            .iter()
+            .any(|u| matches!(u.failure, Failure::AnalysisError(Error::NumericalFailure)))
+    );
+
+    let mut t = tolerances();
+    t.residual_absolute = 0.0;
+    t.residual_relative = 0.0;
+    let model = Model::new(
+        vec![1.0; 2],
+        &[block(DMatrix::from_row_slice(2, 2, &[2.0, 0.3, 0.3, 1.0]))],
+        t,
+    )
+    .unwrap();
+    let r = select(&model, &[], &[], &[case(&[1.0, 0.7], 10.0)], &[], 1).unwrap();
+    assert_eq!(r.proof, Proof::Unresolved);
+    assert!(matches!(
+        r.unresolved[0].failure,
+        Failure::AnalysisStatus(Status::Inaccurate) | Failure::IndependentVerification
+    ));
+}
+
+#[test]
+fn invalid_inputs_are_rejected_even_with_zero_search_budget() {
+    let model = Model::new(vec![1.0], &[], tolerances()).unwrap();
+    for limit in [0.0, -1.0, f64::NAN, f64::INFINITY] {
+        assert!(select(&model, &[], &[], &[case(&[0.0], limit)], &[], 0).is_err());
+    }
+    let candidates = [diagonal(1, &[1.0]), diagonal(1, &[2.0])];
+    assert!(select(&model, &candidates, &[], &[case(&[1.0], 1.0)], &[], 0).is_err());
+    assert!(
+        select(
+            &model,
+            &[diagonal(1, &[-1.0])],
+            &[],
+            &[case(&[1.0], 1.0)],
+            &[],
+            0
+        )
+        .is_err()
+    );
+    assert!(select(&model, &[], &[(1, 2)], &[case(&[1.0], 1.0)], &[], 0).is_err());
+    assert!(select(&model, &[], &[], &[case(&[1.0], 1.0)], &[0, 0], 0).is_err());
+    assert!(select(&model, &[], &[], &[], &[], 0).is_err());
+}
+
+#[test]
+#[ignore = "release-mode synthetic performance benchmark; run explicitly"]
+fn benchmark_synthetic_stiffness() {
+    for (dofs, count, budget) in [(12, 20, 2000), (32, 32, 2000), (64, 48, 500)] {
+        let (base, candidates, cases) = synthetic(dofs, count, &mut 1435);
+        let model = Model::new(vec![1.0; dofs], &[block(base)], tolerances()).unwrap();
+        let start = std::time::Instant::now();
+        let report = select(&model, &candidates, &[], &cases, &[], budget).unwrap();
+        eprintln!(
+            "dofs={dofs} candidates={count} loads={} budget={budget} seconds={:.6} visited={} analyses={} proof={:?} lower_bound={} incumbent={:?} unresolved={}",
+            cases.len(),
+            start.elapsed().as_secs_f64(),
+            report.visited_subsets,
+            report.analyses,
+            report.proof,
+            report.count_lower_bound,
+            report.selected.as_ref().map(|s| (&s.ids, s.objective)),
+            report.unresolved.len()
+        );
+        assert!(report.unresolved.is_empty());
+        assert!(report.visited_subsets <= budget);
+        if let Some(s) = report.selected {
+            assert!(s.objective <= 1.0);
+            assert_eq!(s.verification.len(), cases.len());
+        }
+    }
+}


### PR DESCRIPTION
This PR depends on #1235 and includes its elastic analysis core so CI runs against main. Add deterministic support selection that minimizes support count, then worst normalized compliance, with conflicts, explicit work limits, and independent full-system checks. Report numerical failures and unfinished searches without claiming an optimum.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1238" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->