### PR TITLE
ENG-1432: Add experimental single-tab mouse-bite geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Preserve curves that continue after a closed subpath during polygon preparation.
+- Require experimental tab anchors and witnesses to be resolved interior points of the original regions.
 - Reject experimental tab perforations that overlap support or lack resolved clearance from it.
 - Preserve exact arc endpoints during curve preparation to avoid numerical zero-length edges in release builds.
 - Report malformed SPICE `PARAMS:` tokens instead of crashing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Preserve exact arc endpoints during curve preparation to avoid numerical zero-length edges in release builds.
 - Report malformed SPICE `PARAMS:` tokens instead of crashing.
 - Migrate root-level `.zen` files in container workspaces.
 - Exit non-zero from `pcb rectify fix` and `pcb rectify audit` when batch evaluation fails.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Add reusable polygon-boundary, attachment clearance, cutter reachability, and break-removal connectivity queries to `pcb-ir`, with explicit uncertainty and model limitations.
 - Add deterministic elastic support selection with explicit compliance limits, conflict constraints, exhaustive proof status, work budgets, and independent full-system response checks.
 - Add standalone elastic support analysis with beam and triangular plate elements, explicit stiffness and constraints, and singular-mode diagnostics.
+- Add experimental single mouse-bite tab geometry and reproducible straight/curved break coupons to `pcb-ir`; physical fracture validation remains outstanding.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Reject experimental tab perforations that overlap support or lack resolved clearance from it.
 - Preserve exact arc endpoints during curve preparation to avoid numerical zero-length edges in release builds.
 - Report malformed SPICE `PARAMS:` tokens instead of crashing.
 - Migrate root-level `.zen` files in container workspaces.

--- a/crates/pcb-ir/examples/mouse_bite_coupon.rs
+++ b/crates/pcb-ir/examples/mouse_bite_coupon.rs
@@ -2,12 +2,15 @@
 //! Run: cargo run -p pcb-ir --example mouse_bite_coupon -- /tmp/coupons
 use pcb_ir::geom::attachment::{BoundaryQuery, QueryTolerance, transform_region};
 use pcb_ir::geom::mouse_bite::{Attachment, build};
-use pcb_ir::geom::{Affine2, BBox, ContourSet, Point, shapes};
+use pcb_ir::geom::{Affine2, BBox, ContourSet, Point, Resolution, shapes};
 use pcb_ir::render::svg_path_data;
 use std::fmt::Write;
 
 fn rect(x: f64, y: f64, w: f64, h: f64) -> ContourSet {
-    ContourSet::rectangle(BBox::new(Point::new(x, y), Point::new(x + w, y + h)), 0.0)
+    ContourSet::rectangle(
+        BBox::new(Point::new(x, y), Point::new(x + w, y + h)),
+        Resolution::default().strict(),
+    )
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -25,7 +28,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let name = if curved { "curved" } else { "straight" };
         let board = if curved {
             transform_region(
-                &ContourSet::from_filled_contours(&[shapes::circle(20.0).unwrap()], 0.0),
+                &ContourSet::from_filled_contours(
+                    &[shapes::circle(20.0).unwrap()],
+                    Resolution::default().strict(),
+                )?,
                 Affine2::translation(Point::new(0.0, -10.0)),
             )?
         } else {

--- a/crates/pcb-ir/examples/mouse_bite_coupon.rs
+++ b/crates/pcb-ir/examples/mouse_bite_coupon.rs
@@ -1,0 +1,105 @@
+//! Reproducible geometry coupons, not fabrication-ready manufacturing documents.
+//! Run: cargo run -p pcb-ir --example mouse_bite_coupon -- /tmp/coupons
+use pcb_ir::geom::attachment::{BoundaryQuery, QueryTolerance, transform_region};
+use pcb_ir::geom::mouse_bite::{Attachment, build};
+use pcb_ir::geom::{Affine2, BBox, ContourSet, Point, shapes};
+use pcb_ir::render::svg_path_data;
+use std::fmt::Write;
+
+fn rect(x: f64, y: f64, w: f64, h: f64) -> ContourSet {
+    ContourSet::rectangle(BBox::new(Point::new(x, y), Point::new(x + w, y + h)), 0.0)
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let out = std::path::PathBuf::from(
+        std::env::args_os()
+            .nth(1)
+            .ok_or("supply output directory")?,
+    );
+    std::fs::create_dir_all(&out)?;
+    let tolerance = QueryTolerance {
+        boundary_mm: 0.015,
+        numerical_mm: 1e-6,
+    };
+    for curved in [false, true] {
+        let name = if curved { "curved" } else { "straight" };
+        let board = if curved {
+            transform_region(
+                &ContourSet::from_filled_contours(&[shapes::circle(20.0).unwrap()], 0.0),
+                Affine2::translation(Point::new(0.0, -10.0)),
+            )?
+        } else {
+            rect(-10.0, -20.0, 20.0, 20.0)
+        };
+        let support = rect(-10.0, 3.0, 20.0, 10.0);
+        let stock = rect(-10.0, -20.0, 20.0, 33.0);
+        let query = BoundaryQuery::new(&board, tolerance)?;
+        let boundary = query.boundaries().next().unwrap();
+        let station_mm = query.project(boundary, Point::ZERO)?.site.station_mm;
+        let tab = build(Attachment {
+            stock: &stock,
+            board: &board,
+            support: &support,
+            boundary,
+            station_mm,
+            support_anchor: Point::new(0.0, 5.0),
+            board_witness: Point::new(0.0, -5.0),
+            tolerance,
+        })?;
+        let after = tab.after_break(
+            0.01,
+            &[Point::new(0.0, -5.0), Point::new(0.0, 5.0)],
+            tolerance,
+        )?;
+        let mut drills = String::from("x_mm,y_mm,diameter_mm,plating\n");
+        for hole in &tab.npth {
+            writeln!(
+                drills,
+                "{:.9},{:.9},{:.9},NPTH",
+                hole.center.x, hole.center.y, hole.diameter_mm
+            )?;
+        }
+        std::fs::write(out.join(format!("{name}-npth.csv")), drills)?;
+        for (suffix, viewbox) in [("coupon", "-11 -14 22 35"), ("detail", "-3 -4 6 5")] {
+            let mut svg = format!(
+                "<svg xmlns='http://www.w3.org/2000/svg' width='880' height='700' viewBox='{viewbox}'><rect x='-50' y='-50' width='100' height='100' fill='white'/><g transform='scale(1,-1)'>"
+            );
+            for (id, region, color) in [
+                ("routed-removal", &tab.routed_removal, "#e5e7eb"),
+                ("retained-substrate", &tab.retained_substrate, "#b5d9bd"),
+                ("rounded-shoulders", &tab.shoulders, "#6eaf86"),
+                ("npth", &tab.perforations, "#ffffff"),
+            ] {
+                writeln!(
+                    svg,
+                    "<path id='{id}' d='{}' fill='{color}' fill-rule='nonzero'/>",
+                    svg_path_data(&region.to_contours())
+                )?;
+            }
+            writeln!(
+                svg,
+                "<path d='{}' fill='none' stroke='#111827' stroke-width='.012' stroke-dasharray='.08 .04'/>",
+                svg_path_data(&board.to_contours())
+            )?;
+            writeln!(
+                svg,
+                "<path id='break-row' d='{}' fill='none' stroke='#dc2626' stroke-width='.018'/>",
+                svg_path_data(std::slice::from_ref(&tab.break_path))
+            )?;
+            svg.push_str("</g></svg>");
+            std::fs::write(out.join(format!("{name}-{suffix}.svg")), svg)?;
+        }
+        // Separate, machine-readable polygon paths for downstream adapters.
+        for (part, region) in [
+            ("routed", &tab.routed_removal),
+            ("retained", &tab.retained_substrate),
+            ("after-virtual-break", &after.retained),
+        ] {
+            std::fs::write(
+                out.join(format!("{name}-{part}.path")),
+                svg_path_data(&region.to_contours()),
+            )?;
+        }
+    }
+    Ok(())
+}

--- a/crates/pcb-ir/src/geom/mod.rs
+++ b/crates/pcb-ir/src/geom/mod.rs
@@ -14,6 +14,7 @@ pub mod dfm;
 pub mod dist;
 mod grid;
 pub mod mesh;
+pub mod mouse_bite;
 pub mod path;
 pub mod pattern;
 mod point;

--- a/crates/pcb-ir/src/geom/mouse_bite.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite.rs
@@ -169,8 +169,21 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
             .union(input.support)?
             .difference(input.stock)?
             .is_empty()
-        || !input.support.contains_point(input.support_anchor)
-        || !input.board.contains_point(input.board_witness)
+        || ![
+            (input.support, input.support_anchor),
+            (input.board, input.board_witness),
+        ]
+        .into_iter()
+        .all(|(region, point)| {
+            point.is_finite()
+                && region
+                    .prepare_query()
+                    .signed_distance(point)
+                    .is_some_and(|d| {
+                        d.mm < -input.tolerance.boundary_mm.max(d.uncertainty_mm)
+                            - input.tolerance.numerical_mm
+                    })
+        })
     {
         return Err(QueryError::InvalidInput(
             "expected disjoint connected board/support inside stock with interior witnesses",

--- a/crates/pcb-ir/src/geom/mouse_bite.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite.rs
@@ -5,8 +5,8 @@
 //! source-curve topology, manufacturing yield, or physical release is certified.
 
 use super::attachment::{
-    BoundaryId, BoundaryQuery, PolygonTopology, QueryError, QueryTolerance, material_after_break,
-    transform_region,
+    BoundaryId, BoundaryQuery, Decision, Obstacle, PolygonTopology, QueryError, QueryTolerance,
+    check_footprints, material_after_break, transform_region,
 };
 use super::{
     Affine2, ContourBuf, ContourSet, LineCap, LineJoin, PathCmd, Point, Resolution,
@@ -260,6 +260,25 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
     for &center in &centers {
         perforations =
             perforations.union(&transform_region(&circle, Affine2::translation(center))?)?;
+    }
+    // Only the board interface is perforated. Require the complete drill mask
+    // to clear support, including both stored and caller-supplied uncertainty.
+    if check_footprints(
+        &perforations,
+        &ContourSet::empty(resolution),
+        &[Obstacle {
+            id: "support",
+            region: input.support,
+        }],
+        0.0,
+        input.tolerance,
+    )?
+    .iter()
+    .any(|check| check.decision != Decision::Admissible)
+    {
+        return Err(QueryError::InvalidInput(
+            "perforations overlap support or clearance is unresolved",
+        ));
     }
     let result = TabGeometry {
         retained_substrate: undrilled.difference(&perforations)?,

--- a/crates/pcb-ir/src/geom/mouse_bite.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite.rs
@@ -9,7 +9,8 @@ use super::attachment::{
     transform_region,
 };
 use super::{
-    Affine2, ContourBuf, ContourSet, LineCap, LineJoin, PathCmd, Point, StrokeToFillStyle,
+    Affine2, ContourBuf, ContourSet, LineCap, LineJoin, PathCmd, Point, Resolution,
+    StrokeToFillStyle,
 };
 
 /// Opinionated, experimental shallow-intrusion adaptation of SparkFun's pattern.
@@ -86,20 +87,25 @@ impl TabGeometry {
         }
         material_after_break(
             &self.retained_substrate,
-            &stroke(&self.break_path, probe_width_mm),
+            &stroke(
+                &self.break_path,
+                probe_width_mm,
+                self.retained_substrate.resolution.strict(),
+            )?,
             witnesses,
             tolerance,
         )
     }
 }
 
-fn stroke(path: &ContourBuf, width: f64) -> ContourSet {
+fn stroke(path: &ContourBuf, width: f64, resolution: Resolution) -> Result<ContourSet, QueryError> {
     let contours = super::path::stroke_to_fill(
         std::slice::from_ref(path),
         StrokeToFillStyle::new(width, LineCap::Round, LineJoin::Round),
-    )
-    .expect("positive finite stroke width");
-    ContourSet::from_filled_contours(&contours, 0.0)
+        resolution.accuracy,
+    )?
+    .ok_or(QueryError::InvalidInput("expected positive stroke width"))?;
+    Ok(ContourSet::from_filled_contours(&contours, resolution)?)
 }
 
 /// Extract an exact portion of the supplied polygon boundary, including its
@@ -141,7 +147,10 @@ fn row(
         .into_iter()
         .map(|s| query.site(boundary, start + s).map(|site| site.point))
         .collect::<Result<Vec<_>, _>>()?;
-    Ok((ContourBuf::new(cmds), centers))
+    Ok((
+        ContourBuf::new(cmds).with_uncertainty(region.uncertainty_mm),
+        centers,
+    ))
 }
 
 /// Build one tab. Unsupported geometry is an error, never a fallback pattern.
@@ -154,11 +163,11 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
     let site = query.site(input.boundary, input.station_mm)?;
     if input.board.connected_components().len() != 1
         || input.support.connected_components().len() != 1
-        || !input.board.intersection(input.support).is_empty()
+        || !input.board.intersection(input.support)?.is_empty()
         || !input
             .board
-            .union(input.support)
-            .difference(input.stock)
+            .union(input.support)?
+            .difference(input.stock)?
             .is_empty()
         || !input.support.contains_point(input.support_anchor)
         || !input.board.contains_point(input.board_witness)
@@ -168,30 +177,41 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
         ));
     }
     let radius = SparkFunShallow::CUTTER_RADIUS_MM;
+    let resolution = input.stock.resolution.strict().with_accuracy(
+        input
+            .stock
+            .budget()
+            .min(input.board.budget())
+            .min(input.support.budget()),
+    );
     let neck = stroke(
         &ContourBuf::new(vec![
             PathCmd::move_to(site.point - site.outward_normal * radius),
             PathCmd::line_to(input.support_anchor),
-        ]),
+        ])
+        .with_uncertainty(input.board.uncertainty_mm),
         SparkFunShallow::NECK_WIDTH_MM,
-    );
-    let protected = input.board.union(input.support).union(&neck);
+        resolution,
+    )?;
+    let protected = input.board.union(input.support)?.union(&neck)?;
     // Open the void with the actual cutter disk: its circular sweeps leave
     // rounded concave shoulders instead of demanding a square inside corner.
     // Extend beyond stock so stock-edge corners do not create retained islands.
     let routed_removal = input
         .stock
