### PR TITLE
ENG-1429: Expose canonical board-local physical geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Require experimental tab anchors and witnesses to be resolved interior points of the original regions.
 - Reject experimental tab perforations that overlap support or lack resolved clearance from it.
 - Preserve exact arc endpoints during curve preparation to avoid numerical zero-length edges in release builds.
+- Preserve fractional IPC-2581 stackup sequences when ordering physical layers.
 - Report malformed SPICE `PARAMS:` tokens instead of crashing.
 - Migrate root-level `.zen` files in container workspaces.
 - Exit non-zero from `pcb rectify fix` and `pcb rectify audit` when batch evaluation fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 - Mark standard-library bare test pads and plated test holes as native KiCad test points.
 - Mark standard-library fiducial pads as global fiducials in KiCad layouts.
+- Reconcile IPC-2581 layer and stackup specification references for physical metadata and manufacturing properties.
 - Preserve curves that continue after a closed subpath during polygon preparation.
 - Require experimental tab anchors and witnesses to be resolved interior points of the original regions.
 - Reject experimental tab perforations that overlap support or lack resolved clearance from it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Add standalone elastic support analysis with beam and triangular plate elements, explicit stiffness and constraints, and singular-mode diagnostics.
 - Add experimental single mouse-bite tab geometry and reproducible straight/curved break coupons to `pcb-ir`; physical fracture validation remains outstanding.
 - Add boundary-following clearance intervals with inward landing checks, preserving substrate geometry and reporting missing obstacle evidence.
