### PR TITLE
Add reusable attachment geometry queries to pcb-ir (ENG-1430)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Support KiCad 9 schematics, saving edited pages as KiCad 10.
 - Add `--accuracy-um` to set the geometry accuracy for Gerber, IPC-2581, and release output.
 - Keep circles and ellipses exact in exports and rendering.
+- Add reusable polygon-boundary, attachment clearance, cutter reachability, and break-removal connectivity queries to `pcb-ir`, with explicit uncertainty and model limitations.
 
 ### Changed
 

--- a/crates/pcb-ir/src/geom/attachment.rs
+++ b/crates/pcb-ir/src/geom/attachment.rs
@@ -331,6 +331,7 @@ pub fn transform_region(region: &ContourSet, transform: Affine2) -> Result<Conto
         .collect::<Vec<_>>();
     let mut transformed =
         ContourSet::from_contours(&contours, FillRule::NonZero, region.resolution.strict())?;
+    transformed.resolution = region.resolution;
     // Empty results have no contour on which to carry preparation history.
     transformed.uncertainty_mm = transformed
         .uncertainty_mm
@@ -436,7 +437,20 @@ pub fn check_footprints<'a>(
                         "polygon footprints overlap; source-boundary uncertainty requires refinement",
                     )
                 } else {
-                    Decision::Rejected(GeometricRejection::FootprintOverlap)
+                    // A nonempty numerical intersection alone is not a
+                    // collision certificate. Verify an interior witness
+                    // against both original input boundaries.
+                    let guard = tolerance.numerical_mm + overlap.uncertainty_mm;
+                    let footprint_query = footprint.prepare_query();
+                    let penetrates =
+                        has_penetration_witness(&overlap, [&footprint_query, &prepared], guard);
+                    if penetrates {
+                        Decision::Rejected(GeometricRejection::FootprintOverlap)
+                    } else {
+                        Decision::Unresolved(
+                            "overlap has no penetration witness beyond the numerical uncertainty band",
+                        )
+                    }
                 }
             } else if let Some(d) = distance {
                 if !d.mm.is_finite() {
@@ -469,6 +483,35 @@ pub fn check_footprints<'a>(
         }
     }
     Ok(checks)
+}
+
+/// Enumerate every horizontal vertex slab and every filled span, including
+/// concavities and holes. These are sufficient witnesses, not a penetration
+/// depth optimizer: absence of a deep witness leaves the query unresolved.
+fn has_penetration_witness(overlap: &ContourSet, inputs: [&PreparedRegion; 2], guard: f64) -> bool {
+    let mut heights = overlap
+        .rings
+        .iter()
+        .flatten()
+        .map(|p| p[1])
+        .collect::<Vec<_>>();
+    heights.sort_by(f64::total_cmp);
+    heights.dedup();
+    heights.windows(2).any(|heights| {
+        let y = heights[0] + (heights[1] - heights[0]) / 2.0;
+        let start = Point::new(overlap.bbox.min.x, y);
+        let end = Point::new(overlap.bbox.max.x, y);
+        segment_inside_intervals(overlap, start, end)
+            .into_iter()
+            .any(|(a, b)| {
+                let point = start + (end - start) * (a + (b - a) / 2.0);
+                inputs.iter().all(|input| {
+                    input
+                        .signed_distance(point)
+                        .is_some_and(|distance| distance.mm + distance.uncertainty_mm < -guard)
+                })
+            })
+    })
 }
 
 /// Witness classification in a polygon-model snapshot. Outside is geometric;

--- a/crates/pcb-ir/src/geom/attachment.rs
+++ b/crates/pcb-ir/src/geom/attachment.rs
@@ -18,11 +18,13 @@
 
 use super::dist::{self, Distance};
 use super::region::{ring_edges, segment_inside_intervals};
-use super::{Affine2, ContourSet, FillRule, Point, PreparedRegion};
+use super::{AccuracyError, Affine2, ContourSet, FillRule, Point, PreparedRegion};
 
 /// Caller-supplied position uncertainty for each input boundary, and numerical
-/// guard for comparisons. Include prior transforms, flattening, and offsets in
-/// `boundary_mm`. Neither value is an arc-length, angular, or topology bound.
+/// guard for comparisons. Stored region uncertainty is always a floor;
+/// `boundary_mm` may supply a larger external uncertainty. Neither value is an
+/// arc-length, angular, or topology bound. Operations preserve the region's
+/// preparation budget and propagate AccuracyError rather than widening it.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct QueryTolerance {
     pub boundary_mm: f64,