-        .disk_dilate(2.0 * radius)
-        .difference(&protected)
-        .disk_open(radius)
-        .intersection(input.stock);
-    let undrilled = input.stock.difference(&routed_removal);
-    let shoulders = undrilled.difference(&protected);
-    let attachment_footprint = undrilled.difference(&input.board.union(input.support));
+        .disk_dilate(2.0 * radius)?
+        .difference(&protected)?
+        .disk_open(radius)?
+        .intersection(input.stock)?;
+    let undrilled = input.stock.difference(&routed_removal)?;
+    let shoulders = undrilled.difference(&protected)?;
+    let attachment_footprint = undrilled.difference(&input.board.union(input.support)?)?;
 
     // Offset the whole region first, rather than guessing normals on a curved
     // row or assigning straight-line pitch to the source curve's arc length.
-    let offset = input.board.disk_dilate(SparkFunShallow::OUTWARD_OFFSET_MM);
+    let offset = input
+        .board
+        .disk_dilate(SparkFunShallow::OUTWARD_OFFSET_MM)?;
     let offset_query = BoundaryQuery::new(&offset, input.tolerance)?;
     let target = site.point + site.outward_normal * SparkFunShallow::OUTWARD_OFFSET_MM;
     let projection = offset_query
@@ -217,13 +237,19 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
                 .map(move |b| a.distance_to(*b) - diameter)
         })
         .fold(f64::INFINITY, f64::min);