+- Expose headless board-local physical geometry, component outline semantics, and material/thickness diagnostics in `pcb-ir`.
 
 ### Changed
 

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1952,7 +1952,20 @@ impl<'a> Parser<'a> {
             .and_then(|s| s.parse::<f64>().ok())
             .map(|v| crate::units::to_mm(v, units));
 
-        let layer_number = self.attr(node, "sequence").and_then(|s| s.parse().ok());
+        let layer_number = self
+            .attr(node, "sequence")
+            .map(|value| {
+                value
+                    .parse::<f64>()
+                    .ok()
+                    .filter(|number| number.is_finite() && *number >= 0.0)
+                    .ok_or_else(|| {
+                        Ipc2581Error::InvalidAttribute(format!(
+                            "StackupLayer sequence must be a finite nonnegative number: {value}"
+                        ))
+                    })
+            })
+            .transpose()?;
         let mat_des = self.optional_attr(node, "matDes");
 
         // Preserve every SpecRef, including external/unresolved evidence.

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1953,6 +1953,7 @@ impl<'a> Parser<'a> {
             .map(|v| crate::units::to_mm(v, units));
 
         let layer_number = self.attr(node, "sequence").and_then(|s| s.parse().ok());
+        let mat_des = self.optional_attr(node, "matDes");
 
         // Look up material and dielectric properties from Spec via SpecRef
         let mut material = None;
@@ -1983,6 +1984,7 @@ impl<'a> Parser<'a> {
             thickness,
             tol_plus,
             tol_minus,
+            mat_des,
             material,
             spec_ref,
             dielectric_constant,

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1967,14 +1967,14 @@ impl<'a> Parser<'a> {
             {
                 // Exact match - pure IPC-2581 spec
                 let spec_symbol = self.interner.intern(spec_id);
+                // Keep unresolved evidence for headless physical consumers.
+                spec_ref = Some(spec_symbol);
                 if let Some(spec) = self.specs.get(&spec_symbol) {
-                    spec_ref = Some(spec_symbol);
                     material = spec.material;
                     dielectric_constant = spec.dielectric_constant;
                     loss_tangent = spec.loss_tangent;
                 }
-                // If spec not found, silently continue - this is valid per spec
-                // (SpecRef may reference specs not in this document)
+                // SpecRef may reference a specification outside this document.
             }
         }
 

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1955,29 +1955,25 @@ impl<'a> Parser<'a> {
         let layer_number = self.attr(node, "sequence").and_then(|s| s.parse().ok());
         let mat_des = self.optional_attr(node, "matDes");
 
-        // Look up material and dielectric properties from Spec via SpecRef
-        let mut material = None;
-        let mut spec_ref = None;
-        let mut dielectric_constant = None;
-        let mut loss_tangent = None;
-
-        // Parse SpecRef child element
+        // Preserve every SpecRef, including external/unresolved evidence.
+        let mut spec_refs = Vec::new();
         for child in self.element_children(node) {
             if self.name(&child) == "SpecRef"
                 && let Some(spec_id) = self.attr(&child, "id")
             {
-                // Exact match - pure IPC-2581 spec
-                let spec_symbol = self.interner.intern(spec_id);
-                // Keep unresolved evidence for headless physical consumers.
-                spec_ref = Some(spec_symbol);
-                if let Some(spec) = self.specs.get(&spec_symbol) {
-                    material = spec.material;
-                    dielectric_constant = spec.dielectric_constant;
-                    loss_tangent = spec.loss_tangent;
-                }
-                // SpecRef may reference a specification outside this document.
+                spec_refs.push(self.interner.intern(spec_id));
             }
         }
+        // Legacy convenience fields must not attribute one spec's properties
+        // to another reference. Multi-source reconciliation belongs downstream.
+        let spec_ref = match spec_refs.as_slice() {
+            [reference] => Some(*reference),
+            _ => None,
+        };
+        let spec = spec_ref.and_then(|reference| self.specs.get(&reference));
+        let material = spec.and_then(|spec| spec.material);
+        let dielectric_constant = spec.and_then(|spec| spec.dielectric_constant);
+        let loss_tangent = spec.and_then(|spec| spec.loss_tangent);
 
         Ok(StackupLayer {
             layer_ref,
@@ -1987,6 +1983,7 @@ impl<'a> Parser<'a> {
             mat_des,
             material,
             spec_ref,
+            spec_refs,
             dielectric_constant,
             loss_tangent,
             layer_number,

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1916,11 +1916,18 @@ impl<'a> Parser<'a> {
                     name: self.required_attr(&child, "name", "StackupGroup")?,
                     mat_des: self.optional_attr(&child, "matDes"),
                     spec_refs: Vec::new(),
+                    cad_data_layer_refs: Vec::new(),
                     source_layers: layers.len()..layers.len(),
                 };
                 for layer_node in self.element_children(&child) {
                     if self.name(&layer_node) == "StackupLayer" {
                         layers.push(self.parse_stackup_layer(&layer_node)?);
+                    } else if self.name(&layer_node) == "CADDataLayerRef" {
+                        group.cad_data_layer_refs.push(self.required_attr(
+                            &layer_node,
+                            "layerId",
+                            "CADDataLayerRef",
+                        )?);
                     } else if self.name(&layer_node) == "SpecRef" {
                         group
                             .spec_refs

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1905,14 +1905,26 @@ impl<'a> Parser<'a> {
             .map(|v| crate::units::to_mm(v, units));
 
         let mut layers = Vec::new();
+        let mut groups = Vec::new();
         for child in self.element_children(node) {
             if self.name(&child) == "StackupGroup" {
-                // StackupGroup contains StackupLayer elements
+                let mut group = StackupGroup {
+                    name: self.required_attr(&child, "name", "StackupGroup")?,
+                    mat_des: self.optional_attr(&child, "matDes"),
+                    spec_refs: Vec::new(),
+                    source_layers: layers.len()..layers.len(),
+                };
                 for layer_node in self.element_children(&child) {
                     if self.name(&layer_node) == "StackupLayer" {
                         layers.push(self.parse_stackup_layer(&layer_node)?);
+                    } else if self.name(&layer_node) == "SpecRef" {
+                        group
+                            .spec_refs
+                            .push(self.required_attr(&layer_node, "id", "SpecRef")?);
                     }
                 }
+                group.source_layers.end = layers.len();
+                groups.push(group);
             }
         }
 
@@ -1923,6 +1935,7 @@ impl<'a> Parser<'a> {
             tol_plus,
             tol_minus,
             layers,
+            groups,
         })
     }
 
@@ -1956,12 +1969,15 @@ impl<'a> Parser<'a> {
             .attr(node, "sequence")
             .map(|value| {
                 value
+                    .trim()
                     .parse::<f64>()
                     .ok()
-                    .filter(|number| number.is_finite() && *number >= 0.0)
+                    .filter(|number| *number >= 0.0)
+                    // Numeric sequence identity treats both signed zeros alike.
+                    .map(|number| if number == 0.0 { 0.0 } else { number })
                     .ok_or_else(|| {
                         Ipc2581Error::InvalidAttribute(format!(
-                            "StackupLayer sequence must be a finite nonnegative number: {value}"
+                            "StackupLayer sequence must be a nonnegative number: {value}"
                         ))
                     })
             })

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1910,8 +1910,11 @@ impl<'a> Parser<'a> {
 
         let mut layers = Vec::new();
         let mut groups = Vec::new();
+        let mut spec_refs = Vec::new();
         for child in self.element_children(node) {
-            if self.name(&child) == "StackupGroup" {
+            if self.name(&child) == "SpecRef" {
+                spec_refs.push(self.required_attr(&child, "id", "SpecRef")?);
+            } else if self.name(&child) == "StackupGroup" {
                 let mut group = StackupGroup {
                     name: self.required_attr(&child, "name", "StackupGroup")?,
                     mat_des: self.optional_attr(&child, "matDes"),
@@ -1941,6 +1944,7 @@ impl<'a> Parser<'a> {
 
         Ok(Stackup {
             name,
+            spec_refs,
             overall_thickness,
             where_measured,
             tol_plus,

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1587,7 +1587,6 @@ impl<'a> Parser<'a> {
     fn parse_spec(&mut self, node: &Node) -> Result<ecad::Spec> {
         let name = self.required_attr(node, "name", "Spec")?;
 
-        let mut material = None;
         let mut dielectric_constant = None;
         let mut loss_tangent = None;
         let mut properties = Vec::new();
@@ -1612,10 +1611,6 @@ impl<'a> Parser<'a> {
                                     let text_sym = self.interner.intern(text);
                                     // Store all property texts
                                     properties.push(text_sym);
-                                    // Take the first non-empty material text we find
-                                    if material.is_none() {
-                                        material = Some(text_sym);
-                                    }
                                 }
                             }
                             "ColorTerm" => {
@@ -1679,6 +1674,15 @@ impl<'a> Parser<'a> {
             }
         }
 
+        // Property text has no identity/description discriminator. Only a
+        // unique nonblank value can populate the convenience material field.
+        let mut texts = properties
+            .iter()
+            .copied()
+            .filter(|text| !self.interner.resolve(*text).trim().is_empty());
+        let material = texts
+            .next()
+            .filter(|first| texts.all(|text| text == *first));
         Ok(ecad::Spec {
             name,
             items,

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1363,6 +1363,21 @@ impl<'a> Parser<'a> {
         self.attr(node, attr).map(|s| self.interner.intern(s))
     }
 
+    fn source_attributes(&mut self, node: &Node) -> Vec<(Symbol, Symbol)> {
+        self.doc()
+            .element(*node)
+            .expect("expected XML element")
+            .attributes
+            .iter()
+            .map(|attr| {
+                (
+                    self.interner.intern(attr.name.local_name.as_ref()),
+                    self.interner.intern(attr.value.as_ref()),
+                )
+            })
+            .collect()
+    }
+
     fn parse_ipc_integer(&self, value: Symbol, attr: &str, positive: bool) -> Result<u32> {
         let source = self.interner.resolve(value).trim();
         let parsed = source.parse::<u32>().map_err(|_| {
@@ -1917,6 +1932,8 @@ impl<'a> Parser<'a> {
             } else if self.name(&child) == "StackupGroup" {
                 let mut group = StackupGroup {
                     name: self.required_attr(&child, "name", "StackupGroup")?,
+                    source_attributes: self.source_attributes(&child),
+                    source_units: units,
                     mat_des: self.optional_attr(&child, "matDes"),
                     spec_refs: Vec::new(),
                     cad_data_layer_refs: Vec::new(),
@@ -1944,6 +1961,8 @@ impl<'a> Parser<'a> {
 
         Ok(Stackup {
             name,
+            source_attributes: self.source_attributes(node),
+            source_units: units,
             spec_refs,
             overall_thickness,
             where_measured,

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -89,6 +89,10 @@ pub struct CadData {
 #[derive(Debug, Clone)]
 pub struct Stackup {
     pub name: Symbol,
+    /// Verbatim source attributes (including percentage tolerances and status),
+    /// not normalized or interpreted as layer material properties.
+    pub source_attributes: Vec<(Symbol, Symbol)>,
+    pub source_units: Units,
     /// Direct stackup-scoped references, not inherited by groups or layers.
     pub spec_refs: Vec<Symbol>,
     pub overall_thickness: Option<f64>,
@@ -103,6 +107,9 @@ pub struct Stackup {
 #[derive(Debug, Clone)]
 pub struct StackupGroup {
     pub name: Symbol,
+    /// Verbatim group construction attributes, not inherited by member layers.
+    pub source_attributes: Vec<(Symbol, Symbol)>,
+    pub source_units: Units,
     pub mat_des: Option<Symbol>,
     pub spec_refs: Vec<Symbol>,
     /// Ordered CADDataLayerRef membership evidence, separate from stackup order.

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -103,6 +103,8 @@ pub struct StackupGroup {
     pub name: Symbol,
     pub mat_des: Option<Symbol>,
     pub spec_refs: Vec<Symbol>,
+    /// Ordered CADDataLayerRef membership evidence, separate from stackup order.
+    pub cad_data_layer_refs: Vec<Symbol>,
     /// Range into Stackup::layers in source order, not physical sequence order.
     pub source_layers: std::ops::Range<usize>,
 }

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -103,8 +103,12 @@ pub struct StackupLayer {
     pub tol_minus: Option<f64>,
     /// Source `matDes`: reference to a BOM MatDes name, not material text.
     pub mat_des: Option<Symbol>,
+    /// Convenience properties from a single referenced specification only.
     pub material: Option<Symbol>,
-    pub spec_ref: Option<Symbol>, // Reference to Spec for looking up properties
+    /// Single-reference compatibility view; None when multiple refs exist.
+    pub spec_ref: Option<Symbol>,
+    /// All declared specification references in source order, including unresolved refs.
+    pub spec_refs: Vec<Symbol>,
     pub dielectric_constant: Option<f64>,
     pub loss_tangent: Option<f64>,
     pub layer_number: Option<u32>,

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -89,6 +89,8 @@ pub struct CadData {
 #[derive(Debug, Clone)]
 pub struct Stackup {
     pub name: Symbol,
+    /// Direct stackup-scoped references, not inherited by groups or layers.
+    pub spec_refs: Vec<Symbol>,
     pub overall_thickness: Option<f64>,
     pub where_measured: Option<WhereMeasured>,
     pub tol_plus: Option<f64>,

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -23,6 +23,8 @@ pub struct Spec {
     pub name: Symbol,
     /// Typed child elements exactly as carried by the IPC Spec payload.
     pub items: Vec<SpecItem>,
+    /// Unique nonblank MATERIAL property text only. Multiple distinct texts
+    /// remain uninterpreted in properties; no first-value or string heuristic.
     pub material: Option<Symbol>,
     pub dielectric_constant: Option<f64>,
     pub loss_tangent: Option<f64>,

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -92,6 +92,17 @@ pub struct Stackup {
     pub tol_plus: Option<f64>,
     pub tol_minus: Option<f64>,
     pub layers: Vec<StackupLayer>,
+    /// Source groups over the flattened layers; group material is not inherited.
+    pub groups: Vec<StackupGroup>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StackupGroup {
+    pub name: Symbol,
+    pub mat_des: Option<Symbol>,
+    pub spec_refs: Vec<Symbol>,
+    /// Range into Stackup::layers in source order, not physical sequence order.
+    pub source_layers: std::ops::Range<usize>,
 }
 
 /// StackupLayer defines a single layer in the stackup

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -111,7 +111,8 @@ pub struct StackupLayer {
     pub spec_refs: Vec<Symbol>,
     pub dielectric_constant: Option<f64>,
     pub loss_tangent: Option<f64>,
-    pub layer_number: Option<u32>,
+    /// IPC sequence is a nonnegative double, not an integer layer ordinal.
+    pub layer_number: Option<f64>,
 }
 
 /// Step represents a design (board, panel, etc.)

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -139,6 +139,27 @@ pub struct StackupLayer {
     pub layer_number: Option<f64>,
 }
 
+impl StackupLayer {
+    /// Unique direct specifications for this physical layer: stackup-position
+    /// refs (including legacy singular evidence), then CadData Layer refs.
+    /// Root and group specifications are not implicitly inherited.
+    pub fn combined_spec_refs(&self, layers: &[Layer]) -> Vec<Symbol> {
+        let mut references = Vec::new();
+        for reference in self.spec_refs.iter().chain(self.spec_ref.iter()).chain(
+            layers
+                .iter()
+                .find(|layer| layer.name == self.layer_ref)
+                .into_iter()
+                .flat_map(|layer| &layer.spec_refs),
+        ) {
+            if !references.contains(reference) {
+                references.push(*reference);
+            }
+        }
+        references
+    }
+}
+
 /// Step represents a design (board, panel, etc.)
 #[derive(Debug, Clone)]
 pub struct Step {

--- a/crates/ipc2581/src/types/ecad.rs
+++ b/crates/ipc2581/src/types/ecad.rs
@@ -101,6 +101,8 @@ pub struct StackupLayer {
     pub thickness: Option<f64>,
     pub tol_plus: Option<f64>,
     pub tol_minus: Option<f64>,
+    /// Source `matDes`: reference to a BOM MatDes name, not material text.
+    pub mat_des: Option<Symbol>,
     pub material: Option<Symbol>,
     pub spec_ref: Option<Symbol>, // Reference to Spec for looking up properties
     pub dielectric_constant: Option<f64>,

--- a/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
@@ -452,14 +452,14 @@ fn unique_value<T: PartialEq>(mut values: impl Iterator<Item = T>) -> Option<T> 
 }
 
 fn agreed_color(colors: &[ColorInfo]) -> Option<ColorInfo> {
-    let name = unique_value(colors.iter().filter_map(|color| color.name.clone()));
-    let rgb = unique_value(colors.iter().filter_map(|color| color.rgb));
-    if (name.is_none() && colors.iter().any(|color| color.name.is_some()))
-        || (rgb.is_none() && colors.iter().any(|color| color.rgb.is_some()))
-    {
-        return None;
-    }
-    (name.is_some() || rgb.is_some()).then_some(ColorInfo { name, rgb })
+    // A name and RGB from separate specifications are not an asserted pair.
+    // Preserve only agreement on a complete source record, without synthesizing
+    // a color or guessing equivalence between names and RGB values.
+    let first = colors.first()?;
+    colors
+        .iter()
+        .all(|color| color.name == first.name && color.rgb == first.rgb)
+        .then(|| first.clone())
 }
 
 fn classify_finish_type(finish_type: ipc2581::types::FinishType) -> SurfaceFinishCategory {

--- a/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
@@ -452,14 +452,12 @@ fn unique_value<T: PartialEq>(mut values: impl Iterator<Item = T>) -> Option<T> 
 }
 
 fn agreed_color(colors: &[ColorInfo]) -> Option<ColorInfo> {
-    // A name and RGB from separate specifications are not an asserted pair.
-    // Preserve only agreement on a complete source record, without synthesizing
-    // a color or guessing equivalence between names and RGB values.
-    let first = colors.first()?;
-    colors
-        .iter()
-        .all(|color| color.name == first.name && color.rgb == first.rgb)
-        .then(|| first.clone())
+    // Keep only fields asserted identically by every available color record.
+    // Missing evidence is not agreement: complementary partial records cannot
+    // invent a name/RGB pair, while a genuinely common name or RGB survives.
+    let name = unique_value(colors.iter().map(|color| color.name.clone())).flatten();
+    let rgb = unique_value(colors.iter().map(|color| color.rgb)).flatten();
+    (name.is_some() || rgb.is_some()).then_some(ColorInfo { name, rgb })
 }
 
 fn classify_finish_type(finish_type: ipc2581::types::FinishType) -> SurfaceFinishCategory {

--- a/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
@@ -288,7 +288,7 @@ impl<'a> IpcAccessor<'a> {
             let layer_function = layer_map.get(&layer_name).copied();
 
             // Check if this is a soldermask or silkscreen layer
-            if let Some(spec_ref) = &stackup_layer.spec_ref {
+            for spec_ref in &stackup_layer.spec_refs {
                 let spec_name = self.ipc.resolve(*spec_ref).to_string();
                 if let Some(spec) = spec_map.get(&spec_name) {
                     // Extract color from Spec (try multiple sources)
@@ -310,6 +310,9 @@ impl<'a> IpcAccessor<'a> {
                         name: color_name,
                         rgb: color_rgb,
                     };
+                    if color_info.name.is_none() && color_info.rgb.is_none() {
+                        continue;
+                    }
 
                     match layer_function {
                         Some(LayerFunction::Soldermask) if soldermask_color.is_none() => {
@@ -350,29 +353,32 @@ impl<'a> IpcAccessor<'a> {
                 _ => StackupLayerType::Other,
             };
 
-            // Get material properties from spec if available
-            let (material, spec_dk, spec_loss_tan) = if let Some(spec_ref) = &stackup_layer.spec_ref
-            {
-                let spec_name = self.ipc.resolve(*spec_ref).to_string();
-                if let Some(spec) = spec_map.get(&spec_name) {
-                    let material = spec.material.map(|m| self.ipc.resolve(m).to_string());
-                    (material, spec.dielectric_constant, spec.loss_tangent)
-                } else {
-                    (None, None, None)
-                }
-            } else {
-                (None, None, None)
-            };
-
-            // Prefer stackup_layer material over spec material
-            let final_material = stackup_layer
-                .material
-                .map(|m| self.ipc.resolve(m).to_string())
-                .or(material);
-
-            // Prefer stackup_layer properties over spec properties
-            let final_dk = stackup_layer.dielectric_constant.or(spec_dk);
-            let final_loss_tan = stackup_layer.loss_tangent.or(spec_loss_tan);
+            // A single display value is available only when referenced
+            // evidence agrees; never select the last or first conflicting spec.
+            let specs = stackup_layer
+                .spec_refs
+                .iter()
+                .filter_map(|reference| ecad.cad_header.specs.get(reference))
+                .collect::<Vec<_>>();
+            let final_material = unique_value(
+                specs
+                    .iter()
+                    .filter_map(|spec| spec.material)
+                    .chain(stackup_layer.material),
+            )
+            .map(|material| self.ipc.resolve(material).to_string());
+            let final_dk = unique_value(
+                specs
+                    .iter()
+                    .filter_map(|spec| spec.dielectric_constant)
+                    .chain(stackup_layer.dielectric_constant),
+            );
+            let final_loss_tan = unique_value(
+                specs
+                    .iter()
+                    .filter_map(|spec| spec.loss_tangent)
+                    .chain(stackup_layer.loss_tangent),
+            );
 
             layers.push(StackupLayerInfo {
                 name: layer_name,
@@ -422,7 +428,7 @@ impl<'a> IpcAccessor<'a> {
             }
 
             // Check if spec has surface finish
-            if let Some(spec_ref) = &stackup_layer.spec_ref {
+            for spec_ref in &stackup_layer.spec_refs {
                 let spec_name = self.ipc.resolve(*spec_ref).to_string();
                 if let Some(spec) = spec_map.get(&spec_name)
                     && let Some(surface_finish) = &spec.surface_finish
@@ -439,6 +445,12 @@ impl<'a> IpcAccessor<'a> {
 
         None
     }
+}
+
+fn unique_value<T: PartialEq>(mut values: impl Iterator<Item = T>) -> Option<T> {
+    values
+        .next()
+        .filter(|first| values.all(|value| value == *first))
 }
 
 fn classify_finish_type(finish_type: ipc2581::types::FinishType) -> SurfaceFinishCategory {

--- a/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
@@ -280,8 +280,8 @@ impl<'a> IpcAccessor<'a> {
             .collect();
 
         // Extract soldermask and silkscreen colors
-        let mut soldermask_color = None;
-        let mut silkscreen_color = None;
+        let mut soldermask_colors = Vec::new();
+        let mut silkscreen_colors = Vec::new();
 
         for stackup_layer in &stackup.layers {
             let layer_name = self.ipc.resolve(stackup_layer.layer_ref).to_string();
@@ -315,13 +315,11 @@ impl<'a> IpcAccessor<'a> {
                     }
 
                     match layer_function {
-                        Some(LayerFunction::Soldermask) if soldermask_color.is_none() => {
-                            soldermask_color = Some(color_info);
+                        Some(LayerFunction::Soldermask) => {
+                            soldermask_colors.push(color_info);
                         }
-                        Some(LayerFunction::Silkscreen) | Some(LayerFunction::Legend)
-                            if silkscreen_color.is_none() =>
-                        {
-                            silkscreen_color = Some(color_info);
+                        Some(LayerFunction::Silkscreen) | Some(LayerFunction::Legend) => {
+                            silkscreen_colors.push(color_info);
                         }
                         _ => {}
                     }
@@ -399,8 +397,8 @@ impl<'a> IpcAccessor<'a> {
             overall_thickness_mm: stackup.overall_thickness,
             layer_count: layers.len(),
             layers,
-            soldermask_color,
-            silkscreen_color,
+            soldermask_color: agreed_color(&soldermask_colors),
+            silkscreen_color: agreed_color(&silkscreen_colors),
             surface_finish,
         })
     }
@@ -415,6 +413,7 @@ impl<'a> IpcAccessor<'a> {
         // Per IPC-2581C spec section 8.1.1.16: SurfaceFinish is referenced by
         // StackupLayer elements that reference a Layer with layerFunction
         // COATINGCOND or COATINGNONCOND
+        let mut finishes = Vec::new();
         for stackup_layer in stackup_layers {
             let layer_name = self.ipc.resolve(stackup_layer.layer_ref).to_string();
             let layer_function = layer_map.get(&layer_name).copied();
@@ -433,17 +432,16 @@ impl<'a> IpcAccessor<'a> {
                 if let Some(spec) = spec_map.get(&spec_name)
                     && let Some(surface_finish) = &spec.surface_finish
                 {
-                    let category = classify_finish_type(surface_finish.finish_type);
-                    return Some(SurfaceFinishInfo {
-                        name: format_finish_type(surface_finish.finish_type),
-                        category,
-                        is_standard: true,
-                    });
+                    finishes.push(surface_finish.finish_type);
                 }
             }
         }
 
-        None
+        unique_value(finishes.into_iter()).map(|finish| SurfaceFinishInfo {
+            name: format_finish_type(finish),
+            category: classify_finish_type(finish),
+            is_standard: true,
+        })
     }
 }
 
@@ -451,6 +449,17 @@ fn unique_value<T: PartialEq>(mut values: impl Iterator<Item = T>) -> Option<T> 
     values
         .next()
         .filter(|first| values.all(|value| value == *first))
+}
+
+fn agreed_color(colors: &[ColorInfo]) -> Option<ColorInfo> {
+    let name = unique_value(colors.iter().filter_map(|color| color.name.clone()));
+    let rgb = unique_value(colors.iter().filter_map(|color| color.rgb));
+    if (name.is_none() && colors.iter().any(|color| color.name.is_some()))
+        || (rgb.is_none() && colors.iter().any(|color| color.rgb.is_some()))
+    {
+        return None;
+    }
+    (name.is_some() || rgb.is_some()).then_some(ColorInfo { name, rgb })
 }
 
 fn classify_finish_type(finish_type: ipc2581::types::FinishType) -> SurfaceFinishCategory {

--- a/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
@@ -288,8 +288,8 @@ impl<'a> IpcAccessor<'a> {
             let layer_function = layer_map.get(&layer_name).copied();
 
             // Check if this is a soldermask or silkscreen layer
-            for spec_ref in &stackup_layer.spec_refs {
-                let spec_name = self.ipc.resolve(*spec_ref).to_string();
+            for spec_ref in stackup_layer.combined_spec_refs(&ecad.cad_data.layers) {
+                let spec_name = self.ipc.resolve(spec_ref).to_string();
                 if let Some(spec) = spec_map.get(&spec_name) {
                     // Extract color from Spec (try multiple sources)
                     let mut color_name = spec.color_term.map(|c| self.ipc.resolve(c).to_string());
@@ -354,7 +354,7 @@ impl<'a> IpcAccessor<'a> {
             // A single display value is available only when referenced
             // evidence agrees; never select the last or first conflicting spec.
             let specs = stackup_layer
-                .spec_refs
+                .combined_spec_refs(&ecad.cad_data.layers)
                 .iter()
                 .filter_map(|reference| ecad.cad_header.specs.get(reference))
                 .collect::<Vec<_>>();
@@ -413,6 +413,7 @@ impl<'a> IpcAccessor<'a> {
         // Per IPC-2581C spec section 8.1.1.16: SurfaceFinish is referenced by
         // StackupLayer elements that reference a Layer with layerFunction
         // COATINGCOND or COATINGNONCOND
+        let ecad = self.ecad()?;
         let mut finishes = Vec::new();
         for stackup_layer in stackup_layers {
             let layer_name = self.ipc.resolve(stackup_layer.layer_ref).to_string();
@@ -427,8 +428,8 @@ impl<'a> IpcAccessor<'a> {
             }
 
             // Check if spec has surface finish
-            for spec_ref in &stackup_layer.spec_refs {
-                let spec_name = self.ipc.resolve(*spec_ref).to_string();
+            for spec_ref in stackup_layer.combined_spec_refs(&ecad.cad_data.layers) {
+                let spec_name = self.ipc.resolve(spec_ref).to_string();
                 if let Some(spec) = spec_map.get(&spec_name)
                     && let Some(surface_finish) = &spec.surface_finish
                 {

--- a/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
+++ b/crates/pcb-ipc2581-tools/src/accessors/stackup.rs
@@ -249,7 +249,7 @@ pub struct StackupLayerInfo {
     /// Loss tangent
     pub loss_tangent: Option<f64>,
     /// Layer number in stackup
-    pub layer_number: Option<u32>,
+    pub layer_number: Option<f64>,
 }
 
 impl<'a> IpcAccessor<'a> {
@@ -381,7 +381,7 @@ impl<'a> IpcAccessor<'a> {
                 material: final_material,
                 dielectric_constant: final_dk,
                 loss_tangent: final_loss_tan,
-                layer_number: stackup_layer.layer_number.or(Some((idx + 1) as u32)),
+                layer_number: stackup_layer.layer_number.or(Some((idx + 1) as f64)),
             });
         }
 

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -1359,15 +1359,21 @@ fn copper_weight_oz(imported: &ImportedDesign, layer: Symbol) -> Option<f64> {
         .iter()
         .flat_map(|stackup| &stackup.layers)
         .find(|candidate| candidate.layer_ref == layer)?;
+    let mut weights = stackup_layer
+        .spec_refs
+        .iter()
+        .filter_map(|reference| imported.specs.get(reference))
+        .filter_map(|spec| spec.copper_weight_oz);
+    if let Some(weight) = weights.next() {
+        // Conflicting explicit evidence is unavailable, not a reason to hide
+        // the conflict behind an inferred thickness-based value.
+        return weights
+            .all(|candidate| candidate == weight)
+            .then_some(weight);
+    }
     stackup_layer
-        .spec_ref
-        .and_then(|spec| imported.specs.get(&spec))
-        .and_then(|spec| spec.copper_weight_oz)
-        .or_else(|| {
-            stackup_layer
-                .thickness
-                .map(|millimeters| millimeters / 0.0348)
-        })
+        .thickness
+        .map(|millimeters| millimeters / 0.0348)
 }
 
 fn side_label(side: Side) -> Option<&'static str> {
@@ -1654,6 +1660,35 @@ fn layer_ref(name: &str, function: LayerFunction, side: Option<&'static str>) ->
 mod tests {
     use super::*;
     use crate::ipc2581::Ipc2581;
+
+    #[test]
+    fn copper_weights_reconcile_all_explicit_references_before_thickness() {
+        for (other, expected) in [(2.0, Some(2.0)), (3.0, None)] {
+            for refs in [
+                r#"<SpecRef id="a"/><SpecRef id="b"/>"#,
+                r#"<SpecRef id="b"/><SpecRef id="a"/>"#,
+            ] {
+                let xml = format!(
+                    r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+<Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="board"/></Content>
+<Ecad><CadHeader units="MILLIMETER"><Spec name="a"><Conductor type="WEIGHT"><Property value="2" unit="OZ"/></Conductor></Spec><Spec name="b"><Conductor type="WEIGHT"><Property value="{other}" unit="OZ"/></Conductor></Spec></CadHeader><CadData>
+<Layer name="TOP" layerFunction="CONDUCTOR" side="TOP" polarity="POSITIVE"/>
+<Stackup name="stack"><StackupGroup name="group"><StackupLayer layerOrGroupRef="TOP" thickness="0.0348" sequence="0">{refs}</StackupLayer></StackupGroup></Stackup><Step name="board" type="BOARD"/>
+</CadData></Ecad></IPC-2581>"#
+                );
+                let ipc = Ipc2581::parse(&xml).unwrap();
+                let imported = import_design(&ipc, Resolution::default()).unwrap();
+                let layer = imported.layer_definitions[0].name;
+                assert_eq!(copper_weight_oz(&imported, layer), expected);
+                let ipc = Ipc2581::parse(&xml.replace(refs, "")).unwrap();
+                let imported = import_design(&ipc, Resolution::default()).unwrap();
+                assert_eq!(
+                    copper_weight_oz(&imported, imported.layer_definitions[0].name),
+                    Some(1.0)
+                );
+            }
+        }
+    }
 
     #[test]
     fn mask_owners_preserve_composed_openings_and_repeat_identity() {

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -1358,11 +1358,18 @@ fn copper_weight_oz(imported: &ImportedDesign, layer: Symbol) -> Option<f64> {
         .stackups
         .iter()
         .flat_map(|stackup| &stackup.layers)
-        .find(|candidate| candidate.layer_ref == layer)?;
-    let mut weights = stackup_layer
-        .spec_refs
+        .find(|candidate| candidate.layer_ref == layer);
+    let references = match stackup_layer {
+        Some(position) => position.combined_spec_refs(&imported.layer_definitions),
+        None => imported
+            .layer_definitions
+            .iter()
+            .find(|definition| definition.name == layer)?
+            .spec_refs
+            .clone(),
+    };
+    let mut weights = references
         .iter()
-        .chain(stackup_layer.spec_ref.iter())
         .filter_map(|reference| imported.specs.get(reference))
         .filter_map(|spec| spec.copper_weight_oz);
     if let Some(weight) = weights.next() {
@@ -1372,7 +1379,7 @@ fn copper_weight_oz(imported: &ImportedDesign, layer: Symbol) -> Option<f64> {
             .all(|candidate| candidate == weight)
             .then_some(weight);
     }
-    stackup_layer
+    stackup_layer?
         .thickness
         .map(|millimeters| millimeters / 0.0348)
 }
@@ -1681,6 +1688,31 @@ mod tests {
                 let imported = import_design(&ipc, Resolution::default()).unwrap();
                 let layer = imported.layer_definitions[0].name;
                 assert_eq!(copper_weight_oz(&imported, layer), expected);
+                let layer_xml = xml.replace(refs, "").replace(
+                    r#"side="TOP" polarity="POSITIVE"/>"#,
+                    &format!(r#"side="TOP" polarity="POSITIVE">{refs}</Layer>"#),
+                );
+                let ipc = Ipc2581::parse(&layer_xml).unwrap();
+                let mut layer_only = import_design(&ipc, Resolution::default()).unwrap();
+                assert_eq!(
+                    copper_weight_oz(&layer_only, layer_only.layer_definitions[0].name),
+                    expected
+                );
+                layer_only.stackups.clear();
+                assert_eq!(
+                    copper_weight_oz(&layer_only, layer_only.layer_definitions[0].name),
+                    expected
+                );
+                let mixed_xml = xml.replace(refs, r#"<SpecRef id="a"/>"#).replace(
+                    r#"side="TOP" polarity="POSITIVE"/>"#,
+                    r#"side="TOP" polarity="POSITIVE"><SpecRef id="b"/></Layer>"#,
+                );
+                let ipc = Ipc2581::parse(&mixed_xml).unwrap();
+                let mixed = import_design(&ipc, Resolution::default()).unwrap();
+                assert_eq!(
+                    copper_weight_oz(&mixed, mixed.layer_definitions[0].name),
+                    expected
+                );
                 let mut compatibility = imported.clone();
                 let layer = &mut compatibility.stackups[0].layers[0];
                 layer.spec_ref = Some(layer.spec_refs[0]);

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -490,7 +490,7 @@ fn collect_physical_stackup(imported: &ImportedDesign) -> Result<PhysicalStackup
         .iter()
         .all(|layer| layer.layer_number.is_some())
     {
-        stackup_layers.sort_by_key(|layer| layer.layer_number);
+        stackup_layers.sort_by(|a, b| a.layer_number.unwrap().total_cmp(&b.layer_number.unwrap()));
         if stackup_layers
             .windows(2)
             .any(|pair| pair[0].layer_number == pair[1].layer_number)

--- a/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm/design.rs
@@ -1362,6 +1362,7 @@ fn copper_weight_oz(imported: &ImportedDesign, layer: Symbol) -> Option<f64> {
     let mut weights = stackup_layer
         .spec_refs
         .iter()
+        .chain(stackup_layer.spec_ref.iter())
         .filter_map(|reference| imported.specs.get(reference))
         .filter_map(|spec| spec.copper_weight_oz);
     if let Some(weight) = weights.next() {
@@ -1680,6 +1681,18 @@ mod tests {
                 let imported = import_design(&ipc, Resolution::default()).unwrap();
                 let layer = imported.layer_definitions[0].name;
                 assert_eq!(copper_weight_oz(&imported, layer), expected);
+                let mut compatibility = imported.clone();
+                let layer = &mut compatibility.stackups[0].layers[0];
+                layer.spec_ref = Some(layer.spec_refs[0]);
+                layer.spec_refs.clear();
+                assert_eq!(
+                    copper_weight_oz(&compatibility, compatibility.layer_definitions[0].name),
+                    Some(if refs.starts_with(r#"<SpecRef id="a""#) {
+                        2.0
+                    } else {
+                        other
+                    })
+                );
                 let ipc = Ipc2581::parse(&xml.replace(refs, "")).unwrap();
                 let imported = import_design(&ipc, Resolution::default()).unwrap();
                 assert_eq!(

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -525,18 +525,17 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
                         layer_index + 1
                     )
                 })?;
-            let mut specs = layer
+            let specs = layer
                 .spec_refs
                 .iter()
-                .filter_map(|spec_ref| ecad.cad_header.specs.get(spec_ref))
-                .map(|spec| spec_signature(&ipc, spec))
-                .collect::<Vec<_>>();
-            if let Some(spec_ref) = stackup_layer.spec_ref
-                && !layer.spec_refs.contains(&spec_ref)
-                && let Some(spec) = ecad.cad_header.specs.get(&spec_ref)
-            {
-                specs.push(spec_signature(&ipc, spec));
-            }
+                .chain(stackup_layer.spec_refs.iter().filter(|reference| !layer.spec_refs.contains(reference)))
+                .map(|reference| {
+                    let spec = ecad.cad_header.specs.get(reference).with_context(|| format!(
+                        "assembly panel input {input_number} stackup references unresolved specification '{}'", ipc.resolve(*reference)
+                    ))?;
+                    Ok(spec_signature(&ipc, spec))
+                })
+                .collect::<Result<Vec<_>>>()?;
 
             Ok(PhysicalStackupLayer {
                 name,

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -157,6 +157,7 @@ struct PhysicalStackup {
 struct PhysicalStackupGroup {
     attributes: Vec<(String, String)>,
     source_layers: std::ops::Range<usize>,
+    cad_data_layer_refs: Vec<String>,
     specs: Vec<SpecEvidence>,
 }
 
@@ -526,6 +527,11 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
         .map(|(node, group)| PhysicalStackupGroup {
             attributes: sorted_attributes(&doc, node, &["name"]),
             source_layers: group.source_layers.clone(),
+            cad_data_layer_refs: group
+                .cad_data_layer_refs
+                .iter()
+                .map(|reference| ipc.resolve(*reference).to_string())
+                .collect(),
             specs: group.spec_refs.iter().map(spec_evidence).collect(),
         })
         .collect::<Vec<_>>();

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -149,8 +149,25 @@ struct SourcePanel {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PhysicalStackup {
     attributes: Vec<(String, String)>,
+    specs: Vec<SpecEvidence>,
     groups: Vec<PhysicalStackupGroup>,
     layers: Vec<PhysicalStackupLayer>,
+    membership_layers: Vec<MembershipLayer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MembershipLayer {
+    name: String,
+    definition: ElementSignature,
+    specs: Vec<SpecEvidence>,
+    profile_units: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ElementSignature {
+    name: String,
+    attributes: Vec<(String, String)>,
+    children: Vec<ElementSignature>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -177,6 +194,7 @@ struct PhysicalStackupLayer {
     thickness: Option<u64>,
     tol_plus: Option<u64>,
     tol_minus: Option<u64>,
+    mat_des: Option<String>,
     material: Option<String>,
     dielectric_constant: Option<u64>,
     loss_tangent: Option<u64>,
@@ -309,6 +327,13 @@ pub fn create_fab_panel(
     if occurrences.is_empty() {
         bail!("at least one assembly panel is required");
     }
+    // Compare source evidence before manufacturing reduction removes BOM
+    // associations such as matDes from the emitted document.
+    let stackups = source_xml
+        .iter()
+        .enumerate()
+        .map(|(source_index, xml)| physical_stackup(xml, source_index))
+        .collect::<Result<Vec<_>>>()?;
     // Reduce every source to manufacturing content once, up front: assembling
     // already-stripped sources keeps the fabrication panel a pure composition
     // and avoids stripping the much larger composed document.
@@ -339,11 +364,6 @@ pub fn create_fab_panel(
         .map(strip)
         .collect::<Result<Vec<_>>>()?;
 
-    let stackups = source_xml
-        .iter()
-        .enumerate()
-        .map(|(source_index, xml)| physical_stackup(xml, source_index))
-        .collect::<Result<Vec<_>>>()?;
     let first_stackup = stackups
         .first()
         .context("at least one assembly panel source is required")?;
@@ -354,6 +374,12 @@ pub fn create_fab_panel(
         .layers
         .iter()
         .map(|layer| layer.name.clone())
+        .chain(
+            first_stackup
+                .membership_layers
+                .iter()
+                .map(|layer| layer.name.clone()),
+        )
         .collect::<HashSet<_>>();
 
     let sources = source_xml
@@ -536,6 +562,46 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
         })
         .collect::<Vec<_>>();
 
+    let mut membership_layers = Vec::new();
+    for reference in stackup
+        .groups
+        .iter()
+        .flat_map(|group| &group.cad_data_layer_refs)
+    {
+        let name = ipc.resolve(*reference);
+        if membership_layers
+            .iter()
+            .any(|layer: &MembershipLayer| layer.name == name)
+        {
+            continue;
+        }
+        let layer = ecad
+            .cad_data
+            .layers
+            .iter()
+            .find(|layer| layer.name == *reference)
+            .with_context(|| {
+                format!(
+                    "assembly panel input {input_number} group references missing layer '{name}'"
+                )
+            })?;
+        let node = doc
+            .find_all("Layer")
+            .into_iter()
+            .find(|node| doc.attr(*node, "name") == Some(name))
+            .context("parsed group layer must have a source definition")?;
+        membership_layers.push(MembershipLayer {
+            name: name.to_string(),
+            definition: element_signature(&doc, node),
+            specs: layer.spec_refs.iter().map(spec_evidence).collect(),
+            profile_units: doc
+                .children(node)
+                .iter()
+                .any(|child| doc.name(*child) == "Profile")
+                .then(|| format!("{:?}", ecad.cad_header.units)),
+        });
+    }
+
     let layers = stackup
         .layers
         .iter()
@@ -575,6 +641,7 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
                 thickness: float_bits(stackup_layer.thickness),
                 tol_plus: float_bits(stackup_layer.tol_plus),
                 tol_minus: float_bits(stackup_layer.tol_minus),
+                mat_des: stackup_layer.mat_des.map(|value| ipc.resolve(value).to_string()),
                 material: stackup_layer
                     .material
                     .map(|material| ipc.resolve(material).to_string()),
@@ -588,9 +655,24 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
 
     Ok(PhysicalStackup {
         attributes,
+        specs: stackup.spec_refs.iter().map(spec_evidence).collect(),
         groups,
         layers,
+        membership_layers,
     })
+}
+
+fn element_signature(doc: &Doc<'_>, node: Node) -> ElementSignature {
+    ElementSignature {
+        name: doc.name(node).to_string(),
+        attributes: sorted_attributes(doc, node, &[]),
+        children: doc
+            .children(node)
+            .into_iter()
+            .filter(|child| doc.name(*child) != "SpecRef")
+            .map(|child| element_signature(doc, child))
+            .collect(),
+    }
 }
 
 fn require_identical_stackup(
@@ -599,7 +681,11 @@ fn require_identical_stackup(
     source_index: usize,
 ) -> Result<()> {
     let input_number = source_index + 1;
-    if candidate.attributes != first.attributes || candidate.groups != first.groups {
+    if candidate.attributes != first.attributes
+        || candidate.specs != first.specs
+        || candidate.groups != first.groups
+        || candidate.membership_layers != first.membership_layers
+    {
         bail!(
             "assembly panel input {input_number} has stackup attributes that differ from assembly panel input 1"
         );

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -149,8 +149,21 @@ struct SourcePanel {
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct PhysicalStackup {
     attributes: Vec<(String, String)>,
-    group_attributes: Vec<Vec<(String, String)>>,
+    groups: Vec<PhysicalStackupGroup>,
     layers: Vec<PhysicalStackupLayer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PhysicalStackupGroup {
+    attributes: Vec<(String, String)>,
+    source_layers: std::ops::Range<usize>,
+    specs: Vec<SpecEvidence>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SpecEvidence {
+    Resolved(Box<SpecSignature>),
+    External(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -167,7 +180,7 @@ struct PhysicalStackupLayer {
     dielectric_constant: Option<u64>,
     loss_tangent: Option<u64>,
     layer_number: Option<u64>,
-    specs: Vec<SpecSignature>,
+    specs: Vec<SpecEvidence>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -501,11 +514,20 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
     }
     let stackup_node = stackup_nodes[0];
     let attributes = sorted_attributes(&doc, stackup_node, &["name"]);
-    let group_attributes = doc
+    let spec_evidence = |reference: &ipc2581::Symbol| match ecad.cad_header.specs.get(reference) {
+        Some(spec) => SpecEvidence::Resolved(Box::new(spec_signature(&ipc, spec))),
+        None => SpecEvidence::External(ipc.resolve(*reference).to_string()),
+    };
+    let groups = doc
         .children(stackup_node)
         .into_iter()
         .filter(|child| doc.name(*child) == "StackupGroup")
-        .map(|group| sorted_attributes(&doc, group, &["name"]))
+        .zip(&stackup.groups)
+        .map(|(node, group)| PhysicalStackupGroup {
+            attributes: sorted_attributes(&doc, node, &["name"]),
+            source_layers: group.source_layers.clone(),
+            specs: group.spec_refs.iter().map(spec_evidence).collect(),
+        })
         .collect::<Vec<_>>();
 
     let layers = stackup
@@ -529,13 +551,8 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
                 .spec_refs
                 .iter()
                 .chain(stackup_layer.spec_refs.iter().filter(|reference| !layer.spec_refs.contains(reference)))
-                .map(|reference| {
-                    let spec = ecad.cad_header.specs.get(reference).with_context(|| format!(
-                        "assembly panel input {input_number} stackup references unresolved specification '{}'", ipc.resolve(*reference)
-                    ))?;
-                    Ok(spec_signature(&ipc, spec))
-                })
-                .collect::<Result<Vec<_>>>()?;
+                .map(spec_evidence)
+                .collect();
 
             Ok(PhysicalStackupLayer {
                 name,
@@ -565,7 +582,7 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
 
     Ok(PhysicalStackup {
         attributes,
-        group_attributes,
+        groups,
         layers,
     })
 }
@@ -576,9 +593,7 @@ fn require_identical_stackup(
     source_index: usize,
 ) -> Result<()> {
     let input_number = source_index + 1;
-    if candidate.attributes != first.attributes
-        || candidate.group_attributes != first.group_attributes
-    {
+    if candidate.attributes != first.attributes || candidate.groups != first.groups {
         bail!(
             "assembly panel input {input_number} has stackup attributes that differ from assembly panel input 1"
         );

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -619,10 +619,9 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
                         layer_index + 1
                     )
                 })?;
-            let specs = layer
-                .spec_refs
+            let specs = stackup_layer
+                .combined_spec_refs(&ecad.cad_data.layers)
                 .iter()
-                .chain(stackup_layer.spec_refs.iter().filter(|reference| !layer.spec_refs.contains(reference)))
                 .map(spec_evidence)
                 .collect();
 

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/mod.rs
@@ -166,7 +166,7 @@ struct PhysicalStackupLayer {
     material: Option<String>,
     dielectric_constant: Option<u64>,
     loss_tangent: Option<u64>,
-    layer_number: Option<u32>,
+    layer_number: Option<u64>,
     specs: Vec<SpecSignature>,
 }
 
@@ -558,7 +558,7 @@ fn physical_stackup(xml: &str, source_index: usize) -> Result<PhysicalStackup> {
                     .map(|material| ipc.resolve(material).to_string()),
                 dielectric_constant: float_bits(stackup_layer.dielectric_constant),
                 loss_tangent: float_bits(stackup_layer.loss_tangent),
-                layer_number: stackup_layer.layer_number,
+                layer_number: float_bits(stackup_layer.layer_number),
                 specs,
             })
         })

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -100,6 +100,73 @@ fn multiple_stackup_specs_reach_fab_comparison_and_property_accessors() {
     );
 }
 
+#[test]
+fn external_specs_remain_comparable_and_keep_their_output_identity() {
+    let xml = assembly_panel_xml(20.0, 20.0)
+        .replace(
+            "sequence=\"0\"/>",
+            "sequence=\"0\"><SpecRef id=\"external-stack\"/></StackupLayer>",
+        )
+        .replace(
+            "</StackupGroup>",
+            "<SpecRef id=\"external-group\"/></StackupGroup>",
+        )
+        .replace(
+            "side=\"TOP\" polarity=\"POSITIVE\"/>",
+            "side=\"TOP\" polarity=\"POSITIVE\"><SpecRef id=\"external-layer\"/></Layer>",
+        );
+    let generated = create_fab_panel_xml(&[xml.clone(), xml.clone()], &[0, 1]).unwrap();
+    for reference in ["external-layer", "external-stack", "external-group"] {
+        assert!(generated.contains(&format!(r#"<SpecRef id="{reference}""#)));
+        assert!(!generated.contains(&format!("fab_0_{reference}")));
+        let changed = xml.replace(reference, &format!("different-{reference}"));
+        assert!(create_fab_panel_xml(&[xml.clone(), changed], &[0, 1]).is_err());
+    }
+}
+
+#[test]
+fn group_spec_payloads_participate_in_panel_compatibility() {
+    let xml = assembly_panel_xml(20.0, 20.0)
+        .replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="group-spec"><General type="MATERIAL"><Property text="FR4"/></General></Spec></CadHeader>"#)
+        .replace("</StackupGroup>", "<SpecRef id=\"group-spec\"/></StackupGroup>");
+    let generated = create_fab_panel_xml(&[xml.clone(), xml.clone()], &[0, 1]).unwrap();
+    assert!(generated.contains(r#"<SpecRef id="fab_0_group-spec""#));
+    let changed = xml.replace("FR4", "PTFE");
+    assert!(create_fab_panel_xml(&[xml, changed], &[0, 1]).is_err());
+}
+
+#[test]
+fn conflicting_color_and_finish_evidence_is_order_independent() {
+    for (first, second) in [
+        (r#"<ColorTerm name="RED"/>"#, r#"<ColorTerm name="GREEN"/>"#),
+        (
+            r#"<Color r="1" g="2" b="3"/>"#,
+            r#"<Color r="4" g="5" b="6"/>"#,
+        ),
+    ] {
+        let xml = assembly_panel_xml(20.0, 20.0)
+            .replace("<CadHeader units=\"MILLIMETER\"/>", &format!(r#"<CadHeader units="MILLIMETER"><Spec name="a"><General type="MATERIAL">{first}</General><SurfaceFinish type="OSP"/></Spec><Spec name="b"><General type="MATERIAL">{second}</General><SurfaceFinish type="S"/></Spec></CadHeader>"#));
+        for refs in [
+            r#"<SpecRef id="a"/><SpecRef id="b"/>"#,
+            r#"<SpecRef id="b"/><SpecRef id="a"/>"#,
+        ] {
+            let xml = xml.replace(
+                "sequence=\"0\"/>",
+                &format!("sequence=\"0\">{refs}</StackupLayer>"),
+            );
+            for role in ["SOLDERMASK", "LEGEND", "COATINGNONCOND"] {
+                let ipc = Ipc2581::parse(&xml.replace("CONDUCTOR", role)).unwrap();
+                let details = crate::accessors::IpcAccessor::new(&ipc)
+                    .stackup_details()
+                    .unwrap();
+                assert!(details.soldermask_color.is_none());
+                assert!(details.silkscreen_color.is_none());
+                assert!(details.surface_finish.is_none());
+            }
+        }
+    }
+}
+
 fn assembly_panel_xml(width_mm: f64, height_mm: f64) -> String {
     assembly_panel_xml_at(0.0, 0.0, width_mm, height_mm)
 }

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -104,6 +104,10 @@ fn multiple_stackup_specs_reach_fab_comparison_and_property_accessors() {
 fn external_specs_remain_comparable_and_keep_their_output_identity() {
     let xml = assembly_panel_xml(20.0, 20.0)
         .replace(
+            "<StackupGroup name=",
+            "<SpecRef id=\"external-root\"/><StackupGroup name=",
+        )
+        .replace(
             "sequence=\"0\"/>",
             "sequence=\"0\"><SpecRef id=\"external-stack\"/></StackupLayer>",
         )
@@ -116,7 +120,12 @@ fn external_specs_remain_comparable_and_keep_their_output_identity() {
             "side=\"TOP\" polarity=\"POSITIVE\"><SpecRef id=\"external-layer\"/></Layer>",
         );
     let generated = create_fab_panel_xml(&[xml.clone(), xml.clone()], &[0, 1]).unwrap();
-    for reference in ["external-layer", "external-stack", "external-group"] {
+    for reference in [
+        "external-layer",
+        "external-stack",
+        "external-group",
+        "external-root",
+    ] {
         assert!(generated.contains(&format!(r#"<SpecRef id="{reference}""#)));
         assert!(!generated.contains(&format!("fab_0_{reference}")));
         let changed = xml.replace(reference, &format!("different-{reference}"));
@@ -133,6 +142,40 @@ fn group_spec_payloads_participate_in_panel_compatibility() {
     assert!(generated.contains(r#"<SpecRef id="fab_0_group-spec""#));
     let changed = xml.replace("FR4", "PTFE");
     assert!(create_fab_panel_xml(&[xml, changed], &[0, 1]).is_err());
+}
+
+#[test]
+fn direct_stackup_spec_payloads_participate_in_panel_compatibility() {
+    let xml = assembly_panel_xml(20.0, 20.0)
+        .replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="root-spec"><General type="MATERIAL"><Property text="FR4"/></General></Spec></CadHeader>"#)
+        .replace("<StackupGroup name=", "<SpecRef id=\"root-spec\"/><StackupGroup name=");
+    assert!(create_fab_panel_xml(&[xml.clone(), xml.clone()], &[0, 1]).is_ok());
+    let changed = xml.replace("FR4", "PTFE");
+    assert!(create_fab_panel_xml(&[xml, changed], &[0, 1]).is_err());
+}
+
+#[test]
+fn partial_color_records_retain_only_common_evidence() {
+    let xml = assembly_panel_xml(20.0, 20.0)
+        .replace("CONDUCTOR", "SOLDERMASK")
+        .replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="a"><General type="MATERIAL"><ColorTerm name="RED"/></General></Spec><Spec name="b"><General type="MATERIAL"><ColorTerm name="RED"/><Color r="255" g="0" b="0"/></General></Spec></CadHeader>"#);
+    for refs in [
+        r#"<SpecRef id="a"/><SpecRef id="b"/>"#,
+        r#"<SpecRef id="b"/><SpecRef id="a"/>"#,
+    ] {
+        let ipc = Ipc2581::parse(&xml.replace(
+            "sequence=\"0\"/>",
+            &format!("sequence=\"0\">{refs}</StackupLayer>"),
+        ))
+        .unwrap();
+        let color = crate::accessors::IpcAccessor::new(&ipc)
+            .stackup_details()
+            .unwrap()
+            .soldermask_color
+            .unwrap();
+        assert_eq!(color.name.as_deref(), Some("RED"));
+        assert_eq!(color.rgb, None, "RGB is not common to both source records");
+    }
 }
 
 #[test]
@@ -155,7 +198,26 @@ fn cad_data_group_membership_is_preserved_and_compared() {
     );
     let generated = create_fab_panel_xml(&[xml.clone(), xml.clone()], &[0, 1]).unwrap();
     assert!(generated.contains(r#"<CADDataLayerRef layerId="TOP""#));
+    assert!(generated.contains(r#"<CADDataLayerRef layerId="BOTTOM""#));
+    assert_eq!(generated.matches(r#"<Layer name="BOTTOM""#).count(), 1);
+    assert!(!generated.contains("fab_0_BOTTOM"));
+    assert!(!generated.contains("fab_1_BOTTOM"));
+    let missing = xml.replace(
+        r#"<Layer name="BOTTOM" layerFunction="CONDUCTOR" side="BOTTOM" polarity="POSITIVE"/>"#,
+        "",
+    );
+    assert!(create_fab_panel_xml(&[missing], &[0]).is_err());
+    let changed = xml.replace(r#"side="BOTTOM""#, r#"side="TOP""#);
+    assert!(create_fab_panel_xml(&[xml.clone(), changed], &[0, 1]).is_err());
     let changed = xml.replace(r#"layerId="TOP""#, r#"layerId="BOTTOM""#);
+    assert!(create_fab_panel_xml(&[xml, changed], &[0, 1]).is_err());
+}
+
+#[test]
+fn different_stackup_layer_material_designators_reject_panel_merge() {
+    let xml = assembly_panel_xml(20.0, 20.0)
+        .replace(r#"sequence="0""#, r#"sequence="0" matDes="material-a""#);
+    let changed = xml.replace("material-a", "material-b");
     assert!(create_fab_panel_xml(&[xml, changed], &[0, 1]).is_err());
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -136,9 +136,37 @@ fn group_spec_payloads_participate_in_panel_compatibility() {
 }
 
 #[test]
+fn cad_data_group_membership_is_preserved_and_compared() {
+    let xml = assembly_panel_xml(20.0, 20.0).replace(
+        "</StackupGroup>",
+        r#"<CADDataLayerRef layerId="TOP"/></StackupGroup><StackupGroup name="membership-only" thickness="0" tolPlus="0" tolMinus="0"><CADDataLayerRef layerId="TOP"/><CADDataLayerRef layerId="BOTTOM"/></StackupGroup>"#,
+    ).replace("<Stackup name=", r#"<Layer name="BOTTOM" layerFunction="CONDUCTOR" side="BOTTOM" polarity="POSITIVE"/><Stackup name="#);
+    let ipc = Ipc2581::parse(&xml).unwrap();
+    let groups = &ipc.ecad().unwrap().cad_data.stackups[0].groups;
+    assert_eq!(groups[0].source_layers, 0..1);
+    assert_eq!(groups[1].source_layers, 1..1);
+    assert_eq!(
+        groups[1]
+            .cad_data_layer_refs
+            .iter()
+            .map(|reference| ipc.resolve(*reference))
+            .collect::<Vec<_>>(),
+        ["TOP", "BOTTOM"]
+    );
+    let generated = create_fab_panel_xml(&[xml.clone(), xml.clone()], &[0, 1]).unwrap();
+    assert!(generated.contains(r#"<CADDataLayerRef layerId="TOP""#));
+    let changed = xml.replace(r#"layerId="TOP""#, r#"layerId="BOTTOM""#);
+    assert!(create_fab_panel_xml(&[xml, changed], &[0, 1]).is_err());
+}
+
+#[test]
 fn conflicting_color_and_finish_evidence_is_order_independent() {
     for (first, second) in [
         (r#"<ColorTerm name="RED"/>"#, r#"<ColorTerm name="GREEN"/>"#),
+        (
+            r#"<ColorTerm name="RED"/>"#,
+            r#"<Color r="0" g="255" b="0"/>"#,
+        ),
         (
             r#"<Color r="1" g="2" b="3"/>"#,
             r#"<Color r="4" g="5" b="6"/>"#,

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -42,6 +42,64 @@ fn stackup_signatures_treat_signed_zero_sequences_as_the_same_number() {
     );
 }
 
+#[test]
+fn multiple_stackup_specs_reach_fab_comparison_and_property_accessors() {
+    let xml = assembly_panel_xml(20.0, 20.0)
+        .replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="a"><General type="MATERIAL"><Property text="FR4"/></General></Spec><Spec name="b"><General type="MATERIAL"><Property text="FR4"/><ColorTerm name="GREEN"/></General><Dielectric type="DIELECTRIC_CONSTANT"><Property value="4.2"/></Dielectric><SurfaceFinish type="OSP"/></Spec></CadHeader>"#)
+        .replace("sequence=\"0\"/>", "sequence=\"0\"><SpecRef id=\"a\"/><SpecRef id=\"b\"/></StackupLayer>");
+    let changed = xml.replace(
+        "name=\"b\"><General type=\"MATERIAL\"><Property text=\"FR4\"",
+        "name=\"b\"><General type=\"MATERIAL\"><Property text=\"PTFE\"",
+    );
+    assert_ne!(
+        physical_stackup(&xml, 0).unwrap(),
+        physical_stackup(&changed, 1).unwrap()
+    );
+    assert!(create_fab_panel_xml(&[xml.clone(), changed.clone()], &[0, 1]).is_err());
+    let ipc = Ipc2581::parse(&xml).unwrap();
+    let details = crate::accessors::IpcAccessor::new(&ipc)
+        .stackup_details()
+        .unwrap();
+    assert_eq!(details.layers[0].material.as_deref(), Some("FR4"));
+    assert_eq!(details.layers[0].dielectric_constant, Some(4.2));
+    let ipc = Ipc2581::parse(&changed).unwrap();
+    assert!(
+        crate::accessors::IpcAccessor::new(&ipc)
+            .stackup_details()
+            .unwrap()
+            .layers[0]
+            .material
+            .is_none()
+    );
+    let mask = Ipc2581::parse(&xml.replace(
+        "layerFunction=\"CONDUCTOR\"",
+        "layerFunction=\"SOLDERMASK\"",
+    ))
+    .unwrap();
+    assert_eq!(
+        crate::accessors::IpcAccessor::new(&mask)
+            .stackup_details()
+            .unwrap()
+            .soldermask_color
+            .unwrap()
+            .name
+            .as_deref(),
+        Some("GREEN")
+    );
+    let coating = Ipc2581::parse(&xml.replace(
+        "layerFunction=\"CONDUCTOR\"",
+        "layerFunction=\"COATINGNONCOND\"",
+    ))
+    .unwrap();
+    assert!(
+        crate::accessors::IpcAccessor::new(&coating)
+            .stackup_details()
+            .unwrap()
+            .surface_finish
+            .is_some()
+    );
+}
+
 fn assembly_panel_xml(width_mm: f64, height_mm: f64) -> String {
     assembly_panel_xml_at(0.0, 0.0, width_mm, height_mm)
 }

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -101,6 +101,68 @@ fn multiple_stackup_specs_reach_fab_comparison_and_property_accessors() {
 }
 
 #[test]
+fn cad_data_layer_specs_reconcile_with_stackup_position_evidence() {
+    for (stack_ref, conflicting) in [("", false), ("a", false), ("b", false), ("b", true)] {
+        let (material, dk, color, finish) = if conflicting {
+            ("PTFE", "2.1", "BLUE", "S")
+        } else {
+            ("FR4", "4.2", "RED", "OSP")
+        };
+        let xml = assembly_panel_xml(20.0, 20.0)
+            .replace("<CadHeader units=\"MILLIMETER\"/>", &format!(r#"<CadHeader units="MILLIMETER"><Spec name="a"><General type="MATERIAL"><Property text="FR4"/><ColorTerm name="RED"/></General><Dielectric type="DIELECTRIC_CONSTANT"><Property value="4.2"/></Dielectric><SurfaceFinish type="OSP"/></Spec><Spec name="b"><General type="MATERIAL"><Property text="{material}"/><ColorTerm name="{color}"/></General><Dielectric type="DIELECTRIC_CONSTANT"><Property value="{dk}"/></Dielectric><SurfaceFinish type="{finish}"/></Spec></CadHeader>"#))
+            .replace("side=\"TOP\" polarity=\"POSITIVE\"/>", "side=\"TOP\" polarity=\"POSITIVE\"><SpecRef id=\"a\"/></Layer>");
+        let xml = if stack_ref.is_empty() {
+            xml
+        } else {
+            xml.replace(
+                "sequence=\"0\"/>",
+                &format!("sequence=\"0\"><SpecRef id=\"{stack_ref}\"/></StackupLayer>"),
+            )
+        };
+        let ipc = Ipc2581::parse(&xml).unwrap();
+        let imported = pcb_ir::import::ipc2581::import_design(&ipc, Resolution::default()).unwrap();
+        let metadata = imported.physical_board_metadata();
+        assert_eq!(
+            metadata.layers[0].spec_refs.len(),
+            if stack_ref == "b" { 2 } else { 1 }
+        );
+        assert_eq!(
+            metadata.layers[0]
+                .material
+                .resolved()
+                .map(|value| imported.resolve(*value)),
+            if conflicting { None } else { Some("FR4") }
+        );
+        for role in ["SOLDERMASK", "COATINGNONCOND"] {
+            let ipc = Ipc2581::parse(&xml.replace("CONDUCTOR", role)).unwrap();
+            let details = crate::accessors::IpcAccessor::new(&ipc)
+                .stackup_details()
+                .unwrap();
+            assert_eq!(
+                details.layers[0].material.as_deref(),
+                if conflicting { None } else { Some("FR4") }
+            );
+            assert_eq!(
+                details.layers[0].dielectric_constant,
+                if conflicting { None } else { Some(4.2) }
+            );
+            if role == "SOLDERMASK" {
+                assert_eq!(
+                    details.soldermask_color.and_then(|color| color.name),
+                    if conflicting {
+                        None
+                    } else {
+                        Some("RED".to_string())
+                    }
+                );
+            } else {
+                assert_eq!(details.surface_finish.is_some(), !conflicting);
+            }
+        }
+    }
+}
+
+#[test]
 fn external_specs_remain_comparable_and_keep_their_output_identity() {
     let xml = assembly_panel_xml(20.0, 20.0)
         .replace(

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/tests.rs
@@ -32,6 +32,16 @@ fn manufacturing_package(
 const FAB_PANEL_WIDTH_MM: f64 = FabPanelSpec::INCHES_18_X_24.width_mm();
 const FAB_PANEL_HEIGHT_MM: f64 = FabPanelSpec::INCHES_18_X_24.height_mm();
 
+#[test]
+fn stackup_signatures_treat_signed_zero_sequences_as_the_same_number() {
+    let xml = assembly_panel_xml(20.0, 20.0);
+    let negative_zero = xml.replace("sequence=\"0\"", "sequence=\"-0.0\"");
+    assert_eq!(
+        physical_stackup(&xml, 0).unwrap(),
+        physical_stackup(&negative_zero, 1).unwrap()
+    );
+}
+
 fn assembly_panel_xml(width_mm: f64, height_mm: f64) -> String {
     assembly_panel_xml_at(0.0, 0.0, width_mm, height_mm)
 }

--- a/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/fab_panel/xml.rs
@@ -21,8 +21,20 @@ pub(super) fn namespace_source(
 ) -> Result<String> {
     let doc = Doc::parse(xml)?;
     let root = doc.root()?;
+    let local_specs = doc
+        .find_all("Spec")
+        .into_iter()
+        .filter_map(|node| doc.attr(node, "name").map(str::to_string))
+        .collect();
     let mut edits = Vec::new();
-    collect_namespace_edits(&doc, root, prefix, shared_stackup_layers, &mut edits);
+    collect_namespace_edits(
+        &doc,
+        root,
+        prefix,
+        shared_stackup_layers,
+        &local_specs,
+        &mut edits,
+    );
     Ok(edit::apply(xml, edits)?)
 }
 
@@ -31,6 +43,7 @@ fn collect_namespace_edits(
     node: Node,
     prefix: &str,
     shared_stackup_layers: &HashSet<String>,
+    local_specs: &HashSet<String>,
     edits: &mut Vec<Edit>,
 ) {
     let element = doc.name(node);
@@ -38,7 +51,13 @@ fn collect_namespace_edits(
     let attrs = doc
         .attrs(node)
         .map(|(name, value)| {
-            let value = if should_namespace_attr(element, name, value, shared_stackup_layers) {
+            // Only local definitions move into the source namespace. External
+            // specification identities must remain usable by downstream tools.
+            let external_spec =
+                element == "SpecRef" && name == "id" && !local_specs.contains(value);
+            let value = if !external_spec
+                && should_namespace_attr(element, name, value, shared_stackup_layers)
+            {
                 changed = true;
                 format!("{prefix}{value}")
             } else {
@@ -59,7 +78,14 @@ fn collect_namespace_edits(
     }
 
     for child in doc.children(node) {
-        collect_namespace_edits(doc, child, prefix, shared_stackup_layers, edits);
+        collect_namespace_edits(
+            doc,
+            child,
+            prefix,
+            shared_stackup_layers,
+            local_specs,
+            edits,
+        );
     }
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/html_export.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/html_export.rs
@@ -515,7 +515,7 @@ fn extract_stackup_data(accessor: &IpcAccessor, unit_format: UnitFormat) -> Opti
             };
 
             StackupLayer {
-                number: layer.layer_number.unwrap_or(0).to_string(),
+                number: layer.layer_number.unwrap_or(0.0).to_string(),
                 name: layer.name.clone(),
                 layer_type: layer.layer_type.as_str().to_string(),
                 thickness_mm,

--- a/crates/pcb-ipc2581-tools/src/commands/info.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/info.rs
@@ -357,7 +357,7 @@ fn output_text(
             .iter()
             .filter(|l| l.layer_type != StackupLayerType::Other)
         {
-            let layer_num = layer.layer_number.unwrap_or(0);
+            let layer_num = layer.layer_number.unwrap_or(0.0);
             let material = layer.material.as_deref().unwrap_or("");
             let dk = layer
                 .dielectric_constant

--- a/crates/pcb-ipc2581-tools/src/warp.rs
+++ b/crates/pcb-ipc2581-tools/src/warp.rs
@@ -139,7 +139,7 @@ pub(crate) fn physical_stack(ipc: &Ipc2581) -> Result<(ThermalStack, Vec<String>
         .context("IPC-2581 file carries no physical stackup")?;
     let mut ordered = stackup.layers.iter().collect::<Vec<_>>();
     if ordered.iter().all(|layer| layer.layer_number.is_some()) {
-        ordered.sort_by_key(|layer| layer.layer_number);
+        ordered.sort_by(|a, b| a.layer_number.unwrap().total_cmp(&b.layer_number.unwrap()));
     }
 
     // Silkscreen and coating are carried in the stackup at zero thickness. They

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -1350,11 +1350,32 @@ impl ImportedDesign {
             definition.layer_function,
             LayerFunction::Drill | LayerFunction::Rout
         ) {
-            for feature in &mut document.features {
-                if feature.bucket == FeatureBucket::Cutout {
-                    feature.bucket = FeatureBucket::Fill;
+            use crate::dialects::artwork;
+            crate::dialects::ipc::process::normalize_for_artwork(&mut document, resolution)?;
+            let artwork = crate::dialects::ipc::lower_layer_to_artwork(
+                &document,
+                0,
+                layer_role(definition.layer_function),
+                side_for_layer(definition.side),
+            );
+            let mut artwork = artwork::expand_instances(&artwork);
+            // Apertures are terminal positive removals from the board, not
+            // clears of the removal image. Stable ordering preserves ordinary
+            // route paint/clear order before appending all aperture positives.
+            artwork
+                .objects
+                .sort_by_key(|object| object.order.stage == artwork::PaintStage::FinalCutout);
+            for object in &mut artwork.objects {
+                if object.order.stage == artwork::PaintStage::FinalCutout {
+                    object.order.stage = artwork::PaintStage::Overlay;
                 }
             }
+            let (mut layers, _) =
+                artwork::compose_owner_regions(&artwork, |_| Some(()), resolution)?;
+            return Ok(layers
+                .pop()
+                .and_then(|mut owners| owners.pop())
+                .map_or_else(|| ContourSet::empty(resolution), |(_, region)| region));
         }
         document.into_layer_image(
             0,

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -1342,7 +1342,21 @@ impl ImportedDesign {
             .layer_definitions
             .get(layer.0 as usize)
             .context("layer id is outside the imported design")?;
-        self.materialize_layer(layer, scope)?.into_layer_image(
+        let mut document = self.materialize_layer(layer, scope)?;
+        // A drill/rout layer images removal itself. Its holes and slots add
+        // apertures even beside generic route artwork; they are not final
+        // cutters of that artwork as they are on a copper layer.
+        if matches!(
+            definition.layer_function,
+            LayerFunction::Drill | LayerFunction::Rout
+        ) {
+            for feature in &mut document.features {
+                if feature.bucket == FeatureBucket::Cutout {
+                    feature.bucket = FeatureBucket::Fill;
+                }
+            }
+        }
+        document.into_layer_image(
             0,
             layer_role(definition.layer_function),
             side_for_layer(definition.side),

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -4,6 +4,9 @@
 //! geometry remains owned once by the canonical IPC document and final images
 //! are composed on demand for the requested layout scope.
 
+mod board;
+pub use board::*;
+
 use crate::geom::Resolution;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -1258,9 +1258,9 @@ pub(super) fn physical_stackup_layers(
     ensure!(!layers.is_empty(), "physical stackup contains no layers");
     if layers.iter().all(|layer| layer.layer_number.is_some()) {
         ensure!(
-            layers.iter().all(|layer| layer
-                .layer_number
-                .is_some_and(|number| number.is_finite() && number >= 0.0)),
+            layers
+                .iter()
+                .all(|layer| layer.layer_number.is_some_and(|number| number >= 0.0)),
             "physical stackup has invalid layer sequence numbers"
         );
         layers.sort_by(|a, b| a.layer_number.unwrap().total_cmp(&b.layer_number.unwrap()));

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -588,6 +588,19 @@ impl ImportedDesign {
                     .map(|layer| layer.name)
                     .collect()
             });
+        self.derive_hole_apertures(scope, lands, &layer_order, resolution)
+    }
+
+    // Geometry and declared source spans do not require a resolved stackup.
+    // Passing no lands deliberately leaves stackup-dependent associations
+    // unresolved, without guessing a layer order or discarding apertures.
+    fn derive_hole_apertures(
+        &self,
+        scope: ArtworkScope,
+        lands: &[PhysicalLand],
+        layer_order: &[Symbol],
+        resolution: Resolution,
+    ) -> Result<Vec<PhysicalHole>> {
         let mut lands_by_layer = BTreeMap::<_, Vec<_>>::new();
         for land in lands {
             lands_by_layer.entry(land.layer).or_default().push(land);
@@ -615,7 +628,7 @@ impl ImportedDesign {
                     if !feature_spans_layer(
                         feature.intent.span,
                         self.layer_definitions[copper_layer.0 as usize].name,
-                        &layer_order,
+                        layer_order,
                     ) {
                         continue;
                     }

--- a/crates/pcb-ir/src/import/physical.rs
+++ b/crates/pcb-ir/src/import/physical.rs
@@ -1257,7 +1257,13 @@ pub(super) fn physical_stackup_layers(
     let mut layers = stackup.layers.iter().collect::<Vec<_>>();
     ensure!(!layers.is_empty(), "physical stackup contains no layers");
     if layers.iter().all(|layer| layer.layer_number.is_some()) {
-        layers.sort_by_key(|layer| layer.layer_number);
+        ensure!(
+            layers.iter().all(|layer| layer
+                .layer_number
+                .is_some_and(|number| number.is_finite() && number >= 0.0)),
+            "physical stackup has invalid layer sequence numbers"
+        );
+        layers.sort_by(|a, b| a.layer_number.unwrap().total_cmp(&b.layer_number.unwrap()));
         ensure!(
             !layers
                 .windows(2)

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -1,0 +1,452 @@
+//! Board-local mechanical evidence over the existing headless import APIs.
+
+use anyhow::{Result, ensure};
+use ipc2581::{Symbol, types::LayerFunction};
+
+use super::{Association, PhysicalHole, physical_stackup_layers};
+use crate::dialects::assembly::{
+    self, ComponentOccurrenceId, PackageGeometryStatus, PackageViewKind,
+};
+use crate::dialects::ipc::{ArtworkScope, LayoutStepKind};
+use crate::geom::{Affine2, ContourSet, Diagnostic, Mirror, Point, Resolution};
+use crate::import::ipc2581::{FeatureOccurrenceId, ImportedDesign, LayerId, is_copper};
+
+#[cfg(test)]
+mod tests;
+
+/// A canonical board definition, not a panel instance. All planar coordinates
+/// and thicknesses are millimeters; no datum shift or placement is applied.
+/// Regions use the caller's explicit resolution and propagate accuracy errors.
+#[derive(Debug, Clone)]
+pub struct BoardPhysicalView {
+    pub step: u32,
+    /// Nominal substrate after profile cutouts, before drilling/routing.
+    /// Blind/buried or unknown-span holes must not be subtracted in 2D.
+    pub substrate: ContourSet,
+    pub profile_cutouts: ContourSet,
+    /// Indices into `ImportedDesign::geometry.profiles` backing the substrate.
+    pub profiles: Vec<u32>,
+    /// Final, polarity-composed copper, kept separate by source layer.
+    pub copper: Vec<BoardCopper>,
+    /// Final drill/rout images, including non-hole artwork. These are not
+    /// automatically through-board voids; source features retain their spans.
+    pub removal_layers: Vec<BoardRemovalLayer>,
+    /// Source-identified hole/slot apertures, retaining plating and Z-span.
+    /// Unlike removal_layers these are source images, before polarity clears.
+    pub holes: Vec<PhysicalHole>,
+    pub components: Vec<ComponentEnvelopes>,
+    pub metadata: BoardPhysicalMetadata,
+    pub diagnostics: Vec<BoardPhysicalDiagnostic>,
+    pub source_diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoardRemovalLayer {
+    pub layer: LayerId,
+    pub image: ContourSet,
+    pub sources: Vec<FeatureOccurrenceId>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoardCopper {
+    pub layer: LayerId,
+    pub image: ContourSet,
+}
+
+/// These are source semantics, not interchangeable collision envelopes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvelopeKind {
+    /// IPC Package/Outline does not specify whether the exporter used a body
+    /// outline or a courtyard. It must not be promoted to physical material.
+    PackageOutlineUnspecified,
+    /// Outline explicitly carried by the package AssemblyDrawing. This is
+    /// assembly evidence, not a measured 3D body or a clearance requirement.
+    AssemblyOutline,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentEnvelope {
+    pub kind: EnvelopeKind,
+    pub view: PackageViewKind,
+    pub status: PackageGeometryStatus,
+    /// Interior of the source closed outline (not the ink stroke).
+    pub image: ContourSet,
+}
+
+#[derive(Debug, Clone)]
+pub struct ComponentEnvelopes {
+    pub component: ComponentOccurrenceId,
+    pub designator: Option<String>,
+    pub population: assembly::Population,
+    pub side: assembly::Side,
+    pub envelopes: Vec<ComponentEnvelope>,
+}
+
+/// Source evidence only. No implicit FR-4, copper weight conversion, elastic
+/// constants, or thickness fallback. Raw stackups/specs remain on ImportedDesign.
+#[derive(Debug, Clone)]
+pub struct BoardPhysicalMetadata {
+    pub stackup: Association<Symbol>,
+    pub overall_thickness_mm: Option<f64>,
+    pub layers: Vec<BoardMaterialLayer>,
+    pub diagnostics: Vec<BoardPhysicalDiagnostic>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BoardMaterialLayer {
+    pub layer_ref: Symbol,
+    pub thickness_mm: Option<f64>,
+    pub material: Association<Symbol>,
+    pub spec_ref: Option<Symbol>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum BoardPhysicalDiagnostic {
+    MissingProfile,
+    MissingStackup,
+    AmbiguousStackup,
+    InvalidStackupOrder(String),
+    MissingThickness { layer: Option<Symbol> },
+    InvalidThickness { layer: Option<Symbol>, value: f64 },
+    MissingMaterial { layer: Symbol },
+    AmbiguousMaterial { layer: Symbol },
+    ConflictingMaterial { layer: Symbol },
+    UnresolvedSpec { layer: Symbol, spec: Symbol },
+    MissingComponentEnvelope(ComponentOccurrenceId),
+    UnspecifiedPackageOutline(ComponentOccurrenceId),
+    IncompleteComponentEnvelope(ComponentOccurrenceId),
+}
+
+impl ImportedDesign {
+    /// Consume a single canonical board without reconstructing IPC geometry.
+    /// Multiple board definitions are rejected rather than selecting an
+    /// arbitrary board from a heterogeneous panel. Nested panel placement
+    /// does not alter the board-local result. Missing metadata is diagnostic;
+    /// invalid geometry/materialization remains an error, never an empty view.
+    pub fn physical_board(&self, resolution: Resolution) -> Result<BoardPhysicalView> {
+        let boards = self
+            .geometry
+            .layout
+            .steps
+            .iter()
+            .enumerate()
+            .filter(|(_, step)| step.kind == LayoutStepKind::Board)
+            .collect::<Vec<_>>();
+        ensure!(
+            boards.len() == 1,
+            "physical board view requires exactly one board definition; found {}",
+            boards.len()
+        );
+        let (step_index, step) = boards[0];
+        let mut substrate = ContourSet::empty(resolution);
+        let mut profile_cutouts = ContourSet::empty(resolution);
+        let profiles = step.profiles.indices().collect::<Vec<_>>();
+        for &index in &profiles {
+            let profile = &self.geometry.profiles[index as usize];
+            let outer = profile_region(self, profile.outer_path, resolution)?;
+            let mut cutouts = ContourSet::empty(resolution);
+            for cutout in profile.cutouts.slice(&self.geometry.profile_cutouts) {
+                cutouts.union_assign(&profile_region(self, cutout.path, resolution)?)?;
+            }
+            substrate.union_assign(&outer.difference(&cutouts)?)?;
+            profile_cutouts.union_assign(&cutouts)?;
+        }
+        let copper = self
+            .layer_definitions
+            .iter()
+            .enumerate()
+            .filter(|(_, layer)| is_copper(layer.layer_function))
+            .map(|(index, _)| {
+                let layer = LayerId(index as u32);
+                Ok(BoardCopper {
+                    layer,
+                    image: self.composed_layer_image(layer, ArtworkScope::Board, resolution)?,
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let removal_layers = self
+            .layer_definitions
+            .iter()
+            .enumerate()
+            .filter(|(_, layer)| {
+                matches!(
+                    layer.layer_function,
+                    LayerFunction::Drill | LayerFunction::Rout
+                )
+            })
+            .map(|(index, _)| {
+                let layer = LayerId(index as u32);
+                Ok(BoardRemovalLayer {
+                    layer,
+                    image: self.composed_layer_image(layer, ArtworkScope::Board, resolution)?,
+                    sources: self
+                        .feature_occurrences(layer, ArtworkScope::Board)?
+                        .into_iter()
+                        .map(|occurrence| occurrence.id)
+                        .collect(),
+                })
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let assembly = self.assembly_document(assembly::Scope::Board)?;
+        ensure!(
+            assembly.root_step == Some(step_index as u32),
+            "canonical board is not reachable from the layout root"
+        );
+        let components = component_envelopes(&assembly, resolution)?;
+        let mut diagnostics = Vec::new();
+        if substrate.is_empty() {
+            diagnostics.push(BoardPhysicalDiagnostic::MissingProfile);
+        }
+        for component in &components {
+            if component.envelopes.is_empty() {
+                diagnostics.push(BoardPhysicalDiagnostic::MissingComponentEnvelope(
+                    component.component,
+                ));
+            }
+            if component
+                .envelopes
+                .iter()
+                .any(|envelope| envelope.kind == EnvelopeKind::PackageOutlineUnspecified)
+            {
+                diagnostics.push(BoardPhysicalDiagnostic::UnspecifiedPackageOutline(
+                    component.component,
+                ));
+            }
+            if component.envelopes.iter().any(|envelope| {
+                envelope.status != PackageGeometryStatus::Complete || envelope.image.is_empty()
+            }) {
+                diagnostics.push(BoardPhysicalDiagnostic::IncompleteComponentEnvelope(
+                    component.component,
+                ));
+            }
+        }
+        Ok(BoardPhysicalView {
+            step: step_index as u32,
+            substrate,
+            profile_cutouts,
+            profiles,
+            copper,
+            removal_layers,
+            holes: self.physical_holes(ArtworkScope::Board, resolution)?,
+            components,
+            metadata: self.physical_board_metadata(),
+            diagnostics,
+            source_diagnostics: self.geometry.diagnostics.clone(),
+        })
+    }
+
+    /// Inspect material/thickness evidence even when ambiguity prevents
+    /// geometry composition. Layer order is validated by the existing physical
+    /// span contract; no declaration-order fallback for an invalid stackup.
+    pub fn physical_board_metadata(&self) -> BoardPhysicalMetadata {
+        let mut result = BoardPhysicalMetadata {
+            stackup: Association::Unresolved,
+            overall_thickness_mm: None,
+            layers: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+        let stackup = match self.stackups.as_slice() {
+            [] => {
+                result
+                    .diagnostics
+                    .push(BoardPhysicalDiagnostic::MissingStackup);
+                return result;
+            }
+            [stackup] => stackup,
+            stackups => {
+                result.stackup =
+                    Association::Ambiguous(stackups.iter().map(|stackup| stackup.name).collect());
+                result
+                    .diagnostics
+                    .push(BoardPhysicalDiagnostic::AmbiguousStackup);
+                return result;
+            }
+        };
+        result.stackup = Association::Resolved(stackup.name);
+        result.overall_thickness_mm =
+            thickness(stackup.overall_thickness, None, &mut result.diagnostics);
+        let order = match physical_stackup_layers(&self.stackups, &self.layer_definitions) {
+            Ok(Some(order)) => order,
+            Err(error) => {
+                result
+                    .diagnostics
+                    .push(BoardPhysicalDiagnostic::InvalidStackupOrder(
+                        error.to_string(),
+                    ));
+                return result;
+            }
+            Ok(None) => unreachable!("one stackup was selected"),
+        };
+        for layer_ref in order {
+            let layer = stackup
+                .layers
+                .iter()
+                .find(|layer| layer.layer_ref == layer_ref)
+                .unwrap();
+            let spec = layer
+                .spec_ref
+                .and_then(|reference| self.specs.get(&reference));
+            if let Some(reference) = layer.spec_ref
+                && spec.is_none()
+            {
+                result
+                    .diagnostics
+                    .push(BoardPhysicalDiagnostic::UnresolvedSpec {
+                        layer: layer_ref,
+                        spec: reference,
+                    });
+            }
+            let mut materials = spec
+                .into_iter()
+                .flat_map(|spec| spec.properties.iter().copied().chain(spec.material))
+                .filter(|material| !self.resolve(*material).trim().is_empty())
+                .collect::<Vec<_>>();
+            materials.sort_by_key(|material| self.resolve(*material));
+            materials.dedup();
+            let declared = layer
+                .material
+                .filter(|material| !self.resolve(*material).trim().is_empty());
+            let material = match (declared, materials.as_slice()) {
+                (Some(a), values) if !values.is_empty() && !values.contains(&a) => {
+                    result
+                        .diagnostics
+                        .push(BoardPhysicalDiagnostic::ConflictingMaterial { layer: layer_ref });
+                    Association::Conflicting(
+                        std::iter::once(a).chain(values.iter().copied()).collect(),
+                    )
+                }
+                (Some(material), []) => Association::Resolved(material),
+                (_, [material]) => Association::Resolved(*material),
+                (None, []) => {
+                    result
+                        .diagnostics
+                        .push(BoardPhysicalDiagnostic::MissingMaterial { layer: layer_ref });
+                    Association::Unresolved
+                }
+                (_, _) => {
+                    result
+                        .diagnostics
+                        .push(BoardPhysicalDiagnostic::AmbiguousMaterial { layer: layer_ref });
+                    Association::Ambiguous(materials)
+                }
+            };
+            result.layers.push(BoardMaterialLayer {
+                layer_ref,
+                thickness_mm: thickness(layer.thickness, Some(layer_ref), &mut result.diagnostics),
+                material,
+                spec_ref: layer.spec_ref,
+            });
+        }
+        result
+    }
+}
+
+fn thickness(
+    value: Option<f64>,
+    layer: Option<Symbol>,
+    diagnostics: &mut Vec<BoardPhysicalDiagnostic>,
+) -> Option<f64> {
+    match value {
+        Some(value) if value.is_finite() && value > 0.0 => Some(value),
+        Some(value) => {
+            diagnostics.push(BoardPhysicalDiagnostic::InvalidThickness { layer, value });
+            None
+        }
+        None => {
+            diagnostics.push(BoardPhysicalDiagnostic::MissingThickness { layer });
+            None
+        }
+    }
+}
+
+fn profile_region(
+    design: &ImportedDesign,
+    path: u32,
+    resolution: Resolution,
+) -> Result<ContourSet> {
+    Ok(ContourSet::from_filled_contours(
+        &design
+            .geometry
+            .transformed_path_contours(path, Affine2::IDENTITY),
+        resolution,
+    )?)
+}
+
+/// Derive separate placed envelope evidence directly from canonical assembly
+/// IR. This pure operation requires no IPC parser, GUI, or material model.
+/// Output coordinates follow the document scope (board-local for Scope::Board).
+pub fn component_envelopes(
+    document: &assembly::Document,
+    resolution: Resolution,
+) -> Result<Vec<ComponentEnvelopes>> {
+    document
+        .occurrences
+        .iter()
+        .map(|occurrence| {
+            let component = &document.components[occurrence.id.component.0 as usize];
+            let envelopes = component
+                .package
+                .into_iter()
+                .flat_map(|package| &document.packages[package.0 as usize].views)
+                .flat_map(|view| {
+                    [
+                        (
+                            EnvelopeKind::PackageOutlineUnspecified,
+                            view.outline.as_ref(),
+                        ),
+                        (
+                            EnvelopeKind::AssemblyOutline,
+                            view.assembly_drawing
+                                .as_ref()
+                                .and_then(|drawing| drawing.outline.as_ref()),
+                        ),
+                    ]
+                    .into_iter()
+                    .filter_map(move |(kind, outline)| {
+                        outline.map(|outline| (view.kind, kind, outline))
+                    })
+                })
+                .map(|(view, kind, outline)| {
+                    let local = outline
+                        .transform
+                        .map_or(Affine2::IDENTITY, outline_transform);
+                    let transform = occurrence.root_from_component.concat(local);
+                    let contours = outline
+                        .shape
+                        .paths
+                        .iter()
+                        .flat_map(|path| &path.contours)
+                        .map(|contour| contour.clone().transformed(transform))
+                        .collect::<Vec<_>>();
+                    Ok(ComponentEnvelope {
+                        kind,
+                        view,
+                        status: outline.shape.status,
+                        image: ContourSet::from_filled_contours(&contours, resolution)?,
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+            Ok(ComponentEnvelopes {
+                component: occurrence.id,
+                designator: component.designator.clone(),
+                population: occurrence.population,
+                side: component.side,
+                envelopes,
+            })
+        })
+        .collect()
+}
+
+fn outline_transform(transform: assembly::Transform) -> Affine2 {
+    let linear = Affine2::placement(
+        Point::default(),
+        transform.rotation_degrees,
+        Mirror::across_y(transform.mirror),
+        transform.scale,
+    );
+    // IPC offsets are in the transformed local frame, as in ipc_placement.
+    Affine2::translation(
+        linear.transform_vector(Point::new(transform.x_offset, transform.y_offset)),
+    )
+    .concat(linear)
+}

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -91,6 +91,8 @@ pub struct ComponentEnvelopes {
 #[derive(Debug, Clone)]
 pub struct BoardPhysicalMetadata {
     pub stackup: Association<Symbol>,
+    /// Direct stackup-scoped raw references; not interpreted as layer material.
+    pub spec_refs: Vec<Symbol>,
     pub overall_thickness_mm: Option<f64>,
     /// Physical order when valid; source order with InvalidStackupOrder otherwise.
     /// Invalid ordering does not discard individual layer evidence.
@@ -271,6 +273,7 @@ impl ImportedDesign {
     pub fn physical_board_metadata(&self) -> BoardPhysicalMetadata {
         let mut result = BoardPhysicalMetadata {
             stackup: Association::Unresolved,
+            spec_refs: Vec::new(),
             overall_thickness_mm: None,
             layers: Vec::new(),
             groups: Vec::new(),
@@ -294,6 +297,7 @@ impl ImportedDesign {
             }
         };
         result.stackup = Association::Resolved(stackup.name);
+        result.spec_refs = stackup.spec_refs.clone();
         result.groups = stackup.groups.clone();
         for group in &result.groups {
             if group.mat_des.is_some() || !group.spec_refs.is_empty() {

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -345,11 +345,11 @@ impl ImportedDesign {
                         });
                     continue;
                 };
+                // Use the importer's selected material field. Other property
+                // text is descriptive evidence, not additional identities.
                 let values = spec
-                    .properties
-                    .iter()
-                    .copied()
-                    .chain(spec.material)
+                    .material
+                    .into_iter()
                     .filter(|material| !self.resolve(*material).trim().is_empty())
                     .collect::<Vec<_>>();
                 conflicting_layer_specs |= !materials.is_empty()
@@ -395,9 +395,9 @@ impl ImportedDesign {
                         for reference in &item.spec_refs {
                             if let Some(spec) = self.specs.get(reference) {
                                 bom_materials.extend(
-                                    spec.properties.iter().copied().chain(spec.material).filter(
-                                        |material| !self.resolve(*material).trim().is_empty(),
-                                    ),
+                                    spec.material.into_iter().filter(|material| {
+                                        !self.resolve(*material).trim().is_empty()
+                                    }),
                                 );
                             } else {
                                 result

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -90,7 +90,12 @@ pub struct ComponentEnvelopes {
 pub struct BoardPhysicalMetadata {
     pub stackup: Association<Symbol>,
     pub overall_thickness_mm: Option<f64>,
+    /// Physical order when valid; source order with InvalidStackupOrder otherwise.
+    /// Invalid ordering does not discard individual layer evidence.
     pub layers: Vec<BoardMaterialLayer>,
+    /// Group-scoped source evidence, not inherited layer material. Ranges index
+    /// the selected ImportedDesign stackup's source layers, not this sorted view.
+    pub groups: Vec<ipc2581::types::StackupGroup>,
     pub diagnostics: Vec<BoardPhysicalDiagnostic>,
 }
 
@@ -120,6 +125,7 @@ pub enum BoardPhysicalDiagnostic {
     UnresolvedMaterialDesignator { layer: Symbol, designator: Symbol },
     AmbiguousMaterialDesignator { layer: Symbol, designator: Symbol },
     UnresolvedSpec { layer: Symbol, spec: Symbol },
+    UninterpretedGroupMaterial { group: Symbol },
     MissingComponentEnvelope(ComponentOccurrenceId),
     UnspecifiedPackageOutline(ComponentOccurrenceId),
     IncompleteComponentEnvelope(ComponentOccurrenceId),
@@ -257,13 +263,14 @@ impl ImportedDesign {
     }
 
     /// Inspect material/thickness evidence even when ambiguity prevents
-    /// geometry composition. Layer order is validated by the existing physical
-    /// span contract; no declaration-order fallback for an invalid stackup.
+    /// geometry composition. Invalid physical order remains diagnostic while
+    /// individual layer evidence remains available in source order.
     pub fn physical_board_metadata(&self) -> BoardPhysicalMetadata {
         let mut result = BoardPhysicalMetadata {
             stackup: Association::Unresolved,
             overall_thickness_mm: None,
             layers: Vec::new(),
+            groups: Vec::new(),
             diagnostics: Vec::new(),
         };
         let stackup = match self.stackups.as_slice() {
@@ -284,26 +291,41 @@ impl ImportedDesign {
             }
         };
         result.stackup = Association::Resolved(stackup.name);
+        result.groups = stackup.groups.clone();
+        for group in &result.groups {
+            if group.mat_des.is_some() || !group.spec_refs.is_empty() {
+                result
+                    .diagnostics
+                    .push(BoardPhysicalDiagnostic::UninterpretedGroupMaterial {
+                        group: group.name,
+                    });
+            }
+        }
         result.overall_thickness_mm =
             thickness(stackup.overall_thickness, None, &mut result.diagnostics);
-        let order = match physical_stackup_layers(&self.stackups, &self.layer_definitions) {
-            Ok(Some(order)) => order,
+        let layers = match physical_stackup_layers(&self.stackups, &self.layer_definitions) {
+            Ok(Some(order)) => order
+                .into_iter()
+                .map(|layer_ref| {
+                    stackup
+                        .layers
+                        .iter()
+                        .find(|layer| layer.layer_ref == layer_ref)
+                        .unwrap()
+                })
+                .collect::<Vec<_>>(),
             Err(error) => {
                 result
                     .diagnostics
                     .push(BoardPhysicalDiagnostic::InvalidStackupOrder(
                         error.to_string(),
                     ));
-                return result;
+                stackup.layers.iter().collect()
             }
             Ok(None) => unreachable!("one stackup was selected"),
         };
-        for layer_ref in order {
-            let layer = stackup
-                .layers
-                .iter()
-                .find(|layer| layer.layer_ref == layer_ref)
-                .unwrap();
+        for layer in layers {
+            let layer_ref = layer.layer_ref;
             let mut spec_refs = layer.spec_refs.clone();
             // Retain legacy callers' explicitly supplied singular evidence too.
             if let Some(reference) = layer.spec_ref

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -33,6 +33,8 @@ pub struct BoardPhysicalView {
     pub removal_layers: Vec<BoardRemovalLayer>,
     /// Source-identified hole/slot apertures, retaining plating and Z-span.
     /// Unlike removal_layers these are source images, before polarity clears.
+    /// Without a valid stackup, this evidence view leaves all derived land and
+    /// termination associations unresolved, including order-independent spans.
     pub holes: Vec<PhysicalHole>,
     pub components: Vec<ComponentEnvelopes>,
     pub metadata: BoardPhysicalMetadata,
@@ -322,14 +324,31 @@ impl ImportedDesign {
             materials.dedup();
             let mut bom_materials = Vec::new();
             if let Some(designator) = layer.mat_des {
+                let mut boards = self
+                    .geometry
+                    .layout
+                    .steps
+                    .iter()
+                    .filter(|step| step.kind == LayoutStepKind::Board);
+                let board = boards.next().filter(|_| boards.next().is_none());
                 let items = self
                     .boms
                     .iter()
+                    .filter(|bom| {
+                        bom.header.as_ref().is_none_or(|header| {
+                            header.step_refs.is_empty()
+                                || board.is_some_and(|board| {
+                                    header.step_refs.contains(&board.source_step_ref)
+                                })
+                        })
+                    })
                     .flat_map(|bom| &bom.items)
                     .filter(|item| {
                         item.designators.iter().any(|candidate| {
                             matches!(candidate,
-                        ipc2581::types::BomDesignator::Material(named) if named.name == designator)
+                        ipc2581::types::BomDesignator::Material(named)
+                            if named.name == designator
+                                && named.layer_ref.is_none_or(|reference| reference == layer_ref))
                         })
                     })
                     .collect::<Vec<_>>();
@@ -378,6 +397,12 @@ impl ImportedDesign {
             let declared = layer
                 .material
                 .filter(|material| !self.resolve(*material).trim().is_empty());
+            let conflicting_sources = conflicting_sources
+                || declared
+                    .is_some_and(|value| !materials.is_empty() && !materials.contains(&value));
+            materials.extend(declared);
+            materials.sort_by_key(|material| self.resolve(*material));
+            materials.dedup();
             let material = match (declared, materials.as_slice()) {
                 (_, _) if conflicting_sources => {
                     result
@@ -385,15 +410,6 @@ impl ImportedDesign {
                         .push(BoardPhysicalDiagnostic::ConflictingMaterial { layer: layer_ref });
                     Association::Conflicting(materials)
                 }
-                (Some(a), values) if !values.is_empty() && !values.contains(&a) => {
-                    result
-                        .diagnostics
-                        .push(BoardPhysicalDiagnostic::ConflictingMaterial { layer: layer_ref });
-                    Association::Conflicting(
-                        std::iter::once(a).chain(values.iter().copied()).collect(),
-                    )
-                }
-                (Some(material), []) => Association::Resolved(material),
                 (_, [material]) => Association::Resolved(*material),
                 (None, []) => {
                     result

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -228,7 +228,8 @@ impl ImportedDesign {
         let holes = if metadata.diagnostics.iter().any(|diagnostic| {
             matches!(
                 diagnostic,
-                BoardPhysicalDiagnostic::AmbiguousStackup
+                BoardPhysicalDiagnostic::MissingStackup
+                    | BoardPhysicalDiagnostic::AmbiguousStackup
                     | BoardPhysicalDiagnostic::InvalidStackupOrder(_)
             )
         }) {

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -220,6 +220,18 @@ impl ImportedDesign {
                 ));
             }
         }
+        let metadata = self.physical_board_metadata();
+        let holes = if metadata.diagnostics.iter().any(|diagnostic| {
+            matches!(
+                diagnostic,
+                BoardPhysicalDiagnostic::AmbiguousStackup
+                    | BoardPhysicalDiagnostic::InvalidStackupOrder(_)
+            )
+        }) {
+            self.derive_hole_apertures(ArtworkScope::Board, &[], &[], resolution)?
+        } else {
+            self.physical_holes(ArtworkScope::Board, resolution)?
+        };
         Ok(BoardPhysicalView {
             step: step_index as u32,
             substrate,
@@ -227,9 +239,9 @@ impl ImportedDesign {
             profiles,
             copper,
             removal_layers,
-            holes: self.physical_holes(ArtworkScope::Board, resolution)?,
+            holes,
             components,
-            metadata: self.physical_board_metadata(),
+            metadata,
             diagnostics,
             source_diagnostics: self.geometry.diagnostics.clone(),
         })

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -33,6 +33,8 @@ pub struct BoardPhysicalView {
     pub removal_layers: Vec<BoardRemovalLayer>,
     /// Source-identified hole/slot apertures, retaining plating and Z-span.
     /// Unlike removal_layers these are source images, before polarity clears.
+    /// Assembly termination/protection enrichment belongs to physical_view;
+    /// this view deliberately does not materialize paste/mask/protection layers.
     /// Without a valid stackup, this evidence view leaves all derived land and
     /// termination associations unresolved, including order-independent spans.
     pub holes: Vec<PhysicalHole>,
@@ -125,6 +127,7 @@ pub enum BoardPhysicalDiagnostic {
     UnresolvedMaterialDesignator { layer: Symbol, designator: Symbol },
     AmbiguousMaterialDesignator { layer: Symbol, designator: Symbol },
     UnresolvedSpec { layer: Symbol, spec: Symbol },
+    UninterpretedMaterialProperties { layer: Symbol, spec: Symbol },
     UninterpretedGroupMaterial { group: Symbol },
     MissingComponentEnvelope(ComponentOccurrenceId),
     UnspecifiedPackageOutline(ComponentOccurrenceId),
@@ -345,6 +348,14 @@ impl ImportedDesign {
                         });
                     continue;
                 };
+                if spec.material.is_none() && !spec.properties.is_empty() {
+                    result.diagnostics.push(
+                        BoardPhysicalDiagnostic::UninterpretedMaterialProperties {
+                            layer: layer_ref,
+                            spec: *reference,
+                        },
+                    );
+                }
                 // Use the importer's selected material field. Other property
                 // text is descriptive evidence, not additional identities.
                 let values = spec
@@ -394,6 +405,14 @@ impl ImportedDesign {
                     [item] => {
                         for reference in &item.spec_refs {
                             if let Some(spec) = self.specs.get(reference) {
+                                if spec.material.is_none() && !spec.properties.is_empty() {
+                                    result.diagnostics.push(
+                                        BoardPhysicalDiagnostic::UninterpretedMaterialProperties {
+                                            layer: layer_ref,
+                                            spec: *reference,
+                                        },
+                                    );
+                                }
                                 bom_materials.extend(
                                     spec.material.into_iter().filter(|material| {
                                         !self.resolve(*material).trim().is_empty()
@@ -485,7 +504,9 @@ fn thickness(
     diagnostics: &mut Vec<BoardPhysicalDiagnostic>,
 ) -> Option<f64> {
     match value {
-        Some(value) if value.is_finite() && value > 0.0 => Some(value),
+        Some(value) if value.is_finite() && (value > 0.0 || (value == 0.0 && layer.is_some())) => {
+            Some(value)
+        }
         Some(value) => {
             diagnostics.push(BoardPhysicalDiagnostic::InvalidThickness { layer, value });
             None

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -115,6 +115,8 @@ pub struct BoardMaterialLayer {
     pub material: Association<Symbol>,
     /// Single-reference compatibility view; use spec_refs for full provenance.
     pub spec_ref: Option<Symbol>,
+    /// Unique direct StackupLayer and CadData Layer references. Original scopes
+    /// remain available on ImportedDesign's stackups and layer_definitions.
     pub spec_refs: Vec<Symbol>,
 }
 
@@ -340,13 +342,7 @@ impl ImportedDesign {
         };
         for layer in layers {
             let layer_ref = layer.layer_ref;
-            let mut spec_refs = layer.spec_refs.clone();
-            // Retain legacy callers' explicitly supplied singular evidence too.
-            if let Some(reference) = layer.spec_ref
-                && !spec_refs.contains(&reference)
-            {
-                spec_refs.push(reference);
-            }
+            let spec_refs = layer.combined_spec_refs(&self.layer_definitions);
             let mut materials = Vec::new();
             let mut conflicting_layer_specs = false;
             for reference in &spec_refs {

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -96,6 +96,8 @@ pub struct BoardPhysicalMetadata {
 pub struct BoardMaterialLayer {
     pub layer_ref: Symbol,
     pub thickness_mm: Option<f64>,
+    /// Source BOM material designator; never interpreted as a material name.
+    pub mat_des: Option<Symbol>,
     pub material: Association<Symbol>,
     pub spec_ref: Option<Symbol>,
 }
@@ -111,6 +113,8 @@ pub enum BoardPhysicalDiagnostic {
     MissingMaterial { layer: Symbol },
     AmbiguousMaterial { layer: Symbol },
     ConflictingMaterial { layer: Symbol },
+    UnresolvedMaterialDesignator { layer: Symbol, designator: Symbol },
+    AmbiguousMaterialDesignator { layer: Symbol, designator: Symbol },
     UnresolvedSpec { layer: Symbol, spec: Symbol },
     MissingComponentEnvelope(ComponentOccurrenceId),
     UnspecifiedPackageOutline(ComponentOccurrenceId),
@@ -315,10 +319,71 @@ impl ImportedDesign {
                 .collect::<Vec<_>>();
             materials.sort_by_key(|material| self.resolve(*material));
             materials.dedup();
+            let mut bom_materials = Vec::new();
+            if let Some(designator) = layer.mat_des {
+                let items = self
+                    .boms
+                    .iter()
+                    .flat_map(|bom| &bom.items)
+                    .filter(|item| {
+                        item.designators.iter().any(|candidate| {
+                            matches!(candidate,
+                        ipc2581::types::BomDesignator::Material(named) if named.name == designator)
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                match items.as_slice() {
+                    [item] => {
+                        for reference in &item.spec_refs {
+                            if let Some(spec) = self.specs.get(reference) {
+                                bom_materials.extend(
+                                    spec.properties.iter().copied().chain(spec.material).filter(
+                                        |material| !self.resolve(*material).trim().is_empty(),
+                                    ),
+                                );
+                            } else {
+                                result
+                                    .diagnostics
+                                    .push(BoardPhysicalDiagnostic::UnresolvedSpec {
+                                        layer: layer_ref,
+                                        spec: *reference,
+                                    });
+                            }
+                        }
+                    }
+                    [] => result.diagnostics.push(
+                        BoardPhysicalDiagnostic::UnresolvedMaterialDesignator {
+                            layer: layer_ref,
+                            designator,
+                        },
+                    ),
+                    _ => result.diagnostics.push(
+                        BoardPhysicalDiagnostic::AmbiguousMaterialDesignator {
+                            layer: layer_ref,
+                            designator,
+                        },
+                    ),
+                }
+            }
+            // Reconcile actual material values, not a BOM identity against a
+            // specification's text. Differing nonempty sources conflict.
+            let conflicting_sources = !materials.is_empty()
+                && !bom_materials.is_empty()
+                && (materials.iter().any(|value| !bom_materials.contains(value))
+                    || bom_materials.iter().any(|value| !materials.contains(value)));
+            materials.extend(bom_materials);
+            materials.sort_by_key(|material| self.resolve(*material));
+            materials.dedup();
             let declared = layer
                 .material
                 .filter(|material| !self.resolve(*material).trim().is_empty());
             let material = match (declared, materials.as_slice()) {
+                (_, _) if conflicting_sources => {
+                    result
+                        .diagnostics
+                        .push(BoardPhysicalDiagnostic::ConflictingMaterial { layer: layer_ref });
+                    Association::Conflicting(materials)
+                }
                 (Some(a), values) if !values.is_empty() && !values.contains(&a) => {
                     result
                         .diagnostics
@@ -345,6 +410,7 @@ impl ImportedDesign {
             result.layers.push(BoardMaterialLayer {
                 layer_ref,
                 thickness_mm: thickness(layer.thickness, Some(layer_ref), &mut result.diagnostics),
+                mat_des: layer.mat_des,
                 material,
                 spec_ref: layer.spec_ref,
             });

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -91,6 +91,9 @@ pub struct ComponentEnvelopes {
 #[derive(Debug, Clone)]
 pub struct BoardPhysicalMetadata {
     pub stackup: Association<Symbol>,
+    /// Verbatim selected-stackup construction evidence; values retain source units.
+    pub source_attributes: Vec<(Symbol, Symbol)>,
+    pub source_units: Option<ipc2581::types::Units>,
     /// Direct stackup-scoped raw references; not interpreted as layer material.
     pub spec_refs: Vec<Symbol>,
     pub overall_thickness_mm: Option<f64>,
@@ -273,6 +276,8 @@ impl ImportedDesign {
     pub fn physical_board_metadata(&self) -> BoardPhysicalMetadata {
         let mut result = BoardPhysicalMetadata {
             stackup: Association::Unresolved,
+            source_attributes: Vec::new(),
+            source_units: None,
             spec_refs: Vec::new(),
             overall_thickness_mm: None,
             layers: Vec::new(),
@@ -297,6 +302,8 @@ impl ImportedDesign {
             }
         };
         result.stackup = Association::Resolved(stackup.name);
+        result.source_attributes = stackup.source_attributes.clone();
+        result.source_units = Some(stackup.source_units);
         result.spec_refs = stackup.spec_refs.clone();
         result.groups = stackup.groups.clone();
         for group in &result.groups {

--- a/crates/pcb-ir/src/import/physical/board.rs
+++ b/crates/pcb-ir/src/import/physical/board.rs
@@ -101,7 +101,9 @@ pub struct BoardMaterialLayer {
     /// Source BOM material designator; never interpreted as a material name.
     pub mat_des: Option<Symbol>,
     pub material: Association<Symbol>,
+    /// Single-reference compatibility view; use spec_refs for full provenance.
     pub spec_ref: Option<Symbol>,
+    pub spec_refs: Vec<Symbol>,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -302,24 +304,38 @@ impl ImportedDesign {
                 .iter()
                 .find(|layer| layer.layer_ref == layer_ref)
                 .unwrap();
-            let spec = layer
-                .spec_ref
-                .and_then(|reference| self.specs.get(&reference));
+            let mut spec_refs = layer.spec_refs.clone();
+            // Retain legacy callers' explicitly supplied singular evidence too.
             if let Some(reference) = layer.spec_ref
-                && spec.is_none()
+                && !spec_refs.contains(&reference)
             {
-                result
-                    .diagnostics
-                    .push(BoardPhysicalDiagnostic::UnresolvedSpec {
-                        layer: layer_ref,
-                        spec: reference,
-                    });
+                spec_refs.push(reference);
             }
-            let mut materials = spec
-                .into_iter()
-                .flat_map(|spec| spec.properties.iter().copied().chain(spec.material))
-                .filter(|material| !self.resolve(*material).trim().is_empty())
-                .collect::<Vec<_>>();
+            let mut materials = Vec::new();
+            let mut conflicting_layer_specs = false;
+            for reference in &spec_refs {
+                let Some(spec) = self.specs.get(reference) else {
+                    result
+                        .diagnostics
+                        .push(BoardPhysicalDiagnostic::UnresolvedSpec {
+                            layer: layer_ref,
+                            spec: *reference,
+                        });
+                    continue;
+                };
+                let values = spec
+                    .properties
+                    .iter()
+                    .copied()
+                    .chain(spec.material)
+                    .filter(|material| !self.resolve(*material).trim().is_empty())
+                    .collect::<Vec<_>>();
+                conflicting_layer_specs |= !materials.is_empty()
+                    && !values.is_empty()
+                    && (materials.iter().any(|value| !values.contains(value))
+                        || values.iter().any(|value| !materials.contains(value)));
+                materials.extend(values);
+            }
             materials.sort_by_key(|material| self.resolve(*material));
             materials.dedup();
             let mut bom_materials = Vec::new();
@@ -387,10 +403,11 @@ impl ImportedDesign {
             }
             // Reconcile actual material values, not a BOM identity against a
             // specification's text. Differing nonempty sources conflict.
-            let conflicting_sources = !materials.is_empty()
-                && !bom_materials.is_empty()
-                && (materials.iter().any(|value| !bom_materials.contains(value))
-                    || bom_materials.iter().any(|value| !materials.contains(value)));
+            let conflicting_sources = conflicting_layer_specs
+                || (!materials.is_empty()
+                    && !bom_materials.is_empty()
+                    && (materials.iter().any(|value| !bom_materials.contains(value))
+                        || bom_materials.iter().any(|value| !materials.contains(value))));
             materials.extend(bom_materials);
             materials.sort_by_key(|material| self.resolve(*material));
             materials.dedup();
@@ -429,7 +446,11 @@ impl ImportedDesign {
                 thickness_mm: thickness(layer.thickness, Some(layer_ref), &mut result.diagnostics),
                 mat_des: layer.mat_des,
                 material,
-                spec_ref: layer.spec_ref,
+                spec_ref: match spec_refs.as_slice() {
+                    [reference] => Some(*reference),
+                    _ => None,
+                },
+                spec_refs,
             });
         }
         result

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -342,3 +342,52 @@ fn unresolved_stackup_keeps_board_and_hole_evidence_without_land_associations() 
         );
     }
 }
+
+#[test]
+fn material_designators_preserve_identity_and_reconcile_bom_spec_evidence() {
+    let xml = fixture().replace("sequence=\"0\"", "sequence=\"0\" matDes=\"laminate-42\"");
+    let imported = design(&xml);
+    let metadata = imported.physical_board_metadata();
+    let layer = &metadata.layers[0];
+    assert_eq!(imported.resolve(layer.mat_des.unwrap()), "laminate-42");
+    assert_eq!(imported.stackups[0].layers[0].mat_des, layer.mat_des);
+    assert!(matches!(layer.material, Association::Unresolved));
+    assert!(metadata.diagnostics.iter().any(|diagnostic| matches!(
+        diagnostic,
+        BoardPhysicalDiagnostic::UnresolvedMaterialDesignator { .. }
+    )));
+
+    let bom = r#"<Bom name="materials"><BomItem OEMDesignNumberRef="laminate" quantity="1" category="MATERIAL"><MatDes name="laminate-42"/><SpecRef id="bom-material"/></BomItem></Bom>"#;
+    let xml = xml.replace("<Ecad name=\"test\">", &format!("{bom}<Ecad name=\"test\">"))
+        .replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="bom-material"><General type="MATERIAL"><Property text="FR4"/></General></Spec><Spec name="layer-material"><General type="MATERIAL"><Property text="PTFE"/></General></Spec></CadHeader>"#);
+    let imported = design(&xml);
+    let metadata = imported.physical_board_metadata();
+    assert_eq!(
+        imported.resolve(*metadata.layers[0].material.resolved().unwrap()),
+        "FR4"
+    );
+    assert!(metadata.diagnostics.is_empty());
+
+    let conflict = design(&xml.replace(
+        "matDes=\"laminate-42\"/>",
+        "matDes=\"laminate-42\"><SpecRef id=\"layer-material\"/></StackupLayer>",
+    ));
+    let metadata = conflict.physical_board_metadata();
+    assert!(matches!(
+        metadata.layers[0].material,
+        Association::Conflicting(_)
+    ));
+    assert_eq!(
+        conflict.resolve(metadata.layers[0].mat_des.unwrap()),
+        "laminate-42"
+    );
+    // A designator name differing from material text is not itself a conflict.
+    let consistent = design(&xml.replace(
+        "matDes=\"laminate-42\"/>",
+        "matDes=\"laminate-42\"><SpecRef id=\"bom-material\"/></StackupLayer>",
+    ));
+    assert!(matches!(
+        consistent.physical_board_metadata().layers[0].material,
+        Association::Resolved(_)
+    ));
+}

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -391,3 +391,29 @@ fn material_designators_preserve_identity_and_reconcile_bom_spec_evidence() {
         Association::Resolved(_)
     ));
 }
+
+#[test]
+fn missing_stackup_does_not_infer_hole_land_links_from_layer_declarations() {
+    let xml = fixture().replace("</Content>", r#"<DictionaryStandard units="MILLIMETER"><EntryStandard id="pad"><Circle diameter="3"/></EntryStandard></DictionaryStandard></Content>"#)
+        .replace("<LayerFeature layerRef=\"TOP\">", r#"<LayerFeature layerRef="TOP"><Set><Pad padstackDefRef="P"><Location x="8" y="2"/><StandardPrimitiveRef id="pad"/></Pad></Set>"#);
+    let mut imported = design(&xml);
+    imported.stackups.clear();
+    // Demonstrate the legacy API really has a declaration-order association
+    // to suppress, rather than testing a board with no source lands.
+    let strict = imported
+        .physical_holes(ArtworkScope::Board, Resolution::default())
+        .unwrap();
+    assert!(!strict[0].lands.is_empty());
+    let view = imported.physical_board(Resolution::default()).unwrap();
+    assert!(
+        view.metadata
+            .diagnostics
+            .contains(&BoardPhysicalDiagnostic::MissingStackup)
+    );
+    assert_eq!(view.holes[0].id, strict[0].id);
+    assert_eq!(view.holes[0].span, strict[0].span);
+    assert_eq!(view.holes[0].plating, strict[0].plating);
+    assert_eq!(view.holes[0].image.area(), strict[0].image.area());
+    assert!(view.holes[0].lands.is_empty());
+    assert!(matches!(view.holes[0].termination, Association::Unresolved));
+}

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -551,8 +551,13 @@ fn multiple_stackup_specs_preserve_provenance_and_reconcile_without_last_ref_win
         assert!(source.loss_tangent.is_none());
         let metadata = imported.physical_board_metadata();
         let layer = &metadata.layers[0];
-        assert_eq!(layer.spec_refs, source.spec_refs);
-        assert!(layer.spec_ref.is_none());
+        let mut unique_refs = source.spec_refs.clone();
+        unique_refs.dedup();
+        assert_eq!(layer.spec_refs, unique_refs);
+        assert_eq!(
+            layer.spec_ref,
+            (unique_refs.len() == 1).then_some(unique_refs[0])
+        );
         if refs.contains(&"b") {
             let Association::Conflicting(values) = &layer.material else {
                 panic!("different resolved specs must conflict");

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -3,7 +3,7 @@ use crate::import::ipc2581::import_design;
 use ipc2581::Ipc2581;
 
 fn design(xml: &str) -> ImportedDesign {
-    import_design(&Ipc2581::parse(xml).unwrap()).unwrap()
+    import_design(&Ipc2581::parse(xml).unwrap(), Resolution::default()).unwrap()
 }
 
 // Deliberately asymmetric geometry: mirroring/rotation mistakes cannot hide
@@ -302,4 +302,43 @@ fn missing_profile_and_multiple_board_definitions_are_not_silent() {
             .to_string()
             .contains("exactly one board definition")
     );
+}
+
+#[test]
+fn unresolved_stackup_keeps_board_and_hole_evidence_without_land_associations() {
+    let baseline = design(fixture())
+        .physical_board(Resolution::default())
+        .unwrap();
+    for ambiguous in [true, false] {
+        let mut imported = design(fixture());
+        if ambiguous {
+            imported.stackups.push(imported.stackups[0].clone());
+        } else {
+            let layer = imported.stackups[0].layers[0].clone();
+            imported.stackups[0].layers.push(layer);
+        }
+        let view = imported.physical_board(Resolution::default()).unwrap();
+        assert!(view.metadata.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            BoardPhysicalDiagnostic::AmbiguousStackup
+                | BoardPhysicalDiagnostic::InvalidStackupOrder(_)
+        )));
+        assert_eq!(view.substrate.area(), baseline.substrate.area());
+        assert_eq!(view.holes.len(), baseline.holes.len());
+        let hole = &view.holes[0];
+        let original = &baseline.holes[0];
+        assert_eq!(hole.id, original.id);
+        assert_eq!(hole.source_name, original.source_name);
+        assert_eq!(hole.span, original.span);
+        assert_eq!(hole.plating, original.plating);
+        assert_eq!(hole.image.area(), original.image.area());
+        assert!(hole.lands.is_empty());
+        assert!(matches!(hole.termination, Association::Unresolved));
+        // The strict association API keeps its existing rejection contract.
+        assert!(
+            imported
+                .physical_holes(ArtworkScope::Board, Resolution::default())
+                .is_err()
+        );
+    }
 }

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -509,6 +509,41 @@ fn multiple_stackup_specs_preserve_provenance_and_reconcile_without_last_ref_win
 }
 
 #[test]
+fn fractional_stackup_sequences_order_layers_and_reject_invalid_order_evidence() {
+    let xml = fixture().replace("sequence=\"0\"", "sequence=\"2.5\"")
+        .replace("</StackupGroup>", r#"<StackupLayer layerOrGroupRef="BOTTOM" thickness="0.035" sequence="0.25"/></StackupGroup>"#)
+        .replace("<Layer name=\"TOP\"", r#"<Layer name="BOTTOM" layerFunction="SIGNAL" side="BOTTOM" polarity="POSITIVE"/><Layer name="TOP""#);
+    let imported = design(&xml);
+    assert_eq!(imported.stackups[0].layers[0].layer_number, Some(2.5));
+    let view = imported.physical_board(Resolution::default()).unwrap();
+    assert_eq!(
+        view.metadata
+            .layers
+            .iter()
+            .map(|layer| imported.resolve(layer.layer_ref))
+            .collect::<Vec<_>>(),
+        ["BOTTOM", "TOP"]
+    );
+    for sequence in ["2.5", "2.50", "25e-1"] {
+        let duplicate =
+            Ipc2581::parse(&xml.replace("sequence=\"0.25\"", &format!("sequence=\"{sequence}\"")))
+                .unwrap();
+        assert!(
+            import_design(&duplicate, Resolution::default())
+                .unwrap_err()
+                .to_string()
+                .contains("duplicate layer sequence")
+        );
+    }
+    for invalid in ["NaN", "inf", "-0.25", "invalid"] {
+        assert!(
+            Ipc2581::parse(&xml.replace("sequence=\"0.25\"", &format!("sequence=\"{invalid}\"")))
+                .is_err()
+        );
+    }
+}
+
+#[test]
 fn missing_stackup_does_not_infer_hole_land_links_from_layer_declarations() {
     let xml = fixture().replace("</Content>", r#"<DictionaryStandard units="MILLIMETER"><EntryStandard id="pad"><Circle diameter="3"/></EntryStandard></DictionaryStandard></Content>"#)
         .replace("<LayerFeature layerRef=\"TOP\">", r#"<LayerFeature layerRef="TOP"><Set><Pad padstackDefRef="P"><Location x="8" y="2"/><StandardPrimitiveRef id="pad"/></Pad></Set>"#);

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -622,7 +622,7 @@ fn fractional_stackup_sequences_order_layers_and_reject_invalid_order_evidence()
 #[test]
 fn invalid_order_preserves_each_layer_and_group_material_provenance() {
     let xml = fixture().replace("<StackupGroup name=\"g\">", "<StackupGroup name=\"g\" matDes=\"group-material\">")
-        .replace("</StackupGroup>", "<SpecRef id=\"group-spec\"/></StackupGroup>")
+        .replace("</StackupGroup>", "<CADDataLayerRef layerId=\"top\"/><SpecRef id=\"group-spec\"/></StackupGroup>")
         .replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="mat"><General type="MATERIAL"><Property text="FR4"/></General></Spec></CadHeader>"#)
         .replace("sequence=\"0\"/>", "sequence=\"0\"><SpecRef id=\"mat\"/></StackupLayer>");
     let mut imported = design(&xml);
@@ -654,6 +654,7 @@ fn invalid_order_preserves_each_layer_and_group_material_provenance() {
     }
     let group = &metadata.groups[0];
     assert_eq!(group.source_layers, 0..1);
+    assert_eq!(imported.resolve(group.cad_data_layer_refs[0]), "top");
     assert_eq!(imported.resolve(group.mat_des.unwrap()), "group-material");
     assert_eq!(imported.resolve(group.spec_refs[0]), "group-spec");
     assert!(

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -647,6 +647,60 @@ fn fractional_stackup_sequences_order_layers_and_reject_invalid_order_evidence()
 }
 
 #[test]
+fn construction_attributes_retain_source_units_and_percentage_evidence() {
+    let xml = fixture()
+        .replace("MILLIMETER", "INCH")
+        .replace(r#"<Stackup name="stack" overallThickness="1.6">"#, r#"<Stackup name="stack" overallThickness="0.062" tolPlus="10" tolMinus="5" tolPercent="true" whereMeasured="METAL" matDes="root-material" stackupStatus="PROPOSED" comment="root construction">"#)
+        .replace(r#"<StackupGroup name="g">"#, r#"<StackupGroup name="g" thickness="0.031" tolPlus="0.002" tolMinus="0.001" tolPercent="false" matDes="group-material" comment="group construction">"#);
+    let imported = design(&xml);
+    let metadata = imported.physical_board_metadata();
+    assert_eq!(metadata.source_units, Some(ipc2581::types::Units::Inch));
+    assert_eq!(metadata.groups[0].source_units, ipc2581::types::Units::Inch);
+    for (attributes, expected) in [
+        (
+            &metadata.source_attributes,
+            vec![
+                ("overallThickness", "0.062"),
+                ("tolPlus", "10"),
+                ("tolMinus", "5"),
+                ("tolPercent", "true"),
+                ("whereMeasured", "METAL"),
+                ("matDes", "root-material"),
+                ("stackupStatus", "PROPOSED"),
+                ("comment", "root construction"),
+            ],
+        ),
+        (
+            &metadata.groups[0].source_attributes,
+            vec![
+                ("thickness", "0.031"),
+                ("tolPlus", "0.002"),
+                ("tolMinus", "0.001"),
+                ("tolPercent", "false"),
+                ("matDes", "group-material"),
+                ("comment", "group construction"),
+            ],
+        ),
+    ] {
+        let actual = attributes
+            .iter()
+            .map(|(name, value)| (imported.resolve(*name), imported.resolve(*value)))
+            .collect::<Vec<_>>();
+        for attribute in expected {
+            assert!(
+                actual.contains(&attribute),
+                "missing source evidence {attribute:?}"
+            );
+        }
+    }
+    assert!((metadata.overall_thickness_mm.unwrap() - 0.062 * 25.4).abs() < 1e-12);
+    assert!(
+        metadata.layers[0].mat_des.is_none(),
+        "construction evidence is not inherited by layers"
+    );
+}
+
+#[test]
 fn invalid_order_preserves_each_layer_and_group_material_provenance() {
     let xml = fixture().replace("<StackupGroup name=\"g\">", "<StackupGroup name=\"g\" matDes=\"group-material\">")
         .replace("<StackupGroup name=", "<SpecRef id=\"root-external\"/><SpecRef id=\"mat\"/><StackupGroup name=")

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -368,7 +368,7 @@ fn material_designators_preserve_identity_and_reconcile_bom_spec_evidence() {
     );
     assert!(metadata.diagnostics.is_empty());
 
-    let conflict = design(&xml.replace(
+    let mut conflict = design(&xml.replace(
         "matDes=\"laminate-42\"/>",
         "matDes=\"laminate-42\"><SpecRef id=\"layer-material\"/></StackupLayer>",
     ));
@@ -381,6 +381,20 @@ fn material_designators_preserve_identity_and_reconcile_bom_spec_evidence() {
         conflict.resolve(metadata.layers[0].mat_des.unwrap()),
         "laminate-42"
     );
+    // Public imported evidence can carry a third declared material, even
+    // though XML parsing normally derives this field from the layer SpecRef.
+    conflict.stackups[0].layers[0].material = conflict.stackups[0].layers[0].mat_des;
+    let metadata = conflict.physical_board_metadata();
+    let Association::Conflicting(values) = &metadata.layers[0].material else {
+        panic!("all three source values must remain conflicting");
+    };
+    assert_eq!(
+        values
+            .iter()
+            .map(|value| conflict.resolve(*value))
+            .collect::<Vec<_>>(),
+        ["FR4", "PTFE", "laminate-42"]
+    );
     // A designator name differing from material text is not itself a conflict.
     let consistent = design(&xml.replace(
         "matDes=\"laminate-42\"/>",
@@ -390,6 +404,37 @@ fn material_designators_preserve_identity_and_reconcile_bom_spec_evidence() {
         consistent.physical_board_metadata().layers[0].material,
         Association::Resolved(_)
     ));
+
+    // Identically named designators on another board or layer must neither
+    // override this material nor create ambiguity. Unscoped BOMs still apply.
+    for (header, layer) in [
+        (
+            r#"<BomHeader assembly="other" revision="1"><StepRef name="other-board"/></BomHeader>"#,
+            "",
+        ),
+        ("", r#" layerRef="BOTTOM""#),
+    ] {
+        let foreign = format!(
+            r#"<Bom name="foreign">{header}<BomItem OEMDesignNumberRef="other" quantity="1" category="MATERIAL"><MatDes name="laminate-42"{layer}/><SpecRef id="layer-material"/></BomItem></Bom>"#
+        );
+        let scoped = design(&xml.replace(
+            "<Ecad name=\"test\">",
+            &format!("{foreign}<Ecad name=\"test\">"),
+        ));
+        let metadata = scoped.physical_board_metadata();
+        assert_eq!(
+            scoped.resolve(*metadata.layers[0].material.resolved().unwrap()),
+            "FR4"
+        );
+        assert!(metadata.diagnostics.is_empty());
+    }
+    let scoped = design(&xml.replace("<Bom name=\"materials\">", r#"<Bom name="materials"><BomHeader assembly="board" revision="1"><StepRef name="board"/></BomHeader>"#).replace("<MatDes name=\"laminate-42\"/>", "<MatDes name=\"laminate-42\" layerRef=\"TOP\"/>"));
+    let metadata = scoped.physical_board_metadata();
+    assert_eq!(
+        scoped.resolve(*metadata.layers[0].material.resolved().unwrap()),
+        "FR4"
+    );
+    assert!(metadata.diagnostics.is_empty());
 }
 
 #[test]

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -256,14 +256,24 @@ fn metadata_reports_missing_ambiguous_invalid_and_conflicting_evidence() {
         "{meta:?}"
     );
 
-    let ambiguous = design(&xml.replace(
+    let descriptive = design(&xml.replace(
         "<Property text=\"FR4\"/>",
-        "<Property text=\"FR4\"/><Property text=\"PTFE\"/>",
+        "<Property text=\"FR4\"/><Property text=\"Color : GREEN\"/>",
     ));
-    assert!(matches!(
-        ambiguous.physical_board_metadata().layers[0].material,
-        Association::Ambiguous(_)
-    ));
+    let metadata = descriptive.physical_board_metadata();
+    assert_eq!(
+        descriptive.resolve(*metadata.layers[0].material.resolved().unwrap()),
+        "FR4"
+    );
+    assert!(metadata.diagnostics.is_empty());
+    let spec = &descriptive.specs[&metadata.layers[0].spec_ref.unwrap()];
+    assert_eq!(
+        spec.properties
+            .iter()
+            .map(|text| descriptive.resolve(*text))
+            .collect::<Vec<_>>(),
+        ["FR4", "Color : GREEN"]
+    );
     let unresolved = design(&fixture().replace(
         "sequence=\"0\"/>",
         "sequence=\"0\"><SpecRef id=\"external\"/></StackupLayer>",
@@ -364,6 +374,17 @@ fn material_designators_preserve_identity_and_reconcile_bom_spec_evidence() {
     let metadata = imported.physical_board_metadata();
     assert_eq!(
         imported.resolve(*metadata.layers[0].material.resolved().unwrap()),
+        "FR4"
+    );
+    assert!(metadata.diagnostics.is_empty());
+
+    let described_bom = design(&xml.replace(
+        "<Property text=\"FR4\"/>",
+        "<Property text=\"FR4\"/><Property text=\"Color : GREEN\"/>",
+    ));
+    let metadata = described_bom.physical_board_metadata();
+    assert_eq!(
+        described_bom.resolve(*metadata.layers[0].material.resolved().unwrap()),
         "FR4"
     );
     assert!(metadata.diagnostics.is_empty());

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -1,0 +1,305 @@
+use super::*;
+use crate::import::ipc2581::import_design;
+use ipc2581::Ipc2581;
+
+fn design(xml: &str) -> ImportedDesign {
+    import_design(&Ipc2581::parse(xml).unwrap()).unwrap()
+}
+
+// Deliberately asymmetric geometry: mirroring/rotation mistakes cannot hide
+// behind circular or origin-centered envelopes. The nested placements must
+// disappear from the canonical board frame, but component placements must not.
+fn fixture() -> &'static str {
+    r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner"><FunctionMode mode="FABRICATION"/><StepRef name="panel"/></Content>
+  <Ecad name="test"><CadHeader units="MILLIMETER"/><CadData>
+    <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+    <Layer name="ROUT" layerFunction="ROUT" side="ALL" polarity="POSITIVE"><Span fromLayer="TOP" toLayer="TOP"/></Layer>
+    <Stackup name="stack" overallThickness="1.6"><StackupGroup name="g">
+      <StackupLayer layerOrGroupRef="TOP" thickness="0.035" sequence="0"/>
+    </StackupGroup></Stackup>
+    <Step name="board" type="BOARD"><Datum x="3" y="4"/>
+      <Profile><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="10" y="0"/><PolyStepSegment x="10" y="8"/><PolyStepSegment x="0" y="8"/><PolyStepSegment x="0" y="0"/></Polygon>
+        <Cutout><PolyBegin x="6" y="5"/><PolyStepSegment x="8" y="5"/><PolyStepSegment x="8" y="7"/><PolyStepSegment x="6" y="7"/><PolyStepSegment x="6" y="5"/></Cutout>
+      </Profile>
+      <Package name="pkg" type="OTHER" pinOne="1" pinOneOrientation="OTHER">
+        <Outline><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="4" y="0"/><PolyStepSegment x="4" y="2"/><PolyStepSegment x="0" y="2"/><PolyStepSegment x="0" y="0"/></Polygon><LineDesc lineWidth="0.1" lineEnd="ROUND"/></Outline>
+        <AssemblyDrawing><Outline><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="2" y="0"/><PolyStepSegment x="2" y="1"/><PolyStepSegment x="0" y="1"/><PolyStepSegment x="0" y="0"/></Polygon><LineDesc lineWidth="0.1" lineEnd="ROUND"/></Outline></AssemblyDrawing>
+      </Package>
+      <Component refDes="U1" packageRef="pkg" part="p" layerRef="TOP" mountType="SMT"><Xform rotation="90" mirror="true"/><Location x="4" y="4"/></Component>
+      <Component refDes="U2" packageRef="pkg" part="p" layerRef="TOP" mountType="SMT"><Location x="5" y="1"/></Component>
+      <LayerFeature layerRef="TOP">
+        <Set><Features><Location x="0" y="0"/><Contour><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="5" y="0"/><PolyStepSegment x="5" y="4"/><PolyStepSegment x="0" y="4"/><PolyStepSegment x="0" y="0"/></Polygon></Contour></Features></Set>
+        <Set polarity="NEGATIVE"><Features><Location x="0" y="0"/><Contour><Polygon><PolyBegin x="1" y="1"/><PolyStepSegment x="2" y="1"/><PolyStepSegment x="2" y="2"/><PolyStepSegment x="1" y="2"/><PolyStepSegment x="1" y="1"/></Polygon></Contour></Features></Set>
+      </LayerFeature>
+      <LayerFeature layerRef="ROUT"><Set><SlotCavity name="slot" platingStatus="NONPLATED" plusTol="0" minusTol="0"><Location x="8" y="2"/><Oval width="2" height="1"/></SlotCavity></Set></LayerFeature>
+    </Step>
+    <Step name="cell" type="PALLET"><StepRepeat stepRef="board" x="30" y="40" nx="2" ny="1" dx="20" dy="0" angle="90" mirror="true"/></Step>
+    <Step name="panel" type="PALLET"><StepRepeat stepRef="cell" x="100" y="200" nx="1" ny="2" dx="0" dy="80" angle="270" mirror="true"/></Step>
+  </CadData></Ecad>
+</IPC-2581>"#
+}
+
+#[test]
+fn board_local_profile_copper_rout_and_identity_survive_nested_placement() {
+    let imported = design(fixture());
+    let view = imported.physical_board(Resolution::default()).unwrap();
+    assert_eq!(view.substrate.area(), 76.0);
+    assert_eq!(view.profile_cutouts.area(), 4.0);
+    assert!(!view.substrate.contains_point(Point::new(7.0, 6.0)));
+    assert!(
+        view.substrate.contains_point(Point::new(8.0, 2.0)),
+        "not an implicit through-route subtraction"
+    );
+    assert_eq!(view.copper[0].image.area(), 19.0);
+    assert!(!view.copper[0].image.contains_point(Point::new(1.5, 1.5)));
+    assert_eq!(view.holes.len(), 1);
+    assert_eq!(view.holes[0].at, Point::new(8.0, 2.0));
+    assert!(view.holes[0].image.contains_point(Point::new(8.0, 2.0)));
+    assert_eq!(view.removal_layers.len(), 1);
+    assert_eq!(view.removal_layers[0].sources, [view.holes[0].id.0]);
+    assert!(
+        view.removal_layers[0]
+            .image
+            .contains_point(Point::new(8.0, 2.0))
+    );
+    assert_eq!(imported.resolve(view.holes[0].source_name.unwrap()), "slot");
+    assert!(
+        imported
+            .feature_definition(view.holes[0].id.0.feature)
+            .is_some()
+    );
+    assert_eq!(view.components.len(), 2);
+    assert_ne!(view.components[0].component, view.components[1].component);
+    let u1 = &view.components[0];
+    assert_eq!(u1.designator.as_deref(), Some("U1"));
+    assert_eq!(u1.envelopes.len(), 2);
+    assert_eq!(
+        u1.envelopes[0].kind,
+        EnvelopeKind::PackageOutlineUnspecified
+    );
+    assert_eq!(u1.envelopes[1].kind, EnvelopeKind::AssemblyOutline);
+    assert_eq!(u1.envelopes[0].image.area(), 8.0);
+    assert_eq!(u1.envelopes[1].image.area(), 2.0);
+    assert!(u1.envelopes[1].image.contains_point(Point::new(3.5, 3.0)));
+    assert!(!u1.envelopes[1].image.contains_point(Point::new(2.5, 3.0)));
+    assert!(
+        view.diagnostics
+            .contains(&BoardPhysicalDiagnostic::UnspecifiedPackageOutline(
+                u1.component
+            ))
+    );
+    let direct =
+        design(&fixture().replace("<StepRef name=\"panel\"/>", "<StepRef name=\"board\"/>"));
+    let direct = direct.physical_board(Resolution::default()).unwrap();
+    assert!(
+        view.substrate
+            .difference(&direct.substrate)
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        view.copper[0]
+            .image
+            .difference(&direct.copper[0].image)
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(view.components[0].component, direct.components[0].component);
+}
+
+#[test]
+fn assembly_ir_envelopes_keep_nested_identity_and_outline_local_transform() {
+    let imported = design(fixture());
+    let assembly = imported
+        .assembly_document(assembly::Scope::BoardArray)
+        .unwrap();
+    let envelopes = component_envelopes(&assembly, Resolution::default()).unwrap();
+    assert_eq!(envelopes.len(), 8);
+    let ids = envelopes
+        .iter()
+        .map(|component| component.component)
+        .collect::<std::collections::HashSet<_>>();
+    assert_eq!(ids.len(), 8);
+    for (component, occurrence) in envelopes.iter().zip(&assembly.occurrences) {
+        let expected = occurrence
+            .root_from_component
+            .transform_point(Point::new(1.0, 0.5));
+        assert!(component.envelopes[1].image.contains_point(expected));
+        assert!((component.envelopes[1].image.area() - 2.0).abs() < 1e-6);
+    }
+
+    // Exercise the geometry-only API after import, including polygon-local
+    // offsets in the rotated/mirrored/scaled frame (not world-space offsets).
+    let mut assembly = imported.assembly_document(assembly::Scope::Board).unwrap();
+    assembly.packages[0].views[0]
+        .outline
+        .as_mut()
+        .unwrap()
+        .transform = Some(assembly::Transform {
+        x_offset: 1.0,
+        y_offset: 2.0,
+        rotation_degrees: 90.0,
+        mirror: true,
+        face_up: false,
+        scale: 2.0,
+    });
+    let envelopes = component_envelopes(&assembly, Resolution::default()).unwrap();
+    // (2,1) + offset -> (3,3), mirror/scale -> (-6,6), rotate -> (-6,-6),
+    // U2 translation -> (-1,-5). U2 has no component rotation.
+    assert!(
+        envelopes[1].envelopes[0]
+            .image
+            .contains_point(Point::new(-1.0, -5.0))
+    );
+    assert_eq!(envelopes[1].envelopes[0].image.area(), 32.0);
+    assert_eq!(envelopes[1].envelopes[1].image.area(), 2.0);
+}
+
+#[test]
+fn generic_rout_artwork_and_clears_are_not_lost_to_hole_classification() {
+    let xml = fixture().replace("<LayerFeature layerRef=\"ROUT\"><Set>", r#"<LayerFeature layerRef="ROUT">
+      <Set><Features><Location x="0" y="0"/><Contour><Polygon><PolyBegin x="0" y="0"/><PolyStepSegment x="3" y="0"/><PolyStepSegment x="3" y="3"/><PolyStepSegment x="0" y="3"/><PolyStepSegment x="0" y="0"/></Polygon></Contour></Features></Set>
+      <Set polarity="NEGATIVE"><Features><Location x="0" y="0"/><Contour><Polygon><PolyBegin x="1" y="1"/><PolyStepSegment x="2" y="1"/><PolyStepSegment x="2" y="2"/><PolyStepSegment x="1" y="2"/><PolyStepSegment x="1" y="1"/></Polygon></Contour></Features></Set><Set>"#);
+    let view = design(&xml).physical_board(Resolution::default()).unwrap();
+    assert_eq!(view.holes.len(), 1);
+    assert_eq!(view.removal_layers[0].sources.len(), 3);
+    assert!(
+        view.removal_layers[0]
+            .image
+            .contains_point(Point::new(0.5, 0.5))
+    );
+    assert!(
+        !view.removal_layers[0]
+            .image
+            .contains_point(Point::new(1.5, 1.5))
+    );
+    assert!(
+        view.removal_layers[0]
+            .image
+            .contains_point(Point::new(8.0, 2.0))
+    );
+}
+
+#[test]
+fn inch_input_normalizes_every_physical_length_at_the_boundary() {
+    let mm = design(fixture())
+        .physical_board(Resolution::default())
+        .unwrap();
+    let inch = design(&fixture().replace("MILLIMETER", "INCH"))
+        .physical_board(Resolution::default())
+        .unwrap();
+    // Boolean coordinate snapping introduces small absolute area error on
+    // this 254 mm board. This bound is well below a 1 µm boundary displacement.
+    assert!((inch.substrate.area() - mm.substrate.area() * 25.4 * 25.4).abs() < 1e-4);
+    assert!((inch.components[0].envelopes[1].image.area() - 2.0 * 25.4 * 25.4).abs() < 1e-6);
+    assert!((inch.holes[0].at.x - 8.0 * 25.4).abs() < 1e-9);
+    assert!((inch.metadata.overall_thickness_mm.unwrap() - 1.6 * 25.4).abs() < 1e-9);
+    assert!((inch.metadata.layers[0].thickness_mm.unwrap() - 0.035 * 25.4).abs() < 1e-9);
+}
+
+#[test]
+fn metadata_reports_missing_ambiguous_invalid_and_conflicting_evidence() {
+    let mut imported = design(fixture());
+    let meta = imported.physical_board_metadata();
+    assert_eq!(meta.overall_thickness_mm, Some(1.6));
+    assert!(matches!(meta.layers[0].material, Association::Unresolved));
+    let layer = meta.layers[0].layer_ref;
+    assert!(
+        meta.diagnostics
+            .contains(&BoardPhysicalDiagnostic::MissingMaterial { layer })
+    );
+    imported.stackups[0].layers[0].thickness = Some(-1.0);
+    imported.stackups[0].layers[0].spec_ref = Some(layer);
+    imported.stackups[0].overall_thickness = None;
+    let meta = imported.physical_board_metadata();
+    assert_eq!(meta.layers[0].thickness_mm, None);
+    assert!(
+        meta.diagnostics
+            .contains(&BoardPhysicalDiagnostic::InvalidThickness {
+                layer: Some(layer),
+                value: -1.0
+            })
+    );
+    assert!(
+        meta.diagnostics
+            .contains(&BoardPhysicalDiagnostic::MissingThickness { layer: None })
+    );
+    assert!(
+        meta.diagnostics
+            .contains(&BoardPhysicalDiagnostic::UnresolvedSpec { layer, spec: layer })
+    );
+    let source = imported.stackups[0].clone();
+    imported.stackups.push(source);
+    assert!(matches!(
+        imported.physical_board_metadata().stackup,
+        Association::Ambiguous(_)
+    ));
+    imported.stackups.clear();
+    assert_eq!(
+        imported.physical_board_metadata().diagnostics,
+        [BoardPhysicalDiagnostic::MissingStackup]
+    );
+
+    let xml = fixture().replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="mat"><General type="MATERIAL"><Property text="FR4"/></General></Spec></CadHeader>"#)
+        .replace("sequence=\"0\"/>", "sequence=\"0\"><SpecRef id=\"mat\"/></StackupLayer>");
+    let mut imported = design(&xml);
+    assert!(matches!(
+        imported.physical_board_metadata().layers[0].material,
+        Association::Resolved(_)
+    ));
+    // Canonical source evidence can conflict after programmatic edits.
+    imported.stackups[0].layers[0].material = Some(layer);
+    let meta = imported.physical_board_metadata();
+    assert!(
+        matches!(meta.layers[0].material, Association::Conflicting(_)),
+        "{meta:?}"
+    );
+
+    let ambiguous = design(&xml.replace(
+        "<Property text=\"FR4\"/>",
+        "<Property text=\"FR4\"/><Property text=\"PTFE\"/>",
+    ));
+    assert!(matches!(
+        ambiguous.physical_board_metadata().layers[0].material,
+        Association::Ambiguous(_)
+    ));
+    let unresolved = design(&fixture().replace(
+        "sequence=\"0\"/>",
+        "sequence=\"0\"><SpecRef id=\"external\"/></StackupLayer>",
+    ));
+    assert!(
+        unresolved
+            .physical_board_metadata()
+            .diagnostics
+            .iter()
+            .any(|diagnostic| matches!(diagnostic, BoardPhysicalDiagnostic::UnresolvedSpec { .. }))
+    );
+}
+
+#[test]
+fn missing_profile_and_multiple_board_definitions_are_not_silent() {
+    let mut imported = design(fixture());
+    let board = imported
+        .geometry
+        .layout
+        .steps
+        .iter_mut()
+        .find(|step| step.kind == LayoutStepKind::Board)
+        .unwrap();
+    board.profiles = crate::geom::Span::EMPTY;
+    let extra = board.clone();
+    let view = imported.physical_board(Resolution::default()).unwrap();
+    assert!(
+        view.diagnostics
+            .contains(&BoardPhysicalDiagnostic::MissingProfile)
+    );
+    imported.geometry.layout.steps.push(extra);
+    assert!(
+        imported
+            .physical_board(Resolution::default())
+            .unwrap_err()
+            .to_string()
+            .contains("exactly one board definition")
+    );
+}

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -438,6 +438,77 @@ fn material_designators_preserve_identity_and_reconcile_bom_spec_evidence() {
 }
 
 #[test]
+fn multiple_stackup_specs_preserve_provenance_and_reconcile_without_last_ref_wins() {
+    let xml = fixture().replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="a"><General type="MATERIAL"><Property text="FR4"/></General></Spec><Spec name="b"><General type="MATERIAL"><Property text="PTFE"/></General></Spec></CadHeader>"#);
+    for refs in [["a", "missing"], ["missing", "a"], ["a", "b"], ["a", "a"]] {
+        let children = refs
+            .iter()
+            .map(|reference| format!(r#"<SpecRef id="{reference}"/>"#))
+            .collect::<String>();
+        let imported = design(&xml.replace(
+            "sequence=\"0\"/>",
+            &format!("sequence=\"0\">{children}</StackupLayer>"),
+        ));
+        let source = &imported.stackups[0].layers[0];
+        assert_eq!(
+            source
+                .spec_refs
+                .iter()
+                .map(|reference| imported.resolve(*reference))
+                .collect::<Vec<_>>(),
+            refs
+        );
+        assert!(source.spec_ref.is_none());
+        assert!(source.material.is_none());
+        assert!(source.dielectric_constant.is_none());
+        assert!(source.loss_tangent.is_none());
+        let metadata = imported.physical_board_metadata();
+        let layer = &metadata.layers[0];
+        assert_eq!(layer.spec_refs, source.spec_refs);
+        assert!(layer.spec_ref.is_none());
+        if refs.contains(&"b") {
+            let Association::Conflicting(values) = &layer.material else {
+                panic!("different resolved specs must conflict");
+            };
+            assert_eq!(
+                values
+                    .iter()
+                    .map(|value| imported.resolve(*value))
+                    .collect::<Vec<_>>(),
+                ["FR4", "PTFE"]
+            );
+            assert!(
+                metadata
+                    .diagnostics
+                    .contains(&BoardPhysicalDiagnostic::ConflictingMaterial {
+                        layer: layer.layer_ref
+                    })
+            );
+        } else {
+            assert_eq!(imported.resolve(*layer.material.resolved().unwrap()), "FR4");
+            let missing = metadata
+                .diagnostics
+                .iter()
+                .filter_map(|diagnostic| match diagnostic {
+                    BoardPhysicalDiagnostic::UnresolvedSpec { spec, .. } => {
+                        Some(imported.resolve(*spec))
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            assert_eq!(
+                missing,
+                if refs.contains(&"missing") {
+                    vec!["missing"]
+                } else {
+                    vec![]
+                }
+            );
+        }
+    }
+}
+
+#[test]
 fn missing_stackup_does_not_infer_hole_land_links_from_layer_declarations() {
     let xml = fixture().replace("</Content>", r#"<DictionaryStandard units="MILLIMETER"><EntryStandard id="pad"><Circle diameter="3"/></EntryStandard></DictionaryStandard></Content>"#)
         .replace("<LayerFeature layerRef=\"TOP\">", r#"<LayerFeature layerRef="TOP"><Set><Pad padstackDefRef="P"><Location x="8" y="2"/><StandardPrimitiveRef id="pad"/></Pad></Set>"#);

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -182,6 +182,33 @@ fn generic_rout_artwork_and_clears_are_not_lost_to_hole_classification() {
 }
 
 #[test]
+fn route_apertures_survive_later_generic_clears() {
+    let clear = r#"<Set polarity="NEGATIVE"><Features><Location x="0" y="0"/><Contour><Polygon><PolyBegin x="6" y="0"/><PolyStepSegment x="10" y="0"/><PolyStepSegment x="10" y="4"/><PolyStepSegment x="6" y="4"/></Polygon></Contour></Features></Set>"#;
+    let xml = fixture().replace(
+        "</SlotCavity></Set>",
+        &format!("</SlotCavity></Set>{clear}"),
+    );
+    let view = design(&xml).physical_board(Resolution::default()).unwrap();
+    assert!(
+        view.removal_layers[0]
+            .image
+            .contains_point(Point::new(8.0, 2.0))
+    );
+    assert!(
+        !view.removal_layers[0]
+            .image
+            .contains_point(Point::new(6.5, 0.5))
+    );
+    let original = design(fixture())
+        .physical_board(Resolution::default())
+        .unwrap();
+    assert!(
+        (view.removal_layers[0].image.area() - original.removal_layers[0].image.area()).abs()
+            < 1e-6
+    );
+}
+
+#[test]
 fn inch_input_normalizes_every_physical_length_at_the_boundary() {
     let mm = design(fixture())
         .physical_board(Resolution::default())

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -622,6 +622,7 @@ fn fractional_stackup_sequences_order_layers_and_reject_invalid_order_evidence()
 #[test]
 fn invalid_order_preserves_each_layer_and_group_material_provenance() {
     let xml = fixture().replace("<StackupGroup name=\"g\">", "<StackupGroup name=\"g\" matDes=\"group-material\">")
+        .replace("<StackupGroup name=", "<SpecRef id=\"root-external\"/><SpecRef id=\"mat\"/><StackupGroup name=")
         .replace("</StackupGroup>", "<CADDataLayerRef layerId=\"top\"/><SpecRef id=\"group-spec\"/></StackupGroup>")
         .replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="mat"><General type="MATERIAL"><Property text="FR4"/></General></Spec></CadHeader>"#)
         .replace("sequence=\"0\"/>", "sequence=\"0\"><SpecRef id=\"mat\"/></StackupLayer>");
@@ -630,6 +631,14 @@ fn invalid_order_preserves_each_layer_and_group_material_provenance() {
     duplicate.thickness = Some(0.07);
     imported.stackups[0].layers.push(duplicate);
     let metadata = imported.physical_board_metadata();
+    assert_eq!(
+        metadata
+            .spec_refs
+            .iter()
+            .map(|reference| imported.resolve(*reference))
+            .collect::<Vec<_>>(),
+        ["root-external", "mat"]
+    );
     assert!(
         metadata.diagnostics.iter().any(|diagnostic| matches!(
             diagnostic,

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -535,12 +535,73 @@ fn fractional_stackup_sequences_order_layers_and_reject_invalid_order_evidence()
                 .contains("duplicate layer sequence")
         );
     }
-    for invalid in ["NaN", "inf", "-0.25", "invalid"] {
+    let infinite = design(&xml.replace("sequence=\"2.5\"", "sequence=\" INF \""));
+    assert_eq!(
+        infinite.stackups[0].layers[0].layer_number,
+        Some(f64::INFINITY)
+    );
+    assert_eq!(
+        infinite
+            .physical_board(Resolution::default())
+            .unwrap()
+            .metadata
+            .layers
+            .iter()
+            .map(|layer| infinite.resolve(layer.layer_ref))
+            .collect::<Vec<_>>(),
+        ["BOTTOM", "TOP"]
+    );
+    for invalid in ["NaN", "-INF", "-0.25", "invalid"] {
         assert!(
             Ipc2581::parse(&xml.replace("sequence=\"0.25\"", &format!("sequence=\"{invalid}\"")))
                 .is_err()
         );
     }
+}
+
+#[test]
+fn invalid_order_preserves_each_layer_and_group_material_provenance() {
+    let xml = fixture().replace("<StackupGroup name=\"g\">", "<StackupGroup name=\"g\" matDes=\"group-material\">")
+        .replace("</StackupGroup>", "<SpecRef id=\"group-spec\"/></StackupGroup>")
+        .replace("<CadHeader units=\"MILLIMETER\"/>", r#"<CadHeader units="MILLIMETER"><Spec name="mat"><General type="MATERIAL"><Property text="FR4"/></General></Spec></CadHeader>"#)
+        .replace("sequence=\"0\"/>", "sequence=\"0\"><SpecRef id=\"mat\"/></StackupLayer>");
+    let mut imported = design(&xml);
+    let mut duplicate = imported.stackups[0].layers[0].clone();
+    duplicate.thickness = Some(0.07);
+    imported.stackups[0].layers.push(duplicate);
+    let metadata = imported.physical_board_metadata();
+    assert!(
+        metadata.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            BoardPhysicalDiagnostic::InvalidStackupOrder(_)
+        ))
+    );
+    assert_eq!(
+        metadata
+            .layers
+            .iter()
+            .map(|layer| layer.thickness_mm)
+            .collect::<Vec<_>>(),
+        [Some(0.035), Some(0.07)]
+    );
+    for layer in &metadata.layers {
+        assert_eq!(imported.resolve(*layer.material.resolved().unwrap()), "FR4");
+        assert_eq!(imported.resolve(layer.spec_refs[0]), "mat");
+        assert!(
+            layer.mat_des.is_none(),
+            "group identity is not inherited as layer material"
+        );
+    }
+    let group = &metadata.groups[0];
+    assert_eq!(group.source_layers, 0..1);
+    assert_eq!(imported.resolve(group.mat_des.unwrap()), "group-material");
+    assert_eq!(imported.resolve(group.spec_refs[0]), "group-spec");
+    assert!(
+        metadata
+            .diagnostics
+            .contains(&BoardPhysicalDiagnostic::UninterpretedGroupMaterial { group: group.name })
+    );
+    assert_eq!(imported.stackups[0].groups[0].mat_des, group.mat_des);
 }
 
 #[test]

--- a/crates/pcb-ir/src/import/physical/board/tests.rs
+++ b/crates/pcb-ir/src/import/physical/board/tests.rs
@@ -256,24 +256,50 @@ fn metadata_reports_missing_ambiguous_invalid_and_conflicting_evidence() {
         "{meta:?}"
     );
 
-    let descriptive = design(&xml.replace(
+    for texts in [
+        ["FR4", "Color : GREEN"],
+        ["Color : GREEN", "FR4"],
+        ["FR4", "PTFE"],
+    ] {
+        let properties = texts
+            .iter()
+            .map(|text| format!(r#"<Property text="{text}"/>"#))
+            .collect::<String>();
+        let descriptive = design(&xml.replace("<Property text=\"FR4\"/>", &properties));
+        let metadata = descriptive.physical_board_metadata();
+        assert!(matches!(
+            metadata.layers[0].material,
+            Association::Unresolved
+        ));
+        assert!(metadata.diagnostics.iter().any(|diagnostic| matches!(
+            diagnostic,
+            BoardPhysicalDiagnostic::UninterpretedMaterialProperties { .. }
+        )));
+        let spec = &descriptive.specs[&metadata.layers[0].spec_ref.unwrap()];
+        assert_eq!(
+            spec.properties
+                .iter()
+                .map(|text| descriptive.resolve(*text))
+                .collect::<Vec<_>>(),
+            texts
+        );
+    }
+    let blank = design(&xml.replace(
         "<Property text=\"FR4\"/>",
-        "<Property text=\"FR4\"/><Property text=\"Color : GREEN\"/>",
+        "<Property text=\"   \"/><Property text=\"FR4\"/>",
     ));
-    let metadata = descriptive.physical_board_metadata();
+    let metadata = blank.physical_board_metadata();
     assert_eq!(
-        descriptive.resolve(*metadata.layers[0].material.resolved().unwrap()),
+        blank.resolve(*metadata.layers[0].material.resolved().unwrap()),
         "FR4"
     );
     assert!(metadata.diagnostics.is_empty());
-    let spec = &descriptive.specs[&metadata.layers[0].spec_ref.unwrap()];
+    let zero = design(&xml.replace("thickness=\"0.035\"", "thickness=\"0\""));
     assert_eq!(
-        spec.properties
-            .iter()
-            .map(|text| descriptive.resolve(*text))
-            .collect::<Vec<_>>(),
-        ["FR4", "Color : GREEN"]
+        zero.physical_board_metadata().layers[0].thickness_mm,
+        Some(0.0)
     );
+    assert!(zero.physical_board_metadata().diagnostics.is_empty());
     let unresolved = design(&fixture().replace(
         "sequence=\"0\"/>",
         "sequence=\"0\"><SpecRef id=\"external\"/></StackupLayer>",
@@ -383,8 +409,21 @@ fn material_designators_preserve_identity_and_reconcile_bom_spec_evidence() {
         "<Property text=\"FR4\"/><Property text=\"Color : GREEN\"/>",
     ));
     let metadata = described_bom.physical_board_metadata();
+    assert!(matches!(
+        metadata.layers[0].material,
+        Association::Unresolved
+    ));
+    assert!(metadata.diagnostics.iter().any(|diagnostic| matches!(
+        diagnostic,
+        BoardPhysicalDiagnostic::UninterpretedMaterialProperties { .. }
+    )));
+    let blank = design(&xml.replace(
+        "<Property text=\"FR4\"/>",
+        "<Property text=\"   \"/><Property text=\"FR4\"/>",
+    ));
+    let metadata = blank.physical_board_metadata();
     assert_eq!(
-        described_bom.resolve(*metadata.layers[0].material.resolved().unwrap()),
+        blank.resolve(*metadata.layers[0].material.resolved().unwrap()),
         "FR4"
     );
     assert!(metadata.diagnostics.is_empty());


### PR DESCRIPTION
Add a headless board-local physical view with separate copper, removal, and component outline evidence. Preserve source identity and report missing or ambiguous material and thickness inputs. Use caller-supplied geometry resolution and retain drill and rout apertures during composition.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->