@@ -52,6 +54,7 @@ impl QueryTolerance {
 pub enum QueryError {
     InvalidInput(&'static str),
     Numerical(&'static str),
+    Accuracy(AccuracyError),
 }
 
 impl std::fmt::Display for QueryError {
@@ -59,15 +62,23 @@ impl std::fmt::Display for QueryError {
         match self {
             Self::InvalidInput(message) => write!(f, "invalid geometry query: {message}"),
             Self::Numerical(message) => write!(f, "numerical geometry failure: {message}"),
+            Self::Accuracy(error) => error.fmt(f),
         }
     }
 }
 
 impl std::error::Error for QueryError {}
 
+impl From<AccuracyError> for QueryError {
+    fn from(error: AccuracyError) -> Self {
+        Self::Accuracy(error)
+    }
+}
+
 fn validate_region(region: &ContourSet) -> Result<(), QueryError> {
-    if !region.tolerance.is_finite()
-        || region.tolerance < 0.0
+    region.budget().check(region.uncertainty_mm)?;
+    if !region.tolerance().is_finite()
+        || region.tolerance() < 0.0
         || region.rings.iter().any(|ring| {
             ring.len() < 3 || ring.iter().any(|p| !p[0].is_finite() || !p[1].is_finite())
         })
@@ -82,7 +93,11 @@ fn validate_region(region: &ContourSet) -> Result<(), QueryError> {
 // Do not discard newly created narrow pieces according to an input region's
 // significance threshold. This cannot restore pieces lost before the query.
 fn unfiltered(region: &ContourSet) -> ContourSet {
-    ContourSet::from_regularized(region.rings.clone(), 0.0)
+    ContourSet::from_regularized(
+        region.rings.clone(),
+        region.resolution.strict(),
+        region.uncertainty_mm,
+    )
 }
 
 /// Stable only within a BoundaryQuery's immutable source snapshot. `ring` is
@@ -233,7 +248,8 @@ impl<'a> BoundaryQuery<'a> {
             site,
             distance: Distance {
                 mm,
-                uncertainty_mm: self.tolerance.boundary_mm + self.tolerance.numerical_mm,
+                uncertainty_mm: self.tolerance.boundary_mm.max(self.region.uncertainty_mm)
+                    + self.tolerance.numerical_mm,
                 first: point,
                 second: closest,
             },
@@ -297,29 +313,25 @@ impl<'a> BoundaryQuery<'a> {
 }
 
 /// Transform the polygon model with the existing IR affine convention. Rebuild
-/// winding after reflections. The caller must scale its uncertainty budget by
-/// the transform's largest singular value; arbitrary affine transforms do not
-/// preserve stations, angles, or circular cutters.
+/// winding after reflections and scale stored uncertainty without widening the
+/// preparation budget. Callers must separately scale any larger external
+/// QueryTolerance by the largest singular value. Arbitrary affine transforms
+/// do not preserve stations, angles, or circular cutters.
 pub fn transform_region(region: &ContourSet, transform: Affine2) -> Result<ContourSet, QueryError> {
     validate_region(region)?;
     if transform.inverse().is_none() {
         return Err(QueryError::InvalidInput("singular affine transform"));
     }
-    let rings = region
-        .rings
-        .iter()
-        .map(|ring| {
-            ring.iter()
-                .map(|p| {
-                    let p = transform.transform_point(Point::new(p[0], p[1]));
-                    [p.x, p.y]
-                })
-                .collect()
-        })
-        .collect();
-    let raw = ContourSet::from_regularized(rings, 0.0);
-    validate_region(&raw)?;
-    Ok(ContourSet::new(raw.rings, FillRule::NonZero, 0.0))
+    let contours = region
+        .to_contours()
+        .into_iter()
+        .map(|contour| contour.transformed(transform))
+        .collect::<Vec<_>>();
+    Ok(ContourSet::from_contours(
+        &contours,
+        FillRule::NonZero,
+        region.resolution.strict(),
+    )?)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -392,7 +404,7 @@ pub fn check_footprints<'a>(
             (FootprintPart::Attachment, attachment),
             (FootprintPart::RouterShoulder, router_shoulder),
         ] {
-            let overlap = unfiltered(footprint).intersection(&unfiltered(obstacle.region));
+            let overlap = unfiltered(footprint).intersection(&unfiltered(obstacle.region))?;
             let bounds = footprint.bbox().union(obstacle.region.bbox());
             let reach = bounds.width().hypot(bounds.height());
             if !reach.is_finite() && !footprint.is_empty() && !obstacle.region.is_empty() {
@@ -405,11 +417,16 @@ pub fn check_footprints<'a>(
                 .filter_map(|(a, b)| prepared.segment_nearest_within(a, b, reach))
                 .min_by(|a, b| a.mm.total_cmp(&b.mm))
                 .map(|d| Distance {
-                    uncertainty_mm: tolerance.pair_band(),
+                    uncertainty_mm: tolerance.boundary_mm.max(footprint.uncertainty_mm)
+                        + tolerance.boundary_mm.max(obstacle.region.uncertainty_mm)
+                        + tolerance.numerical_mm,
                     ..d
                 });
             let decision = if !overlap.is_empty() {
-                if tolerance.boundary_mm > 0.0 {
+                if tolerance.boundary_mm > 0.0
+                    || footprint.uncertainty_mm > 0.0
+                    || obstacle.region.uncertainty_mm > 0.0
+                {
                     Decision::Unresolved(
                         "polygon footprints overlap; source-boundary uncertainty requires refinement",
                     )
@@ -476,7 +493,7 @@ fn membership(
         if !d.mm.is_finite() {
             return Err(QueryError::Numerical("membership distance overflow"));
         }
-        if d.mm.abs() <= guard {
+        if d.mm.abs() <= guard.max(d.uncertainty_mm) {
             return Ok(RegionMembership::BoundaryBand);
         }
         if d.mm < 0.0 {
@@ -523,8 +540,8 @@ pub fn cutter_reachability(
         ));
     }
     let center_space = unfiltered(workspace)
-        .difference(&unfiltered(obstacles))
-        .disk_erode(radius_mm);
+        .difference(&unfiltered(obstacles))?
+        .disk_erode(radius_mm)?;
     let components = center_space
         .connected_components()
         .iter()
@@ -615,7 +632,7 @@ pub fn material_after_break(
     tolerance.validate()?;
     validate_region(material)?;
     validate_region(removal)?;
-    let retained = unfiltered(material).difference(&unfiltered(removal));
+    let retained = unfiltered(material).difference(&unfiltered(removal))?;
     let components = retained.connected_components();
     let prepared = components
         .iter()

--- a/crates/pcb-ir/src/geom/attachment.rs
+++ b/crates/pcb-ir/src/geom/attachment.rs
@@ -1,0 +1,637 @@
+//! Policy-free attachment geometry on the canonical regularized polygon model.
+//!
+//! All lengths are millimeters. Callers supply material, complete footprints,
+//! obstacles (including component overhangs and forbidden holes), cutter entry
+//! points, and swept break-removal regions. This module selects no tab pattern,
+//! support count, fixture, or fracture model.
+//!
+//! # Scope of guarantees
+//! Boundary stations and topology refer to the supplied [`ContourSet`], not its
+//! pre-flattened curves. Flattening does not bound arc-length or tangent error,
+//! and a Hausdorff error alone does not preserve topology. Region booleans use
+//! the existing floating-point/integer overlay backend; these are not exact
+//! predicates. Missing features already discarded by a caller's region
+//! tolerance cannot be recovered. [`QueryTolerance`] is an explicit uncertainty
+//! budget, not an independently certified bound on that backend. In particular,
+//! [`PolygonTopology`] and [`CutterReachability`] are model results, **not**
+//! certified source-curve topology, toolpath generation, or physical separation.
+
+use super::dist::{self, Distance};
+use super::region::{ring_edges, segment_inside_intervals};
+use super::{Affine2, ContourSet, FillRule, Point, PreparedRegion};
+
+/// Caller-supplied position uncertainty for each input boundary, and numerical
+/// guard for comparisons. Include prior transforms, flattening, and offsets in
+/// `boundary_mm`. Neither value is an arc-length, angular, or topology bound.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct QueryTolerance {
+    pub boundary_mm: f64,
+    pub numerical_mm: f64,
+}
+
+impl QueryTolerance {
+    fn validate(self) -> Result<(), QueryError> {
+        if !self.boundary_mm.is_finite()
+            || self.boundary_mm < 0.0
+            || !self.numerical_mm.is_finite()
+            || self.numerical_mm <= 0.0
+            || !self.pair_band().is_finite()
+        {
+            return Err(QueryError::InvalidInput("invalid uncertainty budget"));
+        }
+        Ok(())
+    }
+
+    fn pair_band(self) -> f64 {
+        2.0 * self.boundary_mm + self.numerical_mm
+    }
+}
+
+/// Invalid inputs and numerical failures are not geometric rejections.
+#[derive(Debug, Clone, PartialEq)]
+pub enum QueryError {
+    InvalidInput(&'static str),
+    Numerical(&'static str),
+}
+
+impl std::fmt::Display for QueryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidInput(message) => write!(f, "invalid geometry query: {message}"),
+            Self::Numerical(message) => write!(f, "numerical geometry failure: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for QueryError {}
+
+fn validate_region(region: &ContourSet) -> Result<(), QueryError> {
+    if !region.tolerance.is_finite()
+        || region.tolerance < 0.0
+        || region.rings.iter().any(|ring| {
+            ring.len() < 3 || ring.iter().any(|p| !p[0].is_finite() || !p[1].is_finite())
+        })
+    {
+        return Err(QueryError::InvalidInput(
+            "expected finite regularized rings",
+        ));
+    }
+    Ok(())
+}
+
+// Do not discard newly created narrow pieces according to an input region's
+// significance threshold. This cannot restore pieces lost before the query.
+fn unfiltered(region: &ContourSet) -> ContourSet {
+    ContourSet::from_regularized(region.rings.clone(), 0.0)
+}
+
+/// Stable only within a BoundaryQuery's immutable source snapshot. `ring` is
+/// the original ContourSet ring index; holes retain their material component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BoundaryId {
+    pub component: usize,
+    pub ring: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BoundarySite {
+    pub boundary: BoundaryId,
+    /// Cyclic polygon arc length, in [0, perimeter).
+    pub station_mm: f64,
+    pub point: Point,
+    /// Unit outgoing tangent at a vertex; not an averaged corner tangent.
+    pub tangent: Point,
+    /// Unit normal pointing out of material (into the void on a hole).
+    pub outward_normal: Point,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BoundaryProjection {
+    pub site: BoundarySite,
+    pub distance: Distance,
+}
+
+/// Non-wrapping polygon arc interval. An interval through the cyclic seam is
+/// returned as two intervals, so no small interval needs to be dropped.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct UsableInterval {
+    pub boundary: BoundaryId,
+    pub start_mm: f64,
+    pub end_mm: f64,
+}
+
+/// Arc-length index borrowing the canonical geometry, not another polygon
+/// representation. Construct again after a transform or boolean operation.
+pub struct BoundaryQuery<'a> {
+    region: &'a ContourSet,
+    tolerance: QueryTolerance,
+    components: Vec<usize>,
+    stations: Vec<Vec<f64>>,
+}
+
+impl<'a> BoundaryQuery<'a> {
+    pub fn new(region: &'a ContourSet, tolerance: QueryTolerance) -> Result<Self, QueryError> {
+        tolerance.validate()?;
+        validate_region(region)?;
+        let stations = region
+            .rings
+            .iter()
+            .map(|ring| {
+                let mut stations = vec![0.0];
+                for (a, b) in ring_edges(ring) {
+                    let next = stations.last().unwrap() + a.distance_to(b);
+                    if !next.is_finite() || next <= *stations.last().unwrap() {
+                        return Err(QueryError::Numerical(
+                            "degenerate boundary edge or arc-length overflow",
+                        ));
+                    }
+                    stations.push(next);
+                }
+                Ok(stations)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let (components, _) = region.ring_components();
+        if components.contains(&usize::MAX) {
+            return Err(QueryError::InvalidInput("unassigned boundary component"));
+        }
+        Ok(Self {
+            region,
+            tolerance,
+            components,
+            stations,
+        })
+    }
+
+    pub fn boundaries(&self) -> impl Iterator<Item = BoundaryId> + '_ {
+        self.components
+            .iter()
+            .enumerate()
+            .map(|(ring, &component)| BoundaryId { component, ring })
+    }
+
+    fn index(&self, id: BoundaryId) -> Result<&[f64], QueryError> {
+        if self.components.get(id.ring) != Some(&id.component) {
+            return Err(QueryError::InvalidInput("unknown boundary identity"));
+        }
+        Ok(&self.stations[id.ring])
+    }
+
+    pub fn perimeter(&self, id: BoundaryId) -> Result<f64, QueryError> {
+        Ok(*self.index(id)?.last().unwrap())
+    }
+
+    pub fn site(&self, id: BoundaryId, station_mm: f64) -> Result<BoundarySite, QueryError> {
+        let stations = self.index(id)?;
+        if !station_mm.is_finite() {
+            return Err(QueryError::InvalidInput("non-finite boundary station"));
+        }
+        let perimeter = *stations.last().unwrap();
+        let s = station_mm.rem_euclid(perimeter);
+        // rem_euclid can round a tiny negative argument up to the divisor.
+        let s = if s == perimeter { 0.0 } else { s };
+        let edge = stations.partition_point(|&v| v <= s) - 1;
+        let ring = &self.region.rings[id.ring];
+        let a = Point::new(ring[edge][0], ring[edge][1]);
+        let b = Point::new(
+            ring[(edge + 1) % ring.len()][0],
+            ring[(edge + 1) % ring.len()][1],
+        );
+        let tangent = (b - a) / (stations[edge + 1] - stations[edge]);
+        Ok(BoundarySite {
+            boundary: id,
+            station_mm: s,
+            point: a + tangent * (s - stations[edge]),
+            tangent,
+            outward_normal: Point::new(tangent.y, -tangent.x),
+        })
+    }
+
+    /// Nearest point on a specified ring; equal-distance ties choose its first
+    /// edge. Repeat over boundaries when all equally near components matter.
+    pub fn project(&self, id: BoundaryId, point: Point) -> Result<BoundaryProjection, QueryError> {
+        let stations = self.index(id)?;
+        if !point.is_finite() {
+            return Err(QueryError::InvalidInput("non-finite projection point"));
+        }
+        let (edge, mm, closest) = ring_edges(&self.region.rings[id.ring])
+            .enumerate()
+            .map(|(edge, (a, b))| {
+                let (mm, closest) = dist::point_segment(point, a, b);
+                (edge, mm, closest)
+            })
+            .min_by(|a, b| a.1.total_cmp(&b.1))
+            .ok_or(QueryError::InvalidInput("empty boundary"))?;
+        let a = self.region.rings[id.ring][edge];
+        if !mm.is_finite() {
+            return Err(QueryError::Numerical("projection overflow"));
+        }
+        let site = self.site(
+            id,
+            stations[edge] + Point::new(a[0], a[1]).distance_to(closest),
+        )?;
+        Ok(BoundaryProjection {
+            site,
+            distance: Distance {
+                mm,
+                uncertainty_mm: self.tolerance.boundary_mm + self.tolerance.numerical_mm,
+                first: point,
+                second: closest,
+            },
+        })
+    }
+
+    /// Intersect every boundary edge with a caller-supplied admissible *site*
+    /// region. Crossings, not a sampling grid, delimit intervals. These are
+    /// polygon-model intervals; endpoints near uncertainty bands and source
+    /// curve arc lengths are not certified. Isolated tangencies have no usable
+    /// positive-length interval. Full-footprint clearance is a separate query.
+    pub fn usable_intervals(
+        &self,
+        id: BoundaryId,
+        admissible: &ContourSet,
+    ) -> Result<Vec<UsableInterval>, QueryError> {
+        let stations = self.index(id)?;
+        validate_region(admissible)?;
+        let mut result: Vec<UsableInterval> = Vec::new();
+        for (edge, (a, b)) in ring_edges(&self.region.rings[id.ring]).enumerate() {
+            let length = stations[edge + 1] - stations[edge];
+            for (start, end) in segment_inside_intervals(admissible, a, b) {
+                let start_mm = stations[edge] + start * length;
+                let end_mm = stations[edge] + end * length;
+                if end_mm <= start_mm {
+                    return Err(QueryError::Numerical(
+                        "usable interval below arc-length resolution",
+                    ));
+                }
+                if let Some(previous) = result
+                    .last_mut()
+                    .filter(|previous| previous.end_mm == start_mm)
+                {
+                    previous.end_mm = end_mm;
+                } else {
+                    result.push(UsableInterval {
+                        boundary: id,
+                        start_mm,
+                        end_mm,
+                    });
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// One representative midpoint per interval, with no truncation. This is
+    /// not an enumeration of all feasible placements or an optimization grid.
+    pub fn interval_site(&self, interval: UsableInterval) -> Result<BoundarySite, QueryError> {
+        if interval.start_mm < 0.0
+            || interval.end_mm > self.perimeter(interval.boundary)?
+            || interval.start_mm >= interval.end_mm
+        {
+            return Err(QueryError::InvalidInput("invalid boundary interval"));
+        }
+        self.site(
+            interval.boundary,
+            interval.start_mm + (interval.end_mm - interval.start_mm) / 2.0,
+        )
+    }
+}
+
+/// Transform the polygon model with the existing IR affine convention. Rebuild
+/// winding after reflections. The caller must scale its uncertainty budget by
+/// the transform's largest singular value; arbitrary affine transforms do not
+/// preserve stations, angles, or circular cutters.
+pub fn transform_region(region: &ContourSet, transform: Affine2) -> Result<ContourSet, QueryError> {
+    validate_region(region)?;
+    if transform.inverse().is_none() {
+        return Err(QueryError::InvalidInput("singular affine transform"));
+    }
+    let rings = region
+        .rings
+        .iter()
+        .map(|ring| {
+            ring.iter()
+                .map(|p| {
+                    let p = transform.transform_point(Point::new(p[0], p[1]));
+                    [p.x, p.y]
+                })
+                .collect()
+        })
+        .collect();
+    let raw = ContourSet::from_regularized(rings, 0.0);
+    validate_region(&raw)?;
+    Ok(ContourSet::new(raw.rings, FillRule::NonZero, 0.0))
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum GeometricRejection {
+    FootprintOverlap,
+    InsufficientClearance { required_mm: f64, measured_mm: f64 },
+    OutsideCutterSpace { point: usize },
+    Unreachable { target: usize },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Decision {
+    /// Passes in the supplied polygon model and caller's uncertainty budget.
+    Admissible,
+    Rejected(GeometricRejection),
+    /// Do not silently treat an uncertainty band as geometric infeasibility.
+    Unresolved(&'static str),
+}
+
+pub struct Obstacle<'a> {
+    /// Caller identity, e.g. a component reference or a hole identifier.
+    pub id: &'a str,
+    pub region: &'a ContourSet,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FootprintPart {
+    Attachment,
+    RouterShoulder,
+}
+
+#[derive(Debug, Clone)]
+pub struct FootprintCheck<'a> {
+    pub part: FootprintPart,
+    pub obstacle: &'a str,
+    pub decision: Decision,
+    pub boundary_distance: Option<Distance>,
+    /// Entire overlapping region, useful for actionable diagnostics.
+    pub overlap: ContourSet,
+}
+
+/// Check both complete filled footprints against every supplied obstacle. No
+/// center-only or vertex-only acceptance; containment, holes and intersecting
+/// edges are checked by filled-region intersection and all-edge distance.
+/// Empty shoulders/obstacles are allowed; an empty attachment is invalid.
+/// Touching within the numerical guard is unresolved, even for zero clearance.
+/// A source-uncertain overlap is unresolved rather than a claim that flattened
+/// curves prove collision. Supply holes as obstacles when occupying them is
+/// forbidden; holes *in* an obstacle are free space under ContourSet semantics.
+pub fn check_footprints<'a>(
+    attachment: &ContourSet,
+    router_shoulder: &ContourSet,
+    obstacles: &[Obstacle<'a>],
+    clearance_mm: f64,
+    tolerance: QueryTolerance,
+) -> Result<Vec<FootprintCheck<'a>>, QueryError> {
+    tolerance.validate()?;
+    if !clearance_mm.is_finite() || clearance_mm < 0.0 || attachment.is_empty() {
+        return Err(QueryError::InvalidInput(
+            "expected nonempty attachment and nonnegative clearance",
+        ));
+    }
+    validate_region(attachment)?;
+    validate_region(router_shoulder)?;
+    let mut checks = Vec::new();
+    for obstacle in obstacles {
+        validate_region(obstacle.region)?;
+        let prepared = obstacle.region.prepare_query();
+        for (part, footprint) in [
+            (FootprintPart::Attachment, attachment),
+            (FootprintPart::RouterShoulder, router_shoulder),
+        ] {
+            let overlap = unfiltered(footprint).intersection(&unfiltered(obstacle.region));
+            let bounds = footprint.bbox().union(obstacle.region.bbox());
+            let reach = bounds.width().hypot(bounds.height());
+            if !reach.is_finite() && !footprint.is_empty() && !obstacle.region.is_empty() {
+                return Err(QueryError::Numerical("footprint bounds overflow"));
+            }
+            let distance = footprint
+                .rings
+                .iter()
+                .flat_map(ring_edges)
+                .filter_map(|(a, b)| prepared.segment_nearest_within(a, b, reach))
+                .min_by(|a, b| a.mm.total_cmp(&b.mm))
+                .map(|d| Distance {
+                    uncertainty_mm: tolerance.pair_band(),
+                    ..d
+                });
+            let decision = if !overlap.is_empty() {
+                if tolerance.boundary_mm > 0.0 {
+                    Decision::Unresolved(
+                        "polygon footprints overlap; source-boundary uncertainty requires refinement",
+                    )
+                } else {
+                    Decision::Rejected(GeometricRejection::FootprintOverlap)
+                }
+            } else if let Some(d) = distance {
+                if !d.mm.is_finite() {
+                    return Err(QueryError::Numerical("footprint distance overflow"));
+                }
+                if d.mm - d.uncertainty_mm > clearance_mm {
+                    Decision::Admissible
+                } else if d.certainly_below(clearance_mm) {
+                    Decision::Rejected(GeometricRejection::InsufficientClearance {
+                        required_mm: clearance_mm,
+                        measured_mm: d.mm,
+                    })
+                } else {
+                    Decision::Unresolved(
+                        "clearance lies within the boundary/numerical uncertainty band",
+                    )
+                }
+            } else if footprint.is_empty() || obstacle.region.is_empty() {
+                Decision::Admissible
+            } else {
+                return Err(QueryError::Numerical("missing footprint distance"));
+            };
+            checks.push(FootprintCheck {
+                part,
+                obstacle: obstacle.id,
+                decision,
+                boundary_distance: distance,
+                overlap,
+            });
+        }
+    }
+    Ok(checks)
+}
+
+/// Witness classification in a polygon-model snapshot. Outside is geometric;
+/// BoundaryBand requests refined geometry or a witness farther from the edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionMembership {
+    Component(usize),
+    Outside,
+    BoundaryBand,
+}
+
+/// Polygon component membership with a guard at boundaries. This is shared by
+/// cutter-space and retained-material queries; boundary witnesses never silently
+/// count as material or provide a zero-width connecting ligament.
+fn membership(
+    components: &[PreparedRegion],
+    point: Point,
+    guard: f64,
+) -> Result<RegionMembership, QueryError> {
+    if !point.is_finite() {
+        return Err(QueryError::InvalidInput("non-finite membership witness"));
+    }
+    for (index, component) in components.iter().enumerate() {
+        let d = component
+            .signed_distance(point)
+            .ok_or(QueryError::Numerical("missing component boundary"))?;
+        if !d.mm.is_finite() {
+            return Err(QueryError::Numerical("membership distance overflow"));
+        }
+        if d.mm.abs() <= guard {
+            return Ok(RegionMembership::BoundaryBand);
+        }
+        if d.mm < 0.0 {
+            return Ok(RegionMembership::Component(index));
+        }
+    }
+    Ok(RegionMembership::Outside)
+}
+
+#[derive(Debug, Clone)]
+pub struct CutterReachability {
+    /// Explicit approximate disk-offset model, including all disconnected voids.
+    pub center_space: ContourSet,
+    /// Every supplied entry is classified; outside and uncertain entries do
+    /// not silently become access points.
+    pub entries: Vec<RegionMembership>,
+    /// One decision for each target, in caller order.
+    pub targets: Vec<Decision>,
+    pub tolerance: QueryTolerance,
+}
+
+/// A disk cutter can translate between points in the same connected component
+/// of free space eroded by its radius. `workspace` is a supplied bounded access
+/// envelope, **not** automatically the board outline; obstacles include retained
+/// material and other forbidden volumes projected into this 2D model. At least
+/// one explicit entry is required. This checks planar translation only, not
+/// plunge access, Z collision, shoulder shape, or a generated machining path.
+/// Disk offsets and topology use the existing approximate region backend; the
+/// returned center_space is reviewable and is not a certified exact disk erosion.
+pub fn cutter_reachability(
+    workspace: &ContourSet,
+    obstacles: &ContourSet,
+    radius_mm: f64,
+    entries: &[Point],
+    targets: &[Point],
+    tolerance: QueryTolerance,
+) -> Result<CutterReachability, QueryError> {
+    tolerance.validate()?;
+    validate_region(workspace)?;
+    validate_region(obstacles)?;
+    if !radius_mm.is_finite() || radius_mm <= 0.0 || entries.is_empty() {
+        return Err(QueryError::InvalidInput(
+            "expected positive cutter radius and explicit entries",
+        ));
+    }
+    let center_space = unfiltered(workspace)
+        .difference(&unfiltered(obstacles))
+        .disk_erode(radius_mm);
+    let components = center_space
+        .connected_components()
+        .iter()
+        .map(ContourSet::prepare_query)
+        .collect::<Vec<_>>();
+    let entry_components = entries
+        .iter()
+        .map(|&p| membership(&components, p, tolerance.pair_band()))
+        .collect::<Result<Vec<_>, _>>()?;
+    let targets = targets
+        .iter()
+        .enumerate()
+        .map(|(target, &p)| {
+            Ok(match membership(&components, p, tolerance.pair_band())? {
+                RegionMembership::Component(component)
+                    if entry_components.contains(&RegionMembership::Component(component)) =>
+                {
+                    Decision::Admissible
+                }
+                RegionMembership::Component(_)
+                    if entry_components.contains(&RegionMembership::BoundaryBand) =>
+                {
+                    Decision::Unresolved("entry is within the cutter-space uncertainty band")
+                }
+                RegionMembership::Component(_) => {
+                    Decision::Rejected(GeometricRejection::Unreachable { target })
+                }
+                RegionMembership::Outside => {
+                    Decision::Rejected(GeometricRejection::OutsideCutterSpace { point: target })
+                }
+                RegionMembership::BoundaryBand => {
+                    Decision::Unresolved("target is within the cutter-space uncertainty band")
+                }
+            })
+        })
+        .collect::<Result<Vec<_>, QueryError>>()?;
+    Ok(CutterReachability {
+        center_space,
+        entries: entry_components,
+        targets,
+        tolerance,
+    })
+}
+
+/// Connectivity of the regularized retained polygon material, not a source-curve
+/// or physical-fracture certificate. Component IDs belong only to this result.
+#[derive(Debug, Clone)]
+pub struct PolygonTopology {
+    pub retained: ContourSet,
+    pub components: Vec<ContourSet>,
+    /// In caller order, distinguishing removed/outside witnesses from numerical
+    /// or source-boundary ambiguity. Neither counts as successful separation.
+    pub witnesses: Vec<RegionMembership>,
+    pub tolerance: QueryTolerance,
+}
+
+impl PolygonTopology {
+    /// Whether two supplied material witnesses remain connected. Missing or
+    /// boundary-band witnesses are unresolved, not successful separation.
+    pub fn connected(&self, first: usize, second: usize) -> Result<Option<bool>, QueryError> {
+        let a = self
+            .witnesses
+            .get(first)
+            .ok_or(QueryError::InvalidInput("unknown material witness"))?;
+        let b = self
+            .witnesses
+            .get(second)
+            .ok_or(QueryError::InvalidInput("unknown material witness"))?;
+        Ok(match (a, b) {
+            (RegionMembership::Component(a), RegionMembership::Component(b)) => Some(a == b),
+            _ => None,
+        })
+    }
+}
+
+/// Subtract a caller-supplied *filled swept removal region*, not a zero-width
+/// line or inferred kerf. Supply an empty removal for pre-break connectivity.
+/// Holes, cutouts, and disconnected retained islands are preserved. Call
+/// `connected(a,b)` on witness pairs for desired retention and separation;
+/// `Some(false)` means separated in this polygon model only. Construct swept
+/// regions with geom/path's stroke_to_fill and the caller's explicit width/caps.
+pub fn material_after_break(
+    material: &ContourSet,
+    removal: &ContourSet,
+    witnesses: &[Point],
+    tolerance: QueryTolerance,
+) -> Result<PolygonTopology, QueryError> {
+    tolerance.validate()?;
+    validate_region(material)?;
+    validate_region(removal)?;
+    let retained = unfiltered(material).difference(&unfiltered(removal));
+    let components = retained.connected_components();
+    let prepared = components
+        .iter()
+        .map(ContourSet::prepare_query)
+        .collect::<Vec<_>>();
+    let witnesses = witnesses
+        .iter()
+        .map(|&p| membership(&prepared, p, tolerance.pair_band()))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(PolygonTopology {
+        retained,
+        components,
+        witnesses,
+        tolerance,
+    })
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pcb-ir/src/geom/attachment.rs
+++ b/crates/pcb-ir/src/geom/attachment.rs
@@ -319,19 +319,24 @@ impl<'a> BoundaryQuery<'a> {
 /// do not preserve stations, angles, or circular cutters.
 pub fn transform_region(region: &ContourSet, transform: Affine2) -> Result<ContourSet, QueryError> {
     validate_region(region)?;
-    if transform.inverse().is_none() {
-        return Err(QueryError::InvalidInput("singular affine transform"));
+    if transform.inverse().is_none() || !transform.m02.is_finite() || !transform.m12.is_finite() {
+        return Err(QueryError::InvalidInput(
+            "singular or non-finite affine transform",
+        ));
     }
     let contours = region
         .to_contours()
         .into_iter()
         .map(|contour| contour.transformed(transform))
         .collect::<Vec<_>>();
-    Ok(ContourSet::from_contours(
-        &contours,
-        FillRule::NonZero,
-        region.resolution.strict(),
-    )?)
+    let mut transformed =
+        ContourSet::from_contours(&contours, FillRule::NonZero, region.resolution.strict())?;
+    // Empty results have no contour on which to carry preparation history.
+    transformed.uncertainty_mm = transformed
+        .uncertainty_mm
+        .max(region.uncertainty_mm * transform.max_scale());
+    transformed.budget().check(transformed.uncertainty_mm)?;
+    Ok(transformed)
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -481,7 +486,7 @@ pub enum RegionMembership {
 fn membership(
     components: &[PreparedRegion],
     point: Point,
-    guard: f64,
+    tolerance: QueryTolerance,
 ) -> Result<RegionMembership, QueryError> {
     if !point.is_finite() {
         return Err(QueryError::InvalidInput("non-finite membership witness"));
@@ -493,7 +498,8 @@ fn membership(
         if !d.mm.is_finite() {
             return Err(QueryError::Numerical("membership distance overflow"));
         }
-        if d.mm.abs() <= guard.max(d.uncertainty_mm) {
+        let guard = (2.0 * tolerance.boundary_mm).max(d.uncertainty_mm) + tolerance.numerical_mm;
+        if d.mm.abs() <= guard {
             return Ok(RegionMembership::BoundaryBand);
         }
         if d.mm < 0.0 {
@@ -549,7 +555,7 @@ pub fn cutter_reachability(
         .collect::<Vec<_>>();
     let entry_components = entries
         .iter()
-        .map(|&p| membership(&components, p, tolerance.pair_band()))
+        .map(|&p| membership(&components, p, tolerance))
         .collect::<Result<Vec<_>, _>>()?;
     // An uncertain entry may border several components, but cannot provide
     // possible access to remote ones. Retain all adjacent candidates rather
@@ -558,11 +564,9 @@ pub fn cutter_reachability(
     for (&entry, classification) in entries.iter().zip(&entry_components) {
         if *classification == RegionMembership::BoundaryBand {
             for (index, component) in components.iter().enumerate() {
-                uncertain_access[index] |= membership(
-                    std::slice::from_ref(component),
-                    entry,
-                    tolerance.pair_band(),
-                )? == RegionMembership::BoundaryBand;
+                uncertain_access[index] |=
+                    membership(std::slice::from_ref(component), entry, tolerance)?
+                        == RegionMembership::BoundaryBand;
             }
         }
     }
@@ -570,7 +574,7 @@ pub fn cutter_reachability(
         .iter()
         .enumerate()
         .map(|(target, &p)| {
-            Ok(match membership(&components, p, tolerance.pair_band())? {
+            Ok(match membership(&components, p, tolerance)? {
                 RegionMembership::Component(component)
                     if entry_components.contains(&RegionMembership::Component(component)) =>
                 {
@@ -653,7 +657,7 @@ pub fn material_after_break(
         .collect::<Vec<_>>();
     let witnesses = witnesses
         .iter()
-        .map(|&p| membership(&prepared, p, tolerance.pair_band()))
+        .map(|&p| membership(&prepared, p, tolerance))
         .collect::<Result<Vec<_>, _>>()?;
     Ok(PolygonTopology {
         retained,

--- a/crates/pcb-ir/src/geom/attachment.rs
+++ b/crates/pcb-ir/src/geom/attachment.rs
@@ -551,6 +551,21 @@ pub fn cutter_reachability(
         .iter()
         .map(|&p| membership(&components, p, tolerance.pair_band()))
         .collect::<Result<Vec<_>, _>>()?;
+    // An uncertain entry may border several components, but cannot provide
+    // possible access to remote ones. Retain all adjacent candidates rather
+    // than only the first boundary found by the aggregate membership query.
+    let mut uncertain_access = vec![false; components.len()];
+    for (&entry, classification) in entries.iter().zip(&entry_components) {
+        if *classification == RegionMembership::BoundaryBand {
+            for (index, component) in components.iter().enumerate() {
+                uncertain_access[index] |= membership(
+                    std::slice::from_ref(component),
+                    entry,
+                    tolerance.pair_band(),
+                )? == RegionMembership::BoundaryBand;
+            }
+        }
+    }
     let targets = targets
         .iter()
         .enumerate()
@@ -561,9 +576,7 @@ pub fn cutter_reachability(
                 {
                     Decision::Admissible
                 }
-                RegionMembership::Component(_)
-                    if entry_components.contains(&RegionMembership::BoundaryBand) =>
-                {
+                RegionMembership::Component(component) if uncertain_access[component] => {
                     Decision::Unresolved("entry is within the cutter-space uncertainty band")
                 }
                 RegionMembership::Component(_) => {

--- a/crates/pcb-ir/src/geom/attachment/tests.rs
+++ b/crates/pcb-ir/src/geom/attachment/tests.rs
@@ -553,6 +553,51 @@ fn stored_membership_uncertainty_keeps_additive_numerical_guard() {
 }
 
 #[test]
+fn numerical_overlap_requires_a_deep_interior_witness() {
+    let footprint = rect(0.0, 0.0, 1.0, 1.0);
+    let tolerance = QueryTolerance {
+        numerical_mm: 0.001,
+        ..TOL
+    };
+    for (depth, rejected) in [(0.0005, false), (0.001, false), (0.01, true)] {
+        let obstacle = rect(1.0 - depth, 0.0, 1.0, 1.0);
+        let checks = check_footprints(
+            &footprint,
+            &ContourSet::empty(RESOLUTION),
+            &[Obstacle {
+                id: "overlap",
+                region: &obstacle,
+            }],
+            0.0,
+            tolerance,
+        )
+        .unwrap();
+        if rejected {
+            assert_eq!(
+                checks[0].decision,
+                Decision::Rejected(GeometricRejection::FootprintOverlap)
+            );
+        } else {
+            assert!(matches!(checks[0].decision, Decision::Unresolved(_)));
+        }
+    }
+}
+
+#[test]
+fn transform_preserves_nonzero_significance_for_following_operations() {
+    let resolution = RESOLUTION.with_tolerance(0.1);
+    let region = ContourSet::rectangle(BBox::new(Point::ZERO, Point::new(2.0, 2.0)), resolution);
+    let moved = transform_region(&region, Affine2::IDENTITY).unwrap();
+    assert_eq!(moved.resolution, resolution);
+    assert!(
+        moved
+            .intersection(&rect(0.0, 0.0, 0.05, 0.05))
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
 fn invalid_queries_are_errors_not_geometric_rejections() {
     let region = rect(0.0, 0.0, 1.0, 1.0);
     assert!(

--- a/crates/pcb-ir/src/geom/attachment/tests.rs
+++ b/crates/pcb-ir/src/geom/attachment/tests.rs
@@ -421,6 +421,51 @@ fn boundary_witnesses_are_unresolved_not_access_or_separation() {
 }
 
 #[test]
+fn uncertain_cutter_entries_affect_only_adjacent_components() {
+    let workspace = rect(0.0, 0.0, 4.0, 4.0)
+        .union(&rect(4.2, 0.0, 4.0, 4.0))
+        .unwrap()
+        .union(&rect(20.0, 0.0, 4.0, 4.0))
+        .unwrap();
+    let empty = ContourSet::empty(RESOLUTION);
+    let targets = [
+        Point::new(2.0, 2.0),
+        Point::new(6.0, 2.0),
+        Point::new(22.0, 2.0),
+    ];
+    // The first entry borders only the left component; the second borders
+    // both nearby components. Neither can reach the distant third component.
+    for (entry, second_uncertain) in [(Point::new(0.1, 2.0), false), (Point::new(4.1, 2.0), true)] {
+        let reach = cutter_reachability(
+            &workspace,
+            &empty,
+            0.1,
+            &[entry],
+            &targets,
+            QueryTolerance {
+                boundary_mm: 0.15,
+                ..TOL
+            },
+        )
+        .unwrap();
+        assert_eq!(reach.entries, vec![RegionMembership::BoundaryBand]);
+        assert!(matches!(reach.targets[0], Decision::Unresolved(_)));
+        if second_uncertain {
+            assert!(matches!(reach.targets[1], Decision::Unresolved(_)));
+        } else {
+            assert_eq!(
+                reach.targets[1],
+                Decision::Rejected(GeometricRejection::Unreachable { target: 1 })
+            );
+        }
+        assert_eq!(
+            reach.targets[2],
+            Decision::Rejected(GeometricRejection::Unreachable { target: 2 })
+        );
+    }
+}
+
+#[test]
 fn preparation_uncertainty_and_budget_survive_queries_and_transforms() {
     let original = rect(0.0, 0.0, 1.0, 1.0);
     let prepared = ContourSet::from_regularized(original.rings, RESOLUTION, 0.002);

--- a/crates/pcb-ir/src/geom/attachment/tests.rs
+++ b/crates/pcb-ir/src/geom/attachment/tests.rs
@@ -500,6 +500,59 @@ fn preparation_uncertainty_and_budget_survive_queries_and_transforms() {
 }
 
 #[test]
+fn empty_transform_keeps_scaled_uncertainty_and_budget() {
+    let empty = ContourSet::from_regularized(vec![], RESOLUTION, 0.002);
+    let transform = Affine2::placement(Point::new(1.0, 2.0), 30.0, Mirror::X, 2.0);
+    let result = transform_region(&empty, transform).unwrap();
+    assert!(result.is_empty());
+    close(result.uncertainty_mm, 0.004, 1e-12);
+    assert_eq!(result.resolution, RESOLUTION);
+    assert!(matches!(
+        transform_region(
+            &empty,
+            Affine2::placement(Point::ZERO, 0.0, Mirror::NONE, 10.0)
+        ),
+        Err(QueryError::Accuracy(AccuracyError::BudgetExceeded { .. }))
+    ));
+}
+
+#[test]
+fn stored_membership_uncertainty_keeps_additive_numerical_guard() {
+    let material = ContourSet::from_regularized(rect(0.0, 0.0, 4.0, 4.0).rings, RESOLUTION, 0.002);
+    let empty = ContourSet::empty(RESOLUTION);
+    let tolerance = QueryTolerance {
+        boundary_mm: 0.0,
+        numerical_mm: 0.001,
+    };
+    let topology =
+        material_after_break(&material, &empty, &[Point::new(0.0025, 2.0)], tolerance).unwrap();
+    assert_eq!(topology.witnesses, vec![RegionMembership::BoundaryBand]);
+    let baseline = cutter_reachability(
+        &material,
+        &empty,
+        0.5,
+        &[Point::new(2.0, 2.0)],
+        &[],
+        tolerance,
+    )
+    .unwrap();
+    let band_point = Point::new(
+        baseline.center_space.bbox.min.x + baseline.center_space.uncertainty_mm + 0.0005,
+        2.0,
+    );
+    let result = cutter_reachability(
+        &material,
+        &empty,
+        0.5,
+        &[Point::new(2.0, 2.0)],
+        &[band_point],
+        tolerance,
+    )
+    .unwrap();
+    assert!(matches!(result.targets[0], Decision::Unresolved(_)));
+}
+
+#[test]
 fn invalid_queries_are_errors_not_geometric_rejections() {
     let region = rect(0.0, 0.0, 1.0, 1.0);
     assert!(

--- a/crates/pcb-ir/src/geom/attachment/tests.rs
+++ b/crates/pcb-ir/src/geom/attachment/tests.rs
@@ -1,5 +1,13 @@
 use super::*;
-use crate::geom::{BBox, ContourBuf, LineCap, LineJoin, Mirror, PathCmd, StrokeToFillStyle};
+use crate::geom::{
+    BBox, ContourBuf, GeometryAccuracy, LineCap, LineJoin, Mirror, PathCmd, Resolution,
+    StrokeToFillStyle,
+};
+
+const RESOLUTION: Resolution = Resolution {
+    tolerance_mm: 0.0,
+    accuracy: GeometryAccuracy::micrometres(10),
+};
 
 const TOL: QueryTolerance = QueryTolerance {
     boundary_mm: 0.0,
@@ -7,7 +15,10 @@ const TOL: QueryTolerance = QueryTolerance {
 };
 
 fn rect(x: f64, y: f64, w: f64, h: f64) -> ContourSet {
-    ContourSet::rectangle(BBox::new(Point::new(x, y), Point::new(x + w, y + h)), 0.0)
+    ContourSet::rectangle(
+        BBox::new(Point::new(x, y), Point::new(x + w, y + h)),
+        RESOLUTION,
+    )
 }
 
 fn close(a: f64, b: f64, tolerance: f64) {
@@ -18,7 +29,9 @@ fn close(a: f64, b: f64, tolerance: f64) {
 fn cyclic_projection_and_material_normals_preserve_hole_identity() {
     let material = rect(0.0, 0.0, 10.0, 10.0)
         .difference(&rect(3.0, 3.0, 4.0, 4.0))
-        .union(&rect(20.0, 0.0, 2.0, 2.0));
+        .unwrap()
+        .union(&rect(20.0, 0.0, 2.0, 2.0))
+        .unwrap();
     let query = BoundaryQuery::new(&material, TOL).unwrap();
     let ids = query.boundaries().collect::<Vec<_>>();
     assert_eq!(ids.len(), 3);
@@ -50,10 +63,13 @@ fn intervals_retain_every_narrow_window_and_hole_split() {
     let id = query.boundaries().next().unwrap();
     // More windows than a typical candidate cap, each much smaller than a
     // plausible sampling step. The hole removes a central part of one window.
-    let windows = (0..80).fold(ContourSet::empty(0.0), |r, i| {
+    let windows = (0..80).fold(ContourSet::empty(RESOLUTION), |r, i| {
         r.union(&rect(0.1 + i as f64 * 0.1, -0.1, 0.0001, 0.2))
+            .unwrap()
     });
-    let windows = windows.difference(&rect(0.10004, -0.05, 0.00002, 0.1));
+    let windows = windows
+        .difference(&rect(0.10004, -0.05, 0.00002, 0.1))
+        .unwrap();
     let intervals = query.usable_intervals(id, &windows).unwrap();
     assert_eq!(intervals.len(), 81);
     close(
@@ -74,9 +90,9 @@ fn curved_contours_use_explicit_polygon_model() {
         PathCmd::arc_to(Point::new(5.0, 0.0), Point::ZERO, false),
         PathCmd::close(),
     ]);
-    let region = ContourSet::from_contours(&[circle], FillRule::NonZero, 0.0);
+    let region = ContourSet::from_contours(&[circle], FillRule::NonZero, RESOLUTION).unwrap();
     let tolerance = QueryTolerance {
-        boundary_mm: crate::geom::tol::FLATTEN_MM,
+        boundary_mm: 0.0,
         ..TOL
     };
     let query = BoundaryQuery::new(&region, tolerance).unwrap();
@@ -93,7 +109,7 @@ fn curved_contours_use_explicit_polygon_model() {
         0.0,
         1e-10,
     );
-    assert!(p.distance.uncertainty_mm > crate::geom::tol::FLATTEN_MM);
+    assert!(p.distance.uncertainty_mm > region.uncertainty_mm);
     let intervals = query
         .usable_intervals(id, &rect(4.0, -1.0, 2.0, 2.0))
         .unwrap();
@@ -110,7 +126,7 @@ fn curved_contours_use_explicit_polygon_model() {
         ),
         PathCmd::close(),
     ]);
-    let region = ContourSet::from_contours(&[cubic], FillRule::EvenOdd, 0.0);
+    let region = ContourSet::from_contours(&[cubic], FillRule::EvenOdd, RESOLUTION).unwrap();
     let query = BoundaryQuery::new(&region, tolerance).unwrap();
     let id = query.boundaries().next().unwrap();
     close(
@@ -122,7 +138,9 @@ fn curved_contours_use_explicit_polygon_model() {
 
 #[test]
 fn concavity_and_affine_reflection_keep_outward_normals_and_clearance() {
-    let material = rect(0.0, 0.0, 6.0, 2.0).union(&rect(0.0, 0.0, 2.0, 6.0));
+    let material = rect(0.0, 0.0, 6.0, 2.0)
+        .union(&rect(0.0, 0.0, 2.0, 6.0))
+        .unwrap();
     let transform = Affine2::placement(Point::new(30.0, -12.0), 37.0, Mirror::X, 2.0);
     let moved = transform_region(&material, transform).unwrap();
     let query = BoundaryQuery::new(&moved, TOL).unwrap();
@@ -137,7 +155,7 @@ fn concavity_and_affine_reflection_keep_outward_normals_and_clearance() {
     let attachment = transform_region(&rect(3.0, 3.0, 1.0, 1.0), transform).unwrap();
     let checks = check_footprints(
         &attachment,
-        &ContourSet::empty(0.0),
+        &ContourSet::empty(RESOLUTION),
         &[Obstacle {
             id: "concave board",
             region: &moved,
@@ -205,7 +223,7 @@ fn complete_footprints_detect_crossings_containment_shoulders_and_holes() {
             .decision,
         Decision::Rejected(GeometricRejection::FootprintOverlap)
     );
-    let annulus = enclosing.difference(&rect(-5.0, -5.0, 10.0, 10.0));
+    let annulus = enclosing.difference(&rect(-5.0, -5.0, 10.0, 10.0)).unwrap();
     assert_eq!(
         check_footprints(
             &attachment,
@@ -234,7 +252,7 @@ fn tolerance_ambiguity_is_not_geometric_rejection() {
     let check = |clearance| {
         check_footprints(
             &attachment,
-            &ContourSet::empty(0.0),
+            &ContourSet::empty(RESOLUTION),
             &[Obstacle {
                 id: "near",
                 region: &obstacle,
@@ -272,7 +290,9 @@ fn tolerance_ambiguity_is_not_geometric_rejection() {
 #[test]
 fn cutter_reachability_detects_closed_holes_and_radius_limited_necks() {
     let workspace = rect(-5.0, -5.0, 10.0, 10.0);
-    let ring = rect(-3.0, -3.0, 6.0, 6.0).difference(&rect(-1.0, -1.0, 2.0, 2.0));
+    let ring = rect(-3.0, -3.0, 6.0, 6.0)
+        .difference(&rect(-1.0, -1.0, 2.0, 2.0))
+        .unwrap();
     let reach = cutter_reachability(
         &workspace,
         &ring,
@@ -289,8 +309,10 @@ fn cutter_reachability_detects_closed_holes_and_radius_limited_necks() {
     );
     let free = rect(0.0, 0.0, 3.0, 4.0)
         .union(&rect(3.0, 1.7, 4.0, 0.6))
-        .union(&rect(7.0, 0.0, 3.0, 4.0));
-    let empty = ContourSet::empty(0.0);
+        .unwrap()
+        .union(&rect(7.0, 0.0, 3.0, 4.0))
+        .unwrap();
+    let empty = ContourSet::empty(RESOLUTION);
     for (radius, reachable) in [(0.2, true), (0.4, false)] {
         let result = cutter_reachability(
             &free,
@@ -307,13 +329,16 @@ fn cutter_reachability_detects_closed_holes_and_radius_limited_necks() {
 
 #[test]
 fn supplied_break_sweep_separates_only_when_last_ligament_is_removed() {
-    let material = rect(0.0, 0.0, 10.0, 4.0).difference(&rect(4.5, 1.0, 1.0, 2.0));
+    let material = rect(0.0, 0.0, 10.0, 4.0)
+        .difference(&rect(4.5, 1.0, 1.0, 2.0))
+        .unwrap();
     let points = [
         Point::new(1.0, 2.0),
         Point::new(9.0, 2.0),
         Point::new(5.0, 2.0),
     ];
-    let before = material_after_break(&material, &ContourSet::empty(0.0), &points, TOL).unwrap();
+    let before =
+        material_after_break(&material, &ContourSet::empty(RESOLUTION), &points, TOL).unwrap();
     assert_eq!(before.connected(0, 1).unwrap(), Some(true));
     assert_eq!(before.connected(0, 2).unwrap(), None);
     let partial =
@@ -326,9 +351,11 @@ fn supplied_break_sweep_separates_only_when_last_ligament_is_removed() {
     let sweep = crate::geom::path::stroke_to_fill(
         &[path],
         StrokeToFillStyle::new(0.4, LineCap::Round, LineJoin::Round),
+        RESOLUTION.accuracy,
     )
+    .unwrap()
     .unwrap();
-    let removal = ContourSet::from_contours(&sweep, FillRule::NonZero, 0.0);
+    let removal = ContourSet::from_contours(&sweep, FillRule::NonZero, RESOLUTION).unwrap();
     let after = material_after_break(&material, &removal, &points, TOL).unwrap();
     assert_eq!(after.components.len(), 2);
     assert_eq!(after.connected(0, 1).unwrap(), Some(false));
@@ -347,7 +374,7 @@ fn supplied_break_sweep_separates_only_when_last_ligament_is_removed() {
 #[test]
 fn boundary_witnesses_are_unresolved_not_access_or_separation() {
     let region = rect(0.0, 0.0, 4.0, 4.0);
-    let empty = ContourSet::empty(0.0);
+    let empty = ContourSet::empty(RESOLUTION);
     let points = [
         Point::new(2.0, 2.0),
         Point::new(-1.0, 2.0),
@@ -391,6 +418,40 @@ fn boundary_witnesses_are_unresolved_not_access_or_separation() {
     )
     .unwrap();
     assert_eq!(multiple_entries.targets[0], Decision::Admissible);
+}
+
+#[test]
+fn preparation_uncertainty_and_budget_survive_queries_and_transforms() {
+    let original = rect(0.0, 0.0, 1.0, 1.0);
+    let prepared = ContourSet::from_regularized(original.rings, RESOLUTION, 0.002);
+    let transformed = transform_region(
+        &prepared,
+        Affine2::placement(Point::ZERO, 17.0, Mirror::X, 2.0),
+    )
+    .unwrap();
+    assert!(transformed.uncertainty_mm >= 0.004);
+    assert_eq!(transformed.resolution, RESOLUTION);
+    let obstacle = rect(1.003, 0.0, 1.0, 1.0);
+    let checks = check_footprints(
+        &prepared,
+        &ContourSet::empty(RESOLUTION),
+        &[Obstacle {
+            id: "near",
+            region: &obstacle,
+        }],
+        0.002,
+        TOL,
+    )
+    .unwrap();
+    assert!(matches!(checks[0].decision, Decision::Unresolved(_)));
+    assert!(checks[0].boundary_distance.unwrap().uncertainty_mm >= 0.002);
+    assert!(matches!(
+        transform_region(
+            &prepared,
+            Affine2::placement(Point::ZERO, 0.0, Mirror::NONE, 10.0)
+        ),
+        Err(QueryError::Accuracy(AccuracyError::BudgetExceeded { .. }))
+    ));
 }
 
 #[test]

--- a/crates/pcb-ir/src/geom/attachment/tests.rs
+++ b/crates/pcb-ir/src/geom/attachment/tests.rs
@@ -1,0 +1,435 @@
+use super::*;
+use crate::geom::{BBox, ContourBuf, LineCap, LineJoin, Mirror, PathCmd, StrokeToFillStyle};
+
+const TOL: QueryTolerance = QueryTolerance {
+    boundary_mm: 0.0,
+    numerical_mm: 1e-8,
+};
+
+fn rect(x: f64, y: f64, w: f64, h: f64) -> ContourSet {
+    ContourSet::rectangle(BBox::new(Point::new(x, y), Point::new(x + w, y + h)), 0.0)
+}
+
+fn close(a: f64, b: f64, tolerance: f64) {
+    assert!((a - b).abs() < tolerance, "{a} != {b}");
+}
+
+#[test]
+fn cyclic_projection_and_material_normals_preserve_hole_identity() {
+    let material = rect(0.0, 0.0, 10.0, 10.0)
+        .difference(&rect(3.0, 3.0, 4.0, 4.0))
+        .union(&rect(20.0, 0.0, 2.0, 2.0));
+    let query = BoundaryQuery::new(&material, TOL).unwrap();
+    let ids = query.boundaries().collect::<Vec<_>>();
+    assert_eq!(ids.len(), 3);
+    let mut components = ids.iter().map(|id| id.component).collect::<Vec<_>>();
+    components.sort();
+    components.dedup();
+    assert_eq!(components.len(), 2);
+    for id in ids {
+        let perimeter = query.perimeter(id).unwrap();
+        let first = query.site(id, 0.5).unwrap();
+        assert_eq!(first, query.site(id, perimeter + 0.5).unwrap());
+        assert_eq!(first, query.site(id, 0.5 - perimeter).unwrap());
+        close(first.tangent.length(), 1.0, 1e-10);
+        let outside = first.point + first.outward_normal * 0.1;
+        let inside = first.point - first.outward_normal * 0.1;
+        assert!(!material.contains_point(outside));
+        assert!(material.contains_point(inside));
+        let projected = query.project(id, outside).unwrap();
+        close(projected.distance.mm, 0.1, 1e-8);
+        close(projected.site.point.distance_to(first.point), 0.0, 1e-8);
+        assert_eq!(projected.site.boundary, id);
+    }
+}
+
+#[test]
+fn intervals_retain_every_narrow_window_and_hole_split() {
+    let material = rect(0.0, 0.0, 10.0, 3.0);
+    let query = BoundaryQuery::new(&material, TOL).unwrap();
+    let id = query.boundaries().next().unwrap();
+    // More windows than a typical candidate cap, each much smaller than a
+    // plausible sampling step. The hole removes a central part of one window.
+    let windows = (0..80).fold(ContourSet::empty(0.0), |r, i| {
+        r.union(&rect(0.1 + i as f64 * 0.1, -0.1, 0.0001, 0.2))
+    });
+    let windows = windows.difference(&rect(0.10004, -0.05, 0.00002, 0.1));
+    let intervals = query.usable_intervals(id, &windows).unwrap();
+    assert_eq!(intervals.len(), 81);
+    close(
+        intervals.iter().map(|i| i.end_mm - i.start_mm).sum(),
+        0.00798,
+        1e-6,
+    );
+    for interval in intervals {
+        assert!(windows.contains_point(query.interval_site(interval).unwrap().point));
+    }
+}
+
+#[test]
+fn curved_contours_use_explicit_polygon_model() {
+    let circle = ContourBuf::new(vec![
+        PathCmd::move_to(Point::new(5.0, 0.0)),
+        PathCmd::arc_to(Point::new(-5.0, 0.0), Point::ZERO, false),
+        PathCmd::arc_to(Point::new(5.0, 0.0), Point::ZERO, false),
+        PathCmd::close(),
+    ]);
+    let region = ContourSet::from_contours(&[circle], FillRule::NonZero, 0.0);
+    let tolerance = QueryTolerance {
+        boundary_mm: crate::geom::tol::FLATTEN_MM,
+        ..TOL
+    };
+    let query = BoundaryQuery::new(&region, tolerance).unwrap();
+    let id = query.boundaries().next().unwrap();
+    close(
+        query.perimeter(id).unwrap(),
+        10.0 * std::f64::consts::PI,
+        0.04,
+    );
+    let p = query.project(id, Point::new(6.0, 1.0)).unwrap();
+    close(p.site.point.length(), 5.0, 0.006);
+    close(
+        p.site.tangent.x * p.site.outward_normal.x + p.site.tangent.y * p.site.outward_normal.y,
+        0.0,
+        1e-10,
+    );
+    assert!(p.distance.uncertainty_mm > crate::geom::tol::FLATTEN_MM);
+    let intervals = query
+        .usable_intervals(id, &rect(4.0, -1.0, 2.0, 2.0))
+        .unwrap();
+    assert!(!intervals.is_empty());
+    for interval in intervals {
+        assert!(query.interval_site(interval).unwrap().point.x > 4.0);
+    }
+    let cubic = ContourBuf::new(vec![
+        PathCmd::move_to(Point::ZERO),
+        PathCmd::cubic_to(
+            Point::new(0.0, 4.0),
+            Point::new(4.0, 4.0),
+            Point::new(4.0, 0.0),
+        ),
+        PathCmd::close(),
+    ]);
+    let region = ContourSet::from_contours(&[cubic], FillRule::EvenOdd, 0.0);
+    let query = BoundaryQuery::new(&region, tolerance).unwrap();
+    let id = query.boundaries().next().unwrap();
+    close(
+        query.project(id, Point::new(2.0, 4.0)).unwrap().distance.mm,
+        1.0,
+        0.006,
+    );
+}
+
+#[test]
+fn concavity_and_affine_reflection_keep_outward_normals_and_clearance() {
+    let material = rect(0.0, 0.0, 6.0, 2.0).union(&rect(0.0, 0.0, 2.0, 6.0));
+    let transform = Affine2::placement(Point::new(30.0, -12.0), 37.0, Mirror::X, 2.0);
+    let moved = transform_region(&material, transform).unwrap();
+    let query = BoundaryQuery::new(&moved, TOL).unwrap();
+    let id = query.boundaries().next().unwrap();
+    close(query.perimeter(id).unwrap(), 48.0, 1e-6);
+    for (a, b) in ring_edges(&moved.rings[id.ring]) {
+        let midpoint = a.midpoint(b);
+        let site = query.project(id, midpoint).unwrap().site;
+        assert!(!moved.contains_point(site.point + site.outward_normal * 0.01));
+        assert!(moved.contains_point(site.point - site.outward_normal * 0.01));
+    }
+    let attachment = transform_region(&rect(3.0, 3.0, 1.0, 1.0), transform).unwrap();
+    let checks = check_footprints(
+        &attachment,
+        &ContourSet::empty(0.0),
+        &[Obstacle {
+            id: "concave board",
+            region: &moved,
+        }],
+        1.5,
+        TOL,
+    )
+    .unwrap();
+    assert_eq!(checks[0].decision, Decision::Admissible);
+    close(checks[0].boundary_distance.unwrap().mm, 2.0, 1e-6);
+}
+
+#[test]
+fn complete_footprints_detect_crossings_containment_shoulders_and_holes() {
+    let attachment = rect(-3.0, -0.25, 6.0, 0.5);
+    let shoulder = rect(2.5, -1.0, 1.0, 2.0);
+    // Crossing is far from attachment center; no attachment vertex is inside.
+    let overhang = rect(1.0, -2.0, 0.5, 4.0);
+    let shoulder_obstacle = rect(3.2, 0.5, 0.2, 0.2);
+    let hole = rect(-2.0, -0.1, 0.1, 0.1);
+    let checks = check_footprints(
+        &attachment,
+        &shoulder,
+        &[
+            Obstacle {
+                id: "overhang",
+                region: &overhang,
+            },
+            Obstacle {
+                id: "shoulder only",
+                region: &shoulder_obstacle,
+            },
+            Obstacle {
+                id: "existing hole",
+                region: &hole,
+            },
+        ],
+        0.0,
+        TOL,
+    )
+    .unwrap();
+    assert_eq!(checks.len(), 6);
+    for index in [0, 3, 4] {
+        assert_eq!(
+            checks[index].decision,
+            Decision::Rejected(GeometricRejection::FootprintOverlap)
+        );
+        assert!(checks[index].overlap.area() > 0.0);
+    }
+    assert_eq!(checks[3].part, FootprintPart::RouterShoulder);
+    assert_eq!(checks[3].obstacle, "shoulder only");
+    let enclosing = rect(-10.0, -10.0, 20.0, 20.0);
+    assert_eq!(
+        check_footprints(
+            &attachment,
+            &shoulder,
+            &[Obstacle {
+                id: "enclosing",
+                region: &enclosing
+            }],
+            0.0,
+            TOL
+        )
+        .unwrap()[0]
+            .decision,
+        Decision::Rejected(GeometricRejection::FootprintOverlap)
+    );
+    let annulus = enclosing.difference(&rect(-5.0, -5.0, 10.0, 10.0));
+    assert_eq!(
+        check_footprints(
+            &attachment,
+            &shoulder,
+            &[Obstacle {
+                id: "free hole",
+                region: &annulus
+            }],
+            0.5,
+            TOL
+        )
+        .unwrap()[0]
+            .decision,
+        Decision::Admissible
+    );
+}
+
+#[test]
+fn tolerance_ambiguity_is_not_geometric_rejection() {
+    let attachment = rect(0.0, 0.0, 1.0, 1.0);
+    let obstacle = rect(1.1, 0.0, 1.0, 1.0);
+    let tolerance = QueryTolerance {
+        boundary_mm: 0.01,
+        ..TOL
+    };
+    let check = |clearance| {
+        check_footprints(
+            &attachment,
+            &ContourSet::empty(0.0),
+            &[Obstacle {
+                id: "near",
+                region: &obstacle,
+            }],
+            clearance,
+            tolerance,
+        )
+        .unwrap()[0]
+            .decision
+            .clone()
+    };
+    assert_eq!(check(0.07), Decision::Admissible);
+    assert!(matches!(check(0.1), Decision::Unresolved(_)));
+    assert!(matches!(
+        check(0.13),
+        Decision::Rejected(GeometricRejection::InsufficientClearance { .. })
+    ));
+    assert!(matches!(
+        check_footprints(
+            &attachment,
+            &attachment,
+            &[Obstacle {
+                id: "same",
+                region: &attachment
+            }],
+            0.0,
+            tolerance
+        )
+        .unwrap()[0]
+            .decision,
+        Decision::Unresolved(_)
+    ));
+}
+
+#[test]
+fn cutter_reachability_detects_closed_holes_and_radius_limited_necks() {
+    let workspace = rect(-5.0, -5.0, 10.0, 10.0);
+    let ring = rect(-3.0, -3.0, 6.0, 6.0).difference(&rect(-1.0, -1.0, 2.0, 2.0));
+    let reach = cutter_reachability(
+        &workspace,
+        &ring,
+        0.2,
+        &[Point::new(-4.0, 0.0)],
+        &[Point::new(4.0, 0.0), Point::ZERO],
+        TOL,
+    )
+    .unwrap();
+    assert_eq!(reach.targets[0], Decision::Admissible);
+    assert_eq!(
+        reach.targets[1],
+        Decision::Rejected(GeometricRejection::Unreachable { target: 1 })
+    );
+    let free = rect(0.0, 0.0, 3.0, 4.0)
+        .union(&rect(3.0, 1.7, 4.0, 0.6))
+        .union(&rect(7.0, 0.0, 3.0, 4.0));
+    let empty = ContourSet::empty(0.0);
+    for (radius, reachable) in [(0.2, true), (0.4, false)] {
+        let result = cutter_reachability(
+            &free,
+            &empty,
+            radius,
+            &[Point::new(1.0, 2.0)],
+            &[Point::new(9.0, 2.0)],
+            TOL,
+        )
+        .unwrap();
+        assert_eq!(result.targets[0] == Decision::Admissible, reachable);
+    }
+}
+
+#[test]
+fn supplied_break_sweep_separates_only_when_last_ligament_is_removed() {
+    let material = rect(0.0, 0.0, 10.0, 4.0).difference(&rect(4.5, 1.0, 1.0, 2.0));
+    let points = [
+        Point::new(1.0, 2.0),
+        Point::new(9.0, 2.0),
+        Point::new(5.0, 2.0),
+    ];
+    let before = material_after_break(&material, &ContourSet::empty(0.0), &points, TOL).unwrap();
+    assert_eq!(before.connected(0, 1).unwrap(), Some(true));
+    assert_eq!(before.connected(0, 2).unwrap(), None);
+    let partial =
+        material_after_break(&material, &rect(4.8, -1.0, 0.4, 4.9999), &points, TOL).unwrap();
+    assert_eq!(partial.connected(0, 1).unwrap(), Some(true));
+    let path = ContourBuf::new(vec![
+        PathCmd::move_to(Point::new(5.0, -1.0)),
+        PathCmd::line_to(Point::new(5.0, 5.0)),
+    ]);
+    let sweep = crate::geom::path::stroke_to_fill(
+        &[path],
+        StrokeToFillStyle::new(0.4, LineCap::Round, LineJoin::Round),
+    )
+    .unwrap();
+    let removal = ContourSet::from_contours(&sweep, FillRule::NonZero, 0.0);
+    let after = material_after_break(&material, &removal, &points, TOL).unwrap();
+    assert_eq!(after.components.len(), 2);
+    assert_eq!(after.connected(0, 1).unwrap(), Some(false));
+    assert_eq!(after.connected(0, 2).unwrap(), None);
+    let transform = Affine2::placement(Point::new(-8.0, 7.0), 22.0, Mirror::Y, 1.0);
+    let transformed = material_after_break(
+        &transform_region(&material, transform).unwrap(),
+        &transform_region(&removal, transform).unwrap(),
+        &points.map(|p| transform.transform_point(p)),
+        TOL,
+    )
+    .unwrap();
+    assert_eq!(transformed.connected(0, 1).unwrap(), Some(false));
+}
+
+#[test]
+fn boundary_witnesses_are_unresolved_not_access_or_separation() {
+    let region = rect(0.0, 0.0, 4.0, 4.0);
+    let empty = ContourSet::empty(0.0);
+    let points = [
+        Point::new(2.0, 2.0),
+        Point::new(-1.0, 2.0),
+        Point::new(0.0, 2.0),
+    ];
+    let topology = material_after_break(&region, &empty, &points, TOL).unwrap();
+    assert!(matches!(
+        topology.witnesses[0],
+        RegionMembership::Component(_)
+    ));
+    assert_eq!(topology.witnesses[1], RegionMembership::Outside);
+    assert_eq!(topology.witnesses[2], RegionMembership::BoundaryBand);
+    assert_eq!(topology.connected(0, 1).unwrap(), None);
+    assert_eq!(topology.connected(0, 2).unwrap(), None);
+    let tolerance = QueryTolerance {
+        boundary_mm: 0.001,
+        ..TOL
+    };
+    let reach = cutter_reachability(
+        &region,
+        &empty,
+        0.5,
+        &[Point::new(0.5, 2.0)],
+        &points,
+        tolerance,
+    )
+    .unwrap();
+    assert_eq!(reach.entries, vec![RegionMembership::BoundaryBand]);
+    assert!(matches!(reach.targets[0], Decision::Unresolved(_)));
+    assert_eq!(
+        reach.targets[1],
+        Decision::Rejected(GeometricRejection::OutsideCutterSpace { point: 1 })
+    );
+    let multiple_entries = cutter_reachability(
+        &region,
+        &empty,
+        0.5,
+        &[Point::new(0.5, 2.0), points[0]],
+        &points[..1],
+        tolerance,
+    )
+    .unwrap();
+    assert_eq!(multiple_entries.targets[0], Decision::Admissible);
+}
+
+#[test]
+fn invalid_queries_are_errors_not_geometric_rejections() {
+    let region = rect(0.0, 0.0, 1.0, 1.0);
+    assert!(
+        BoundaryQuery::new(
+            &region,
+            QueryTolerance {
+                boundary_mm: f64::NAN,
+                ..TOL
+            }
+        )
+        .is_err()
+    );
+    let query = BoundaryQuery::new(&region, TOL).unwrap();
+    let id = query.boundaries().next().unwrap();
+    assert!(query.site(id, f64::INFINITY).is_err());
+    assert!(query.project(id, Point::new(f64::NAN, 0.0)).is_err());
+    assert!(
+        query
+            .site(
+                BoundaryId {
+                    component: 99,
+                    ..id
+                },
+                0.0
+            )
+            .is_err()
+    );
+    assert!(cutter_reachability(&region, &region, -1.0, &[Point::ZERO], &[], TOL).is_err());
+    assert!(
+        transform_region(
+            &region,
+            Affine2 {
+                m00: 0.0,
+                ..Affine2::IDENTITY
+            }
+        )
+        .is_err()
+    );
+}

--- a/crates/pcb-ir/src/geom/mod.rs
+++ b/crates/pcb-ir/src/geom/mod.rs
@@ -6,6 +6,7 @@
 pub(crate) mod accuracy;
 mod affine;
 mod arc;
+pub mod attachment;
 mod bbox;
 pub mod bridge;
 pub mod copper_balance;

--- a/crates/pcb-ir/src/geom/region/gaps.rs
+++ b/crates/pcb-ir/src/geom/region/gaps.rs
@@ -115,7 +115,7 @@ impl ContourSet {
     /// each component. Regularized rings nest without crossing and holes
     /// are wound opposite their outer ring, so a hole belongs to the
     /// smallest outer ring around it.
-    fn ring_components(&self) -> (Vec<usize>, Vec<usize>) {
+    pub(crate) fn ring_components(&self) -> (Vec<usize>, Vec<usize>) {
         let areas = self.rings.iter().map(ring_signed_area).collect::<Vec<_>>();
         let mut outers = (0..self.rings.len())
             .filter(|&ring| areas[ring] > 0.0)


### PR DESCRIPTION
Add boundary, complete-footprint clearance, cutter access, and break-removal connectivity queries to pcb-ir. Preserve geometry accuracy budgets and report uncertain results separately from geometric rejection so callers can use the polygon model without assuming exact physical behavior.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1240" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->