-    if minimum_ligament_mm <= 2.0 * input.tolerance.boundary_mm + input.tolerance.numerical_mm {
+    let boundary_band = input.tolerance.boundary_mm.max(offset.uncertainty_mm);
+    if minimum_ligament_mm <= 2.0 * boundary_band + input.tolerance.numerical_mm {
         return Err(QueryError::InvalidInput(
             "drill ligaments unresolved or overlapping",
         ));
     }
-    let circle = ContourSet::from_filled_contours(&[super::shapes::circle(diameter).unwrap()], 0.0);
-    let mut perforations = ContourSet::empty(0.0);
+    let circle = ContourSet::from_filled_contours(
+        &[super::shapes::circle(diameter)
+            .unwrap()
+            .with_uncertainty(offset.uncertainty_mm)],
+        resolution,
+    )?;
+    let mut perforations = ContourSet::empty(resolution);
     let npth = centers
         .iter()
         .map(|&center| Npth {
@@ -233,10 +259,10 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
         .collect();
     for &center in &centers {
         perforations =
-            perforations.union(&transform_region(&circle, Affine2::translation(center))?);
+            perforations.union(&transform_region(&circle, Affine2::translation(center))?)?;
     }
     let result = TabGeometry {
-        retained_substrate: undrilled.difference(&perforations),
+        retained_substrate: undrilled.difference(&perforations)?,
         routed_removal,
         npth,
         perforations,
@@ -250,7 +276,7 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
     witnesses.extend(centers.windows(2).map(|p| (p[0] + p[1]) / 2.0));
     let before = material_after_break(
         &result.retained_substrate,
-        &ContourSet::empty(0.0),
+        &ContourSet::empty(resolution),
         &witnesses,
         input.tolerance,
     )?;

--- a/crates/pcb-ir/src/geom/mouse_bite.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite.rs
@@ -1,0 +1,276 @@
+//! One experimental mouse-bite attachment, not a panelizer or fracture model.
+//!
+//! See `mouse_bite/README.md` for dimensional provenance and coupon protocol.
+//! All results inherit `attachment`'s bounded polygon-model guarantees. No
+//! source-curve topology, manufacturing yield, or physical release is certified.
+
+use super::attachment::{
+    BoundaryId, BoundaryQuery, PolygonTopology, QueryError, QueryTolerance, material_after_break,
+    transform_region,
+};
+use super::{
+    Affine2, ContourBuf, ContourSet, LineCap, LineJoin, PathCmd, Point, StrokeToFillStyle,
+};
+
+/// Opinionated, experimental shallow-intrusion adaptation of SparkFun's pattern.
+/// Constants are millimeters. There are deliberately no strength-tuning knobs.
+pub struct SparkFunShallow;
+
+impl SparkFunShallow {
+    pub const HOLE_DIAMETER_MM: f64 = 0.015 * 25.4;
+    pub const PITCH_MM: f64 = 0.025 * 25.4;
+    pub const NOMINAL_LIGAMENT_MM: f64 = Self::PITCH_MM - Self::HOLE_DIAMETER_MM;
+    /// Our experimental adaptation, NOT a tested SparkFun recommendation.
+    pub const OUTWARD_OFFSET_MM: f64 = 0.005 * 25.4;
+    pub const NOMINAL_INTRUSION_MM: f64 = Self::HOLE_DIAMETER_MM / 2.0 - Self::OUTWARD_OFFSET_MM;
+    pub const HOLE_COUNT: usize = 5;
+    pub const NECK_WIDTH_MM: f64 = 2.0;
+    pub const CUTTER_RADIUS_MM: f64 = 0.5;
+}
+
+/// Fully specified single attachment. `stock` is the material before routing;
+/// `board` and `support` are disjoint connected subsets of it. The straight neck
+/// joins the supplied boundary station to `support_anchor`, which must lie in
+/// support. It is not a placement search. Witnesses must be interior material.
+pub struct Attachment<'a> {
+    pub stock: &'a ContourSet,
+    pub board: &'a ContourSet,
+    pub support: &'a ContourSet,
+    pub boundary: BoundaryId,
+    pub station_mm: f64,
+    pub support_anchor: Point,
+    pub board_witness: Point,
+    pub tolerance: QueryTolerance,
+}
+
+/// Analytic circular unplated drill, independent of its flattened boolean mask.
+#[derive(Debug, Clone, Copy)]
+pub struct Npth {
+    pub center: Point,
+    pub diameter_mm: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct TabGeometry {
+    /// Final material after BOTH routing and drilling, including board/support.
+    pub retained_substrate: ContourSet,
+    /// Router removal alone; do not union drill masks into routed profiles.
+    pub routed_removal: ContourSet,
+    pub npth: Vec<Npth>,
+    /// Full circular masks, including portions overlapping routed void.
+    pub perforations: ContourSet,
+    /// Open polygon path following the offset boundary, through every drill.
+    /// This is a proposed fracture locus, NOT a predicted crack trajectory.
+    pub break_path: ContourBuf,
+    /// Complete unperforated footprint for downstream obstacle clearance checks.
+    pub attachment_footprint: ContourSet,
+    /// Rounded material added by disk-opening the ideal routing void.
+    pub shoulders: ContourSet,
+    /// Minimum all-pairs chord clearance, not arc pitch minus diameter on curves.
+    pub minimum_ligament_mm: f64,
+}
+
+impl TabGeometry {
+    /// Virtual removal along the entire supplied row. Width is an explicit
+    /// geometric test probe, not a fracture-process parameter or router kerf.
+    pub fn after_break(
+        &self,
+        probe_width_mm: f64,
+        witnesses: &[Point],
+        tolerance: QueryTolerance,
+    ) -> Result<PolygonTopology, QueryError> {
+        if !probe_width_mm.is_finite() || probe_width_mm <= 0.0 {
+            return Err(QueryError::InvalidInput(
+                "expected positive break probe width",
+            ));
+        }
+        material_after_break(
+            &self.retained_substrate,
+            &stroke(&self.break_path, probe_width_mm),
+            witnesses,
+            tolerance,
+        )
+    }
+}
+
+fn stroke(path: &ContourBuf, width: f64) -> ContourSet {
+    let contours = super::path::stroke_to_fill(
+        std::slice::from_ref(path),
+        StrokeToFillStyle::new(width, LineCap::Round, LineJoin::Round),
+    )
+    .expect("positive finite stroke width");
+    ContourSet::from_filled_contours(&contours, 0.0)
+}
+
+/// Extract an exact portion of the supplied polygon boundary, including its
+/// vertices and requested drill stations, even when it crosses the cyclic seam.
+fn row(
+    region: &ContourSet,
+    query: &BoundaryQuery<'_>,
+    boundary: BoundaryId,
+    center: f64,
+) -> Result<(ContourBuf, Vec<Point>), QueryError> {
+    let half = 2.0 * SparkFunShallow::PITCH_MM + SparkFunShallow::CUTTER_RADIUS_MM;
+    let perimeter = query.perimeter(boundary)?;
+    if perimeter <= 2.0 * half {
+        return Err(QueryError::InvalidInput("attachment boundary too short"));
+    }
+    let start = center - half;
+    let mut stations = vec![0.0, 2.0 * half];
+    let mut cumulative = 0.0;
+    for (a, b) in super::region::ring_edges(&region.rings[boundary.ring]) {
+        let s = (cumulative - start).rem_euclid(perimeter);
+        if s > 0.0 && s < 2.0 * half {
+            stations.push(s);
+        }
+        cumulative += a.distance_to(b);
+    }
+    let drill_stations = (0..SparkFunShallow::HOLE_COUNT)
+        .map(|i| half + (i as f64 - 2.0) * SparkFunShallow::PITCH_MM)
+        .collect::<Vec<_>>();
+    stations.extend(&drill_stations);
+    stations.sort_by(f64::total_cmp);
+    stations.dedup();
+    let points = stations
+        .into_iter()
+        .map(|s| query.site(boundary, start + s).map(|site| site.point))
+        .collect::<Result<Vec<_>, _>>()?;
+    let mut cmds = vec![PathCmd::move_to(points[0])];
+    cmds.extend(points[1..].iter().copied().map(PathCmd::line_to));
+    let centers = drill_stations
+        .into_iter()
+        .map(|s| query.site(boundary, start + s).map(|site| site.point))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok((ContourBuf::new(cmds), centers))
+}
+
+/// Build one tab. Unsupported geometry is an error, never a fallback pattern.
+/// The caller remains responsible for complete obstacle/cutter access checks
+/// in its actual panel workspace, not just this local construction.
+pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
+    let query = BoundaryQuery::new(input.board, input.tolerance)?;
+    BoundaryQuery::new(input.stock, input.tolerance)?;
+    BoundaryQuery::new(input.support, input.tolerance)?;
+    let site = query.site(input.boundary, input.station_mm)?;
+    if input.board.connected_components().len() != 1
+        || input.support.connected_components().len() != 1
+        || !input.board.intersection(input.support).is_empty()
+        || !input
+            .board
+            .union(input.support)
+            .difference(input.stock)
+            .is_empty()
+        || !input.support.contains_point(input.support_anchor)
+        || !input.board.contains_point(input.board_witness)
+    {
+        return Err(QueryError::InvalidInput(
+            "expected disjoint connected board/support inside stock with interior witnesses",
+        ));
+    }
+    let radius = SparkFunShallow::CUTTER_RADIUS_MM;
+    let neck = stroke(
+        &ContourBuf::new(vec![
+            PathCmd::move_to(site.point - site.outward_normal * radius),
+            PathCmd::line_to(input.support_anchor),
+        ]),
+        SparkFunShallow::NECK_WIDTH_MM,
+    );
+    let protected = input.board.union(input.support).union(&neck);
+    // Open the void with the actual cutter disk: its circular sweeps leave
+    // rounded concave shoulders instead of demanding a square inside corner.
+    // Extend beyond stock so stock-edge corners do not create retained islands.
+    let routed_removal = input
+        .stock
+        .disk_dilate(2.0 * radius)
+        .difference(&protected)
+        .disk_open(radius)
+        .intersection(input.stock);
+    let undrilled = input.stock.difference(&routed_removal);
+    let shoulders = undrilled.difference(&protected);
+    let attachment_footprint = undrilled.difference(&input.board.union(input.support));
+
+    // Offset the whole region first, rather than guessing normals on a curved
+    // row or assigning straight-line pitch to the source curve's arc length.
+    let offset = input.board.disk_dilate(SparkFunShallow::OUTWARD_OFFSET_MM);
+    let offset_query = BoundaryQuery::new(&offset, input.tolerance)?;
+    let target = site.point + site.outward_normal * SparkFunShallow::OUTWARD_OFFSET_MM;
+    let projection = offset_query
+        .boundaries()
+        .map(|id| offset_query.project(id, target))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .min_by(|a, b| a.distance.mm.total_cmp(&b.distance.mm))
+        .ok_or(QueryError::InvalidInput("empty offset boundary"))?;
+    let (break_path, centers) = row(
+        &offset,
+        &offset_query,
+        projection.site.boundary,
+        projection.site.station_mm,
+    )?;
+    let diameter = SparkFunShallow::HOLE_DIAMETER_MM;
+    let minimum_ligament_mm = centers
+        .iter()
+        .enumerate()
+        .flat_map(|(i, a)| {
+            centers[i + 1..]
+                .iter()
+                .map(move |b| a.distance_to(*b) - diameter)
+        })
+        .fold(f64::INFINITY, f64::min);
+    if minimum_ligament_mm <= 2.0 * input.tolerance.boundary_mm + input.tolerance.numerical_mm {
+        return Err(QueryError::InvalidInput(
+            "drill ligaments unresolved or overlapping",
+        ));
+    }
+    let circle = ContourSet::from_filled_contours(&[super::shapes::circle(diameter).unwrap()], 0.0);
+    let mut perforations = ContourSet::empty(0.0);
+    let npth = centers
+        .iter()
+        .map(|&center| Npth {
+            center,
+            diameter_mm: diameter,
+        })
+        .collect();
+    for &center in &centers {
+        perforations =
+            perforations.union(&transform_region(&circle, Affine2::translation(center))?);
+    }
+    let result = TabGeometry {
+        retained_substrate: undrilled.difference(&perforations),
+        routed_removal,
+        npth,
+        perforations,
+        break_path,
+        attachment_footprint,
+        shoulders,
+        minimum_ligament_mm,
+    };
+    // Check every inter-hole ligament as material, not merely positive spacing.
+    let mut witnesses = vec![input.board_witness, input.support_anchor];
+    witnesses.extend(centers.windows(2).map(|p| (p[0] + p[1]) / 2.0));
+    let before = material_after_break(
+        &result.retained_substrate,
+        &ContourSet::empty(0.0),
+        &witnesses,
+        input.tolerance,
+    )?;
+    if before.components.len() != 1
+        || (1..witnesses.len()).any(|i| before.connected(0, i) != Ok(Some(true)))
+    {
+        return Err(QueryError::InvalidInput(
+            "attachment does not retain connected ligaments",
+        ));
+    }
+    // Reject wraparound/oblique necks that bypass the finite row. This 2µm
+    // virtual removal is only a polygon topology probe, not a fracture kerf.
+    let after = result.after_break(0.002, &witnesses[..2], input.tolerance)?;
+    if after.components.len() != 2 || after.connected(0, 1)? != Some(false) {
+        return Err(QueryError::InvalidInput(
+            "break row does not completely separate board and support in the polygon model",
+        ));
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/pcb-ir/src/geom/mouse_bite/README.md
+++ b/crates/pcb-ir/src/geom/mouse_bite/README.md
@@ -65,11 +65,14 @@ not manufacturing-qualified. The builder's checks do not replace full-panel
 Disk opening establishes a local swept-disk shape, not a globally reachable
 toolpath. Check actual fixture and tool Z access separately.
 
-Canonical curve flattening is 0.005 mm; offsets and stroke expansion have their
-own approximation error. Caller `QueryTolerance` must budget source, transform,
-offset and numeric uncertainty; it is not a certified bound. The coupon example
-uses 0.015 mm boundary and 0.000001 mm numerical budgets. Model tests also use a
-zero source budget to test polygon topology only. Repeated overlay on curved
+Canonical preparation, offsets and stroke expansion inherit each input region's
+`Resolution` and fallible `GeometryAccuracy` budget. Generated geometry uses the
+tightest input budget without widening it; contours retain their accumulated
+uncertainty. Budget failures propagate through `QueryError::Accuracy`. The coupon
+example uses the default 0.01 mm approximation budget with zero significance,
+plus query allowances of 0.015 mm boundary and 0.000001 mm numerical uncertainty.
+Stored geometry uncertainty is a floor even when a query supplies zero additional
+boundary allowance; neither allowance certifies source-curve topology. Repeated overlay on curved
 polygons can leave sub-micron slivers: tests bound both overlap area (<0.000001
 mm²) and penetration (<0.000001 mm), rather than claiming exact predicates.
 No topology guarantee extends to the pre-flattened source curves.

--- a/crates/pcb-ir/src/geom/mouse_bite/README.md
+++ b/crates/pcb-ir/src/geom/mouse_bite/README.md
@@ -1,0 +1,124 @@
+# Experimental single-tab geometry
+
+`geom::mouse_bite::build(Attachment)` is pure, in millimeters, and uses the
+existing `ContourSet`, stroke, transform, and `attachment` query APIs. It accepts
+explicit stock, board, support, boundary station, support anchor and board
+witness. It does **not** choose support locations/counts, loads, clamps, laminate,
+thickness, or panel dimensions. No CLI panelization or manufacturing export is
+enabled. A tab has one perforated board interface; its other end stays on support.
+
+## Preset and evidence
+
+Authoritative source: Nick Poole, SparkFun, *Building a Better Mouse Bite*, March
+2022, [white paper](https://cdn.sparkfun.com/assets/home_page_posts/4/4/0/0/Mousebites_Whitepaper_Final.pdf),
+especially pages 5–9 and 11; [author's experiment description](https://news.sparkfun.com/4400).
+The paper's recommendations, **not** its introductory industry survey, are:
+
+| Dimension | `SparkFunShallow` | Provenance |
+|---|---:|---|
+| NPTH diameter | 0.381 mm (0.015 in) | Paper p9 |
+| Center pitch | 0.635 mm (0.025 in) | Paper p9; applied to offset polygon arc length |
+| Nominal straight ligament | 0.254 mm | Pitch − diameter; curved chord ligaments are measured separately |
+| Outward center offset | 0.127 mm (0.005 in) | **Experimental project adaptation**, not a SparkFun measurement |
+| Nominal straight board intrusion | 0.0635 mm | Radius − outward offset, not a damage-zone prediction |
+| Hole count / straight neck width | 5 / 2.0 mm | Project construction choice; 2.54 mm center span overlaps shoulders |
+| Router radius | 0.5 mm | Paper p8 example fab's 1 mm minimum slot, not a universal fab capability |
+
+Do not misattribute the outward offset: p9 recommends holes **centered over the
+board edge** for cosmetic use, or recessed inward tangent holes for an
+uninterrupted outer dimension. Page 6 explicitly says outward holes were not
+tested. This adaptation leaves less nominal intrusion than centered holes but
+can leave protruding nubs. The 0.127 mm offset deliberately leaves one sixth of
+the hole diameter inside a straight board, rather than setting a nearly tangent
+feature below the geometry resolution. It is an experimental starting point,
+not an optimized or physically validated value. SparkFun's p9/p11 maximum 3 mm
+tab width is for depaneling-tool compatibility; this library does not certify a
+tool's jaw access, support shape, or curved-tab compatibility.
+
+## Geometry contract and limits
+
+The straight 2 mm neck connects the explicit anchor to the supplied site. Opening
+the ideal routing void with the 0.5 mm cutter disk leaves rounded shoulders.
+The board's outward disk offset supplies a cyclic polygon break row, preserving
+all intervening vertices and five equally spaced stations. This avoids inventing
+smooth-curve tangents, curvature thresholds, or arc-length error bounds.
+
+Outputs keep retained substrate, routed removal, full drill masks, analytic
+NPTH centers/diameters, attachment footprint and shoulder material distinct.
+Routed removal and full drill masks may overlap intentionally. Material is stock
+minus their union. `shoulders` is retained material, **not** the full router sweep;
+use routed removal for routing-footprint obstacle checks. Adapters must map NPTH
+to existing manufacturing tooling with appropriate layer/provenance data.
+
+Construction rejects disconnected stock results, missing/uncertain inter-hole
+ligaments, and incomplete release under a 0.002 mm virtual break sweep. All-pairs
+drill clearance prevents folded rows from silently overlapping nonadjacent holes.
+`after_break(width, witnesses, tolerance)` exposes the shared material query for
+other explicit geometric probes; the probe width is **not** a physical kerf.
+Witnesses in an uncertainty band never count as successful connection/release.
+
+Validated synthetic cases are a straight edge and a convex 10 mm-radius source
+circle represented by canonical flattened polygons, with a 3 mm board/support
+gap. Arbitrary concave, oblique, tight-radius, holed or obstructed attachments are
+not manufacturing-qualified. The builder's checks do not replace full-panel
+`check_footprints` / `cutter_reachability` with explicit obstacles and entry points.
+Disk opening establishes a local swept-disk shape, not a globally reachable
+toolpath. Check actual fixture and tool Z access separately.
+
+Canonical curve flattening is 0.005 mm; offsets and stroke expansion have their
+own approximation error. Caller `QueryTolerance` must budget source, transform,
+offset and numeric uncertainty; it is not a certified bound. The coupon example
+uses 0.015 mm boundary and 0.000001 mm numerical budgets. Model tests also use a
+zero source budget to test polygon topology only. Repeated overlay on curved
+polygons can leave sub-micron slivers: tests bound both overlap area (<0.000001
+mm²) and penetration (<0.000001 mm), rather than claiming exact predicates.
+No topology guarantee extends to the pre-flattened source curves.
+
+## Reproducible coupons and outstanding physical acceptance
+
+Run `cargo run -p pcb-ir --example mouse_bite_coupon -- /tmp/coupons`.
+It writes straight/curved overview and detail SVGs, separate routed/retained
+polygon path data, virtual-break path data, and analytic NPTH CSVs. SVGs show
+substrate green, shoulders darker green, routed removal gray, holes white,
+nominal board boundary dashed black and proposed break row red. These are
+geometry review/interchange artifacts, **not** fabrication-ready Gerbers or IPC.
+The straight board is 20×20 mm; the curved board is a 20 mm diameter disk centered
+at (0, −10); support spans (−10, 3) to (10, 13); stock spans (−10, −20) to (10, 13).
+The single neck runs to (0, 5). Units and these datums must survive any fab adapter.
+
+Physical acceptance is **unfulfilled**. No coupons from this preset have been
+fabricated or measured. The intended initial evaluation matrix is rigid FR-4
+at 0.8, 1.0, 1.2 and 1.6 mm, both geometries, both bending directions, at least
+five replicates per cell and material/fabrication lot. This is a proposed test
+range, not a supported production range. SparkFun primarily tested 1.6 mm PCB
+and compared 0.8 mm; it does not establish validation of this offset, specific
+laminate grades, copper stackups, or every thickness in between.
+
+Protocol before claiming acceptance:
+
+1. Have the fab approve NPTH diameter, drill registration, slot/radius and copper
+   clearances; freeze coupon revision, laminate grade/weave, thickness, stackup,
+   copper distribution, finish and routing/drilling process. Fabricate both
+   geometries. Measure actual diameter, pitch, neck, offset and thickness.
+2. Clamp the board side at y = −5 mm with a padded jaw and apply an out-of-plane
+   load at the support-side line y = 10 mm with a spreader. Record the actual
+   contact positions, clamp torque, load-cell calibration, loading rate and
+   displacement. Reverse bending direction on separate coupons; do not reuse
+   fractured coupons. Record force–displacement and peak force; calculate moment
+   about the break row from the **measured** lever arm, not a guessed clamp model.
+3. Before destructive testing, use separate samples to exercise the actual
+   intended assembly handling, reflow and support loads. Record sag, permanent
+   set, premature breaks and component damage. A single-tab coupon is not a
+   substitute for an entire populated panel/fixture test.
+4. Photograph both fracture faces with a calibrated scale. Measure maximum nub
+   protrusion and indentation relative to the nominal edge, crack extent,
+   delamination, copper tear-out and loose fragments; inspect brittle nearby
+   components where relevant. Record break effort, debris and required cleanup.
+5. Save raw records with specimen/lot/revision IDs, geometry, material/stackup,
+   measured dimensions, conditioning, fixture/load history, force/displacement,
+   nub/indentation/damage measurements and photos. Establish application-specific
+   acceptance thresholds with manufacturing **before** evaluating pass/fail.
+
+Neither connected ligaments, simulated virtual release, nor linear elastic
+compliance establishes fracture load, crack trajectory, safe assembly support,
+damage-free release, or acceptable residual nubs. Those require measured evidence.

--- a/crates/pcb-ir/src/geom/mouse_bite/tests.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite/tests.rs
@@ -63,25 +63,26 @@ fn straight_and_curved_retention_release_intrusion_and_cutter_access() -> Result
         assert_eq!(tab.npth.len(), 5);
         assert!(tab.minimum_ligament_mm > 0.25);
         assert!(tab.minimum_ligament_mm <= SparkFunShallow::NOMINAL_LIGAMENT_MM + 1e-6);
-        assert!(
-            tab.retained_substrate
-                .intersection(&tab.routed_removal)?
-                .is_empty()
-        );
-        assert!(
-            tab.retained_substrate
-                .intersection(&tab.perforations)?
-                .is_empty()
-        );
         // Repeated overlays on curved polygons can leave sub-micron slivers.
-        // Check both area and penetration, not exact empty-set equality.
-        let overlap = tab.routed_removal.intersection(&board.union(&support)?)?;
-        assert!(overlap.area() < 1e-6);
-        assert!(
-            overlap
-                .intersection(&board.union(&support)?.disk_erode(1e-6)?)?
-                .is_empty()
-        );
+        // Check both area and penetration for every material/removal pair,
+        // including drill boundaries whose last-bit rounding varies by platform.
+        let protected = board.union(&support)?;
+        for (label, material, removal) in [
+            ("route", &tab.retained_substrate, &tab.routed_removal),
+            ("drill", &tab.retained_substrate, &tab.perforations),
+            ("protected", &protected, &tab.routed_removal),
+        ] {
+            let overlap = material.intersection(removal)?;
+            assert!(
+                overlap.area() < 1e-6,
+                "{label} curved={curved}: overlap area {}",
+                overlap.area()
+            );
+            assert!(
+                overlap.intersection(&removal.disk_erode(1e-6)?)?.is_empty(),
+                "{label} curved={curved}: overlap exceeds 1nm penetration"
+            );
+        }
         assert!(
             stock
                 .difference(

--- a/crates/pcb-ir/src/geom/mouse_bite/tests.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite/tests.rs
@@ -162,6 +162,41 @@ fn missing_ligament_and_bad_stock_are_not_successful_tabs() {
 }
 
 #[test]
+fn perforations_require_resolved_clearance_from_support() {
+    let (board, _, stock) = fixture(false);
+    let drill_top = SparkFunShallow::OUTWARD_OFFSET_MM + SparkFunShallow::HOLE_DIAMETER_MM / 2.0;
+    // Overlap, tangency, and a positive gap smaller than stored uncertainty
+    // must all fail before drilling support. A resolved gap remains supported.
+    for bottom in [0.2, drill_top, drill_top + 0.001] {
+        let support = rect(-10.0, bottom, 20.0, 10.0);
+        assert!(
+            matches!(
+                tab(&board, &support, &stock),
+                Err(QueryError::InvalidInput(
+                    "perforations overlap support or clearance is unresolved"
+                ))
+            ),
+            "support bottom={bottom}"
+        );
+    }
+    let support = rect(-10.0, 3.0, 20.0, 10.0);
+    let result = tab(&board, &support, &stock).unwrap();
+    assert!(
+        result
+            .perforations
+            .intersection(&support)
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        support
+            .difference(&result.retained_substrate)
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
 fn input_accuracy_is_preserved_and_failures_propagate() {
     let (board, support, stock) = fixture(true);
     let result = tab(&board, &support, &stock).unwrap();

--- a/crates/pcb-ir/src/geom/mouse_bite/tests.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite/tests.rs
@@ -8,13 +8,20 @@ const TOL: QueryTolerance = QueryTolerance {
 };
 
 fn rect(x: f64, y: f64, w: f64, h: f64) -> ContourSet {
-    ContourSet::rectangle(BBox::new(Point::new(x, y), Point::new(x + w, y + h)), 0.0)
+    ContourSet::rectangle(
+        BBox::new(Point::new(x, y), Point::new(x + w, y + h)),
+        Resolution::default().strict(),
+    )
 }
 
 fn fixture(curved: bool) -> (ContourSet, ContourSet, ContourSet) {
     let board = if curved {
         transform_region(
-            &ContourSet::from_filled_contours(&[super::super::shapes::circle(20.0).unwrap()], 0.0),
+            &ContourSet::from_filled_contours(
+                &[super::super::shapes::circle(20.0).unwrap()],
+                Resolution::default().strict(),
+            )
+            .unwrap(),
             Affine2::translation(Point::new(0.0, -10.0)),
         )
         .unwrap()
@@ -49,7 +56,7 @@ fn tab(
 }
 
 #[test]
-fn straight_and_curved_retention_release_intrusion_and_cutter_access() {
+fn straight_and_curved_retention_release_intrusion_and_cutter_access() -> Result<(), QueryError> {
     for curved in [false, true] {
         let (board, support, stock) = fixture(curved);
         let tab = tab(&board, &support, &stock).unwrap();
@@ -58,38 +65,38 @@ fn straight_and_curved_retention_release_intrusion_and_cutter_access() {
         assert!(tab.minimum_ligament_mm <= SparkFunShallow::NOMINAL_LIGAMENT_MM + 1e-6);
         assert!(
             tab.retained_substrate
-                .intersection(&tab.routed_removal)
+                .intersection(&tab.routed_removal)?
                 .is_empty()
         );
         assert!(
             tab.retained_substrate
-                .intersection(&tab.perforations)
+                .intersection(&tab.perforations)?
                 .is_empty()
         );
         // Repeated overlays on curved polygons can leave sub-micron slivers.
         // Check both area and penetration, not exact empty-set equality.
-        let overlap = tab.routed_removal.intersection(&board.union(&support));
+        let overlap = tab.routed_removal.intersection(&board.union(&support)?)?;
         assert!(overlap.area() < 1e-6);
         assert!(
             overlap
-                .intersection(&board.union(&support).disk_erode(1e-6))
+                .intersection(&board.union(&support)?.disk_erode(1e-6)?)?
                 .is_empty()
         );
         assert!(
             stock
                 .difference(
                     &tab.retained_substrate
-                        .union(&tab.routed_removal)
-                        .union(&tab.perforations)
-                )
+                        .union(&tab.routed_removal)?
+                        .union(&tab.perforations)?
+                )?
                 .area()
                 < 1e-6
         );
-        assert!(!tab.perforations.intersection(&board).is_empty());
+        assert!(!tab.perforations.intersection(&board)?.is_empty());
         // Full-mask intrusion check, not merely drill-center placement.
         assert!(
             tab.perforations
-                .intersection(&board.disk_erode(SparkFunShallow::NOMINAL_INTRUSION_MM + 0.015))
+                .intersection(&board.disk_erode(SparkFunShallow::NOMINAL_INTRUSION_MM + 0.015)?)?
                 .is_empty()
         );
         let query = BoundaryQuery::new(&board, TOL).unwrap();
@@ -136,13 +143,14 @@ fn straight_and_curved_retention_release_intrusion_and_cutter_access() {
         .unwrap();
         assert!(large.targets.iter().all(|d| *d != Decision::Admissible));
     }
+    Ok(())
 }
 
 #[test]
 fn missing_ligament_and_bad_stock_are_not_successful_tabs() {
     let (board, support, stock) = fixture(false);
     assert!(tab(&board, &support, &board).is_err());
-    let missing = stock.difference(&rect(-0.4, 0.0, 0.2, 3.0));
+    let missing = stock.difference(&rect(-0.4, 0.0, 0.2, 3.0)).unwrap();
     assert!(tab(&board, &support, &missing).is_err());
     let tab = tab(&board, &support, &stock).unwrap();
     assert!(tab.after_break(f64::NAN, &[], TOL).is_err());
@@ -150,4 +158,22 @@ fn missing_ligament_and_bad_stock_are_not_successful_tabs() {
         .after_break(0.01, &[Point::new(100.0, 100.0), Point::new(0.0, 5.0)], TOL)
         .unwrap();
     assert_eq!(unknown.connected(0, 1).unwrap(), None);
+}
+
+#[test]
+fn input_accuracy_is_preserved_and_failures_propagate() {
+    let (board, support, stock) = fixture(true);
+    let result = tab(&board, &support, &stock).unwrap();
+    assert!(result.break_path.uncertainty_mm >= board.uncertainty_mm);
+    assert!(result.perforations.uncertainty_mm >= result.break_path.uncertainty_mm);
+    assert_eq!(result.retained_substrate.budget(), board.budget());
+    let exhausted = ContourSet::from_regularized(
+        board.rings.clone(),
+        board.resolution,
+        board.budget().max_error_mm(),
+    );
+    assert!(matches!(
+        tab(&exhausted, &support, &stock),
+        Err(QueryError::Accuracy(_))
+    ));
 }

--- a/crates/pcb-ir/src/geom/mouse_bite/tests.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite/tests.rs
@@ -1,0 +1,153 @@
+use super::*;
+use crate::geom::BBox;
+use crate::geom::attachment::{Decision, cutter_reachability};
+
+const TOL: QueryTolerance = QueryTolerance {
+    boundary_mm: 0.0,
+    numerical_mm: 1e-7,
+};
+
+fn rect(x: f64, y: f64, w: f64, h: f64) -> ContourSet {
+    ContourSet::rectangle(BBox::new(Point::new(x, y), Point::new(x + w, y + h)), 0.0)
+}
+
+fn fixture(curved: bool) -> (ContourSet, ContourSet, ContourSet) {
+    let board = if curved {
+        transform_region(
+            &ContourSet::from_filled_contours(&[super::super::shapes::circle(20.0).unwrap()], 0.0),
+            Affine2::translation(Point::new(0.0, -10.0)),
+        )
+        .unwrap()
+    } else {
+        rect(-10.0, -20.0, 20.0, 20.0)
+    };
+    (
+        board,
+        rect(-10.0, 3.0, 20.0, 10.0),
+        rect(-10.0, -20.0, 20.0, 33.0),
+    )
+}
+
+fn tab(
+    board: &ContourSet,
+    support: &ContourSet,
+    stock: &ContourSet,
+) -> Result<TabGeometry, QueryError> {
+    let query = BoundaryQuery::new(board, TOL)?;
+    let boundary = query.boundaries().next().unwrap();
+    let site = query.project(boundary, Point::ZERO)?.site;
+    build(Attachment {
+        board,
+        support,
+        stock,
+        boundary,
+        station_mm: site.station_mm,
+        support_anchor: Point::new(0.0, 5.0),
+        board_witness: Point::new(0.0, -5.0),
+        tolerance: TOL,
+    })
+}
+
+#[test]
+fn straight_and_curved_retention_release_intrusion_and_cutter_access() {
+    for curved in [false, true] {
+        let (board, support, stock) = fixture(curved);
+        let tab = tab(&board, &support, &stock).unwrap();
+        assert_eq!(tab.npth.len(), 5);
+        assert!(tab.minimum_ligament_mm > 0.25);
+        assert!(tab.minimum_ligament_mm <= SparkFunShallow::NOMINAL_LIGAMENT_MM + 1e-6);
+        assert!(
+            tab.retained_substrate
+                .intersection(&tab.routed_removal)
+                .is_empty()
+        );
+        assert!(
+            tab.retained_substrate
+                .intersection(&tab.perforations)
+                .is_empty()
+        );
+        // Repeated overlays on curved polygons can leave sub-micron slivers.
+        // Check both area and penetration, not exact empty-set equality.
+        let overlap = tab.routed_removal.intersection(&board.union(&support));
+        assert!(overlap.area() < 1e-6);
+        assert!(
+            overlap
+                .intersection(&board.union(&support).disk_erode(1e-6))
+                .is_empty()
+        );
+        assert!(
+            stock
+                .difference(
+                    &tab.retained_substrate
+                        .union(&tab.routed_removal)
+                        .union(&tab.perforations)
+                )
+                .area()
+                < 1e-6
+        );
+        assert!(!tab.perforations.intersection(&board).is_empty());
+        // Full-mask intrusion check, not merely drill-center placement.
+        assert!(
+            tab.perforations
+                .intersection(&board.disk_erode(SparkFunShallow::NOMINAL_INTRUSION_MM + 0.015))
+                .is_empty()
+        );
+        let query = BoundaryQuery::new(&board, TOL).unwrap();
+        let id = query.boundaries().next().unwrap();
+        for drill in &tab.npth {
+            let offset = query.project(id, drill.center).unwrap().distance.mm;
+            assert!((offset - SparkFunShallow::OUTWARD_OFFSET_MM).abs() < 0.006);
+        }
+        let witnesses = [Point::new(0.0, -5.0), Point::new(0.0, 5.0)];
+        for width in [0.002, 0.01, 0.02] {
+            let after = tab.after_break(width, &witnesses, TOL).unwrap();
+            assert_eq!(
+                after.connected(0, 1).unwrap(),
+                Some(false),
+                "curved={curved}, width={width}"
+            );
+            assert_eq!(after.components.len(), 2, "no loose shoulder islands");
+        }
+        assert!(tab.shoulders.area() > 0.05);
+        // Both shoulder approaches must be reachable with a 1mm cutter, from
+        // explicit side entries. Targets are deliberately off contact surfaces.
+        let access = cutter_reachability(
+            &rect(-12.0, -22.0, 24.0, 37.0),
+            &tab.retained_substrate,
+            0.5,
+            &[Point::new(-11.0, 1.5), Point::new(11.0, 1.5)],
+            &[Point::new(-1.6, 0.6), Point::new(1.6, 0.6)],
+            TOL,
+        )
+        .unwrap();
+        assert_eq!(
+            access.targets,
+            vec![Decision::Admissible, Decision::Admissible]
+        );
+        // A larger cutter must not inherit the small-cutter shoulder approval.
+        let large = cutter_reachability(
+            &rect(-12.0, -22.0, 24.0, 37.0),
+            &tab.retained_substrate,
+            0.8,
+            &[Point::new(-11.0, 1.5), Point::new(11.0, 1.5)],
+            &[Point::new(-1.6, 0.6), Point::new(1.6, 0.6)],
+            TOL,
+        )
+        .unwrap();
+        assert!(large.targets.iter().all(|d| *d != Decision::Admissible));
+    }
+}
+
+#[test]
+fn missing_ligament_and_bad_stock_are_not_successful_tabs() {
+    let (board, support, stock) = fixture(false);
+    assert!(tab(&board, &support, &board).is_err());
+    let missing = stock.difference(&rect(-0.4, 0.0, 0.2, 3.0));
+    assert!(tab(&board, &support, &missing).is_err());
+    let tab = tab(&board, &support, &stock).unwrap();
+    assert!(tab.after_break(f64::NAN, &[], TOL).is_err());
+    let unknown = tab
+        .after_break(0.01, &[Point::new(100.0, 100.0), Point::new(0.0, 5.0)], TOL)
+        .unwrap();
+    assert_eq!(unknown.connected(0, 1).unwrap(), None);
+}

--- a/crates/pcb-ir/src/geom/mouse_bite/tests.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite/tests.rs
@@ -162,6 +162,40 @@ fn missing_ligament_and_bad_stock_are_not_successful_tabs() {
 }
 
 #[test]
+fn witnesses_must_be_interior_to_the_original_regions() {
+    let (board, support, stock) = fixture(false);
+    let query = BoundaryQuery::new(&board, TOL).unwrap();
+    let boundary = query.boundaries().next().unwrap();
+    let station_mm = query
+        .project(boundary, Point::ZERO)
+        .unwrap()
+        .site
+        .station_mm;
+    for (support_anchor, board_witness) in [
+        (Point::new(0.0, 3.0), Point::new(0.0, -5.0)),
+        (Point::new(0.0, 3.0 - 1e-7), Point::new(0.0, -5.0)),
+        (Point::new(0.0, 5.0), Point::ZERO),
+        (Point::new(0.0, 5.0), Point::new(0.0, 1e-7)),
+    ] {
+        assert!(matches!(
+            build(Attachment {
+                board: &board,
+                support: &support,
+                stock: &stock,
+                boundary,
+                station_mm,
+                support_anchor,
+                board_witness,
+                tolerance: TOL,
+            }),
+            Err(QueryError::InvalidInput(
+                "expected disjoint connected board/support inside stock with interior witnesses"
+            ))
+        ));
+    }
+}
+
+#[test]
 fn perforations_require_resolved_clearance_from_support() {
     let (board, _, stock) = fixture(false);
     let drill_top = SparkFunShallow::OUTWARD_OFFSET_MM + SparkFunShallow::HOLE_DIAMETER_MM / 2.0;

--- a/crates/pcb-ir/src/geom/path.rs
+++ b/crates/pcb-ir/src/geom/path.rs
@@ -400,7 +400,7 @@ impl Segment {
                 path.move_to(kurbo_point(start));
                 path.curve_to(kurbo_point(c1), kurbo_point(c2), kurbo_point(end));
                 let mut points = Vec::new();
-                kurbo::flatten(path, max_error_mm.max(f64::MIN_POSITIVE), |el| {
+                flatten_path(path, max_error_mm.max(f64::MIN_POSITIVE), |el| {
                     if let PathEl::LineTo(point) = el {
                         points.push(ir_point(point));
                     }
@@ -808,11 +808,22 @@ fn append_arc_to_kurbo(out: &mut BezPath, arc: EllipticalArc, accuracy: f64) -> 
     // Tangent at parameter θ is −x_axis·sin θ + y_axis·cos θ.
     let tangent = |angle: f64| arc.y_axis * angle.cos() - arc.x_axis * angle.sin();
 
-    for _ in 0..segment_count {
+    for index in 0..segment_count {
         let next_angle = angle + delta;
         let k = 4.0 / 3.0 * (delta / 4.0).tan();
-        let p0 = arc.point_at(angle);
-        let p3 = arc.point_at(next_angle);
+        // Interpolate the supplied endpoints exactly. Re-evaluating them with
+        // trigonometry can leave a last-bit gap at adjoining arcs; flattening
+        // can turn that gap into an effectively zero-length polygon edge.
+        let p0 = if index == 0 {
+            arc.start
+        } else {
+            arc.point_at(angle)
+        };
+        let p3 = if index + 1 == segment_count {
+            arc.end
+        } else {
+            arc.point_at(next_angle)
+        };
         let c1 = p0 + tangent(angle) * k;
         let c2 = p3 - tangent(next_angle) * k;
         out.curve_to(kurbo_point(c1), kurbo_point(c2), kurbo_point(p3));
@@ -896,6 +907,43 @@ pub(crate) fn kurbo_point(point: Point) -> kurbo::Point {
     kurbo::Point::new(point.x, point.y)
 }
 
+// Kurbo 0.13's cubic flattener can emit sample n as well as the stored
+// endpoint when n * (sum / n) rounds below sum. Convert to quadratics first:
+// their flattener enumerates only integer interior samples, then the endpoint.
+// The two approximation budgets add to the requested tolerance.
+pub(crate) fn flatten_path(
+    path: impl IntoIterator<Item = PathEl>,
+    tolerance: f64,
+    callback: impl FnMut(PathEl),
+) {
+    let mut previous = None;
+    let quadratics = path.into_iter().flat_map(|element| {
+        let mut elements = Vec::new();
+        match element {
+            PathEl::CurveTo(p1, p2, p3) => {
+                if let Some(p0) = previous {
+                    let cubic = kurbo::CubicBez::new(p0, p1, p2, p3);
+                    let mut pieces = cubic.to_quads(tolerance * 0.1).peekable();
+                    while let Some((_, _, quad)) = pieces.next() {
+                        let end = if pieces.peek().is_none() { p3 } else { quad.p2 };
+                        elements.push(PathEl::QuadTo(quad.p1, end));
+                    }
+                }
+                previous = Some(p3);
+            }
+            _ => {
+                previous = match element {
+                    PathEl::MoveTo(p) | PathEl::LineTo(p) | PathEl::QuadTo(_, p) => Some(p),
+                    _ => None,
+                };
+                elements.push(element);
+            }
+        }
+        elements
+    });
+    kurbo::flatten(quadratics, tolerance * 0.9, callback);
+}
+
 pub(crate) fn ir_point(point: kurbo::Point) -> Point {
     Point::new(point.x, point.y)
 }
@@ -903,6 +951,63 @@ pub(crate) fn ir_point(point: kurbo::Point) -> Point {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn arc_cubics_interpolate_source_endpoints_exactly() {
+        let circle = crate::geom::shapes::circle(0.381).unwrap();
+        for contour in [
+            circle.clone(),
+            circle.transformed(Affine2 {
+                m00: 1.5,
+                m01: 0.3,
+                m10: -0.2,
+                m11: 0.8,
+                m02: 10.0,
+                m12: -3.0,
+            }),
+        ] {
+            for segment in contour.segments() {
+                let arc = match segment {
+                    Segment::Arc(arc) => arc.to_elliptical(),
+                    Segment::Ellipse(arc) => arc,
+                    _ => continue,
+                };
+                for accuracy in [0.001, 0.000001] {
+                    let mut path = BezPath::new();
+                    path.move_to(kurbo_point(arc.start));
+                    append_arc_to_kurbo(&mut path, arc, accuracy);
+                    let Some(kurbo::PathEl::CurveTo(_, _, end)) = path.elements().last() else {
+                        panic!("nondegenerate arc must produce cubics");
+                    };
+                    assert_eq!(*end, kurbo_point(arc.end));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn prepared_small_circles_have_no_numerical_join_edges() {
+        use crate::geom::{ContourSet, Resolution};
+        for (diameter, prior) in [0.381, 20.0]
+            .into_iter()
+            .flat_map(|diameter| [0.0, 0.0005, 0.0008, 0.001, 0.002].map(|prior| (diameter, prior)))
+        {
+            let source = crate::geom::shapes::circle(diameter)
+                .unwrap()
+                .with_uncertainty(prior);
+            let region =
+                ContourSet::from_filled_contours(&[source], Resolution::default().strict())
+                    .unwrap();
+            for ring in &region.rings {
+                for (a, b) in crate::geom::region::ring_edges(ring) {
+                    assert!(
+                        a.distance_to(b) > crate::geom::tol::EPSILON_MM,
+                        "prior={prior}: numerical join {a:?} -> {b:?}"
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn signed_area_preserves_arcs_ellipses_and_cubics() {

--- a/crates/pcb-ir/src/geom/path.rs
+++ b/crates/pcb-ir/src/geom/path.rs
@@ -214,12 +214,16 @@ impl ContourBuf {
     pub fn transformed(self, transform: Affine2) -> Self {
         let scale = transform.max_scale();
         let mut current = Point::default();
+        let mut start = current;
         let cmds = self
             .cmds
             .into_iter()
             .map(|cmd| {
                 let transformed = cmd.transformed(transform, current);
-                current = cmd.end_point().unwrap_or(current);
+                if cmd.op == PathOp::MoveTo {
+                    start = cmd.p0;
+                }
+                current = cmd.end_point().unwrap_or(start);
                 transformed
             })
             .collect::<Vec<_>>();
@@ -251,6 +255,7 @@ impl ContourBuf {
         let allowance = accuracy.allowance(self.uncertainty_mm)?;
         let mut cmds = Vec::with_capacity(self.cmds.len());
         let mut current = Point::default();
+        let mut start = current;
         let mut added: f64 = 0.0;
         for cmd in &self.cmds {
             match cmd.op {
@@ -272,7 +277,10 @@ impl ContourBuf {
                 }
                 _ => cmds.push(*cmd),
             }
-            current = cmd.end_point().unwrap_or(current);
+            if cmd.op == PathOp::MoveTo {
+                start = cmd.p0;
+            }
+            current = cmd.end_point().unwrap_or(start);
         }
         Ok(Self::new(cmds).with_uncertainty(self.uncertainty_mm + added))
     }
@@ -514,7 +522,11 @@ impl Iterator for Segments<'_> {
 pub fn contour_bbox(cmds: &[PathCmd]) -> BBox {
     let mut bbox = BBox::empty();
     let mut current = Point::default();
+    let mut start = current;
     for cmd in cmds {
+        if cmd.op == PathOp::MoveTo {
+            start = cmd.p0;
+        }
         match cmd.op {
             PathOp::MoveTo | PathOp::LineTo => {
                 current = cmd.p0;
@@ -534,7 +546,7 @@ pub fn contour_bbox(cmds: &[PathCmd]) -> BBox {
                 bbox.include_point(cmd.p2);
                 current = cmd.p2;
             }
-            PathOp::Close => {}
+            PathOp::Close => current = start,
         }
     }
     bbox
@@ -744,12 +756,14 @@ fn contour_from_segments(segments: &[Segment]) -> Option<ContourBuf> {
 pub(crate) fn contours_to_kurbo(contours: &[ContourBuf], accuracy: f64) -> (BezPath, f64) {
     let mut out = BezPath::new();
     let mut current = Point::default();
+    let mut start = current;
     let mut conversion_error: f64 = 0.0;
     for contour in contours {
         for cmd in &contour.cmds {
             match cmd.op {
                 PathOp::MoveTo => {
                     current = cmd.p0;
+                    start = current;
                     out.move_to(kurbo_point(cmd.p0));
                 }
                 PathOp::LineTo => {
@@ -781,7 +795,10 @@ pub(crate) fn contours_to_kurbo(contours: &[ContourBuf], accuracy: f64) -> (BezP
                         kurbo_point(cmd.p2),
                     );
                 }
-                PathOp::Close => out.close_path(),
+                PathOp::Close => {
+                    current = start;
+                    out.close_path();
+                }
             }
         }
     }
@@ -837,12 +854,14 @@ fn kurbo_path_to_contours(path: &BezPath) -> Vec<ContourBuf> {
     let mut cmds = Vec::new();
     let mut bbox = BBox::empty();
     let mut current = Point::default();
+    let mut start = current;
 
     for element in path.iter() {
         match element {
             PathEl::MoveTo(point) => {
                 push_kurbo_contour(&mut contours, &mut bbox, &mut cmds);
                 current = ir_point(point);
+                start = current;
                 bbox.include_point(current);
                 cmds.push(PathCmd::move_to(current));
             }
@@ -872,7 +891,10 @@ fn kurbo_path_to_contours(path: &BezPath) -> Vec<ContourBuf> {
                 cmds.push(PathCmd::cubic_to(p1, p2, p3));
                 current = p3;
             }
-            PathEl::ClosePath => cmds.push(PathCmd::close()),
+            PathEl::ClosePath => {
+                current = start;
+                cmds.push(PathCmd::close());
+            }
         }
     }
     push_kurbo_contour(&mut contours, &mut bbox, &mut cmds);
@@ -967,6 +989,71 @@ pub(crate) fn ir_point(point: kurbo::Point) -> Point {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn closed_arc_continuations_match_explicit_moves_through_preparation() {
+        use crate::geom::{ContourSet, Resolution};
+        let transform = Affine2 {
+            m00: 1.5,
+            m01: 0.3,
+            m10: -0.2,
+            m11: 0.8,
+            m02: 10.0,
+            m12: -3.0,
+        };
+        for (start, arc) in [
+            (
+                Point::new(1.0, 0.0),
+                PathCmd::arc_to(Point::new(0.0, 1.0), Point::ZERO, false),
+            ),
+            (
+                Point::new(2.0, 0.0),
+                PathCmd::ellipse_to(
+                    Point::new(0.0, 1.0),
+                    Point::ZERO,
+                    Point::new(2.0, 0.0),
+                    Point::new(0.0, 1.0),
+                    false,
+                ),
+            ),
+        ] {
+            let cmds = vec![
+                PathCmd::move_to(start),
+                PathCmd::line_to(Point::new(0.0, -2.0)),
+                PathCmd::line_to(Point::new(-3.0, -2.0)),
+                PathCmd::close(),
+                arc,
+                PathCmd::close(),
+            ];
+            let mut explicit = cmds.clone();
+            explicit.insert(4, PathCmd::move_to(start));
+            let actual = ContourBuf::new(cmds);
+            let expected = ContourBuf::new(explicit);
+            assert_eq!(actual.bbox, expected.bbox);
+            let actual_transformed = actual.clone().transformed(transform);
+            let expected_transformed = expected.clone().transformed(transform);
+            assert_eq!(actual_transformed.cmds[4], expected_transformed.cmds[5]);
+            for (actual, expected) in [
+                (actual, expected),
+                (actual_transformed, expected_transformed),
+            ] {
+                for flatten in [false, true] {
+                    let prepare = |contour: &ContourBuf| {
+                        let contour = if flatten {
+                            contour
+                                .flattened_curves(GeometryAccuracy::new(0.001).unwrap())
+                                .unwrap()
+                        } else {
+                            contour.clone()
+                        };
+                        ContourSet::from_filled_contours(&[contour], Resolution::default().strict())
+                            .unwrap()
+                    };
+                    assert_eq!(prepare(&actual).rings, prepare(&expected).rings);
+                }
+            }
+        }
+    }
 
     #[test]
     fn cubic_after_close_starts_at_the_closed_subpath_start() {

--- a/crates/pcb-ir/src/geom/path.rs
+++ b/crates/pcb-ir/src/geom/path.rs
@@ -917,8 +917,19 @@ pub(crate) fn flatten_path(
     callback: impl FnMut(PathEl),
 ) {
     let mut previous = None;
+    let mut subpath_start = None;
+    let mut closed = false;
     let quadratics = path.into_iter().flat_map(|element| {
         let mut elements = Vec::new();
+        // Kurbo resets its current point on close. Restore it explicitly only
+        // when drawing continues without a new MoveTo.
+        if closed
+            && !matches!(element, PathEl::MoveTo(_) | PathEl::ClosePath)
+            && let Some(start) = subpath_start
+        {
+            elements.push(PathEl::MoveTo(start));
+        }
+        closed = matches!(element, PathEl::ClosePath);
         match element {
             PathEl::CurveTo(p1, p2, p3) => {
                 if let Some(p0) = previous {
@@ -933,7 +944,12 @@ pub(crate) fn flatten_path(
             }
             _ => {
                 previous = match element {
-                    PathEl::MoveTo(p) | PathEl::LineTo(p) | PathEl::QuadTo(_, p) => Some(p),
+                    PathEl::MoveTo(p) => {
+                        subpath_start = Some(p);
+                        Some(p)
+                    }
+                    PathEl::LineTo(p) | PathEl::QuadTo(_, p) => Some(p),
+                    PathEl::ClosePath => subpath_start,
                     _ => None,
                 };
                 elements.push(element);
@@ -951,6 +967,31 @@ pub(crate) fn ir_point(point: kurbo::Point) -> Point {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cubic_after_close_starts_at_the_closed_subpath_start() {
+        let start = kurbo::Point::new(2.0, 3.0);
+        let first = PathEl::CurveTo((3.0, 4.0).into(), (4.0, 4.0).into(), (4.0, 3.0).into());
+        let second = PathEl::CurveTo((1.0, 4.0).into(), (0.0, 4.0).into(), (0.0, 3.0).into());
+        let flatten = |path: Vec<PathEl>| {
+            let mut result = Vec::new();
+            flatten_path(path, 0.001, |el| result.push(el));
+            result
+        };
+        let actual = flatten(vec![
+            PathEl::MoveTo(start),
+            first,
+            PathEl::ClosePath,
+            second,
+        ]);
+        let close = actual
+            .iter()
+            .position(|el| *el == PathEl::ClosePath)
+            .unwrap();
+        let expected = flatten(vec![PathEl::MoveTo(start), second]);
+        assert!(expected.len() > 2);
+        assert_eq!(&actual[close + 1..], expected);
+    }
 
     #[test]
     fn arc_cubics_interpolate_source_endpoints_exactly() {

--- a/crates/pcb-ir/src/geom/region/flattening.rs
+++ b/crates/pcb-ir/src/geom/region/flattening.rs
@@ -25,7 +25,7 @@ pub(super) fn flatten_contours(contours: &[ContourBuf], accuracy: f64) -> (Vec<R
     };
     let mut rings = Vec::new();
     let mut current = Vec::new();
-    kurbo::flatten(
+    crate::geom::path::flatten_path(
         bez_path,
         flatten_error.max(f64::MIN_POSITIVE),
         |element| match element {

--- a/crates/pcb-ir/src/geom/region/flattening.rs
+++ b/crates/pcb-ir/src/geom/region/flattening.rs
@@ -25,10 +25,8 @@ pub(super) fn flatten_contours(contours: &[ContourBuf], accuracy: f64) -> (Vec<R
     };
     let mut rings = Vec::new();
     let mut current = Vec::new();
-    crate::geom::path::flatten_path(
-        bez_path,
-        flatten_error.max(f64::MIN_POSITIVE),
-        |element| match element {
+    crate::geom::path::flatten_path(bez_path, flatten_error.max(f64::MIN_POSITIVE), |element| {
+        match element {
             kurbo::PathEl::MoveTo(point) => {
                 push_ring(&mut rings, &mut current);
                 current.push([point.x, point.y]);
@@ -38,8 +36,8 @@ pub(super) fn flatten_contours(contours: &[ContourBuf], accuracy: f64) -> (Vec<R
             kurbo::PathEl::QuadTo(..) | kurbo::PathEl::CurveTo(..) => {
                 unreachable!("kurbo::flatten emits lines")
             }
-        },
-    );
+        }
+    });
     push_ring(&mut rings, &mut current);
     (rings, conversion_error + flatten_error)
 }


### PR DESCRIPTION
Add pure single-tab geometry with separate routed removal, NPTH perforations, and reproducible coupons. Preserve geometry accuracy budgets and carry the ENG-1430 prerequisite commits from #1240. Keep the outward-offset preset experimental; physical fracture validation remains incomplete.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1242" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->