### PR TITLE
fix(lsp): watch symbols before evaluation (ENG-1500)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Reconnect all affected nets when schematic repair moves symbols out of a short.
-- Refresh failed schematic evaluations when symbol files are corrected, without reloading the editor.
+- Refresh failed schematic evaluations when symbol files are corrected, without reloading the editor, and batch queued file changes into one refresh.
 - Mark standard-library bare test pads and plated test holes as native KiCad test points.
 - Mark standard-library fiducial pads as global fiducials in KiCad layouts.
 - Preserve curves that continue after a closed subpath during polygon preparation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Reconnect all affected nets when schematic repair moves symbols out of a short.
-- Refresh failed schematic evaluations when symbol files are corrected, without reloading the editor, and batch queued file changes into one refresh.
+- Refresh stale schematics when workspace symbol files change.
 - Mark standard-library bare test pads and plated test holes as native KiCad test points.
 - Mark standard-library fiducial pads as global fiducials in KiCad layouts.
 - Preserve curves that continue after a closed subpath during polygon preparation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Reconnect all affected nets when schematic repair moves symbols out of a short.
+- Refresh failed schematic evaluations when symbol files are corrected, without reloading the editor.
 - Mark standard-library bare test pads and plated test holes as native KiCad test points.
 - Mark standard-library fiducial pads as global fiducials in KiCad layouts.
 - Preserve curves that continue after a closed subpath during polygon preparation.

--- a/crates/pcb-starlark-lsp/src/server.rs
+++ b/crates/pcb-starlark-lsp/src/server.rs
@@ -571,6 +571,31 @@ fn record_netlist_payload(
     true
 }
 
+fn coalesce_watched_file_changes(
+    connection: &Connection,
+    mut params: DidChangeWatchedFilesParams,
+    pending: &mut VecDeque<Message>,
+) -> DidChangeWatchedFilesParams {
+    // Stdio uses a zero-capacity channel: give its reader a brief chance to
+    // hand over the next event. Requests and other messages remain barriers.
+    while let Ok(message) = connection
+        .receiver
+        .recv_timeout(std::time::Duration::from_millis(1))
+    {
+        if let Message::Notification(notification) = &message
+            && notification.method == DidChangeWatchedFiles::METHOD
+            && let Ok(next) =
+                serde_json::from_value::<DidChangeWatchedFilesParams>(notification.params.clone())
+        {
+            params.changes.extend(next.changes);
+        } else {
+            pending.push_back(message);
+            break;
+        }
+    }
+    params
+}
+
 /// The logic implementations of stuff
 impl<T: LspContext> Backend<T> {
     fn server_capabilities(context: &T, settings: LspServerSettings) -> ServerCapabilities {
@@ -1927,6 +1952,7 @@ impl<T: LspContext> Backend<T> {
             }
             DidChangeWatchedFiles::METHOD => {
                 self.with_notification_params(notification, |params| {
+                    let params = coalesce_watched_file_changes(&self.connection, params, pending);
                     self.maybe_log_error(self.did_change_watched_files(params))
                 });
             }
@@ -2240,6 +2266,68 @@ mod tests {
 
     fn protocol_uri(uri: &Url) -> Uri {
         uri.as_str().parse().unwrap()
+    }
+
+    #[test]
+    fn coalesces_file_events_without_crossing_message_boundaries() -> anyhow::Result<()> {
+        use lsp_server::{Connection, Message};
+        use lsp_types::{DidChangeWatchedFilesParams, notification::DidChangeWatchedFiles};
+        use std::collections::VecDeque;
+
+        let event = |name, typ| FileEvent {
+            uri: protocol_uri(&temp_file_uri(name)),
+            typ,
+        };
+        let first = event("first.kicad_sym", FileChangeType::CHANGED);
+        let second = event("second.kicad_sym", FileChangeType::DELETED);
+        let third = event("second.kicad_sym", FileChangeType::CREATED);
+        let notification = |changes| {
+            Message::Notification(new_notification::<DidChangeWatchedFiles>(
+                DidChangeWatchedFilesParams { changes },
+            ))
+        };
+        for boundary in [
+            serde_json::json!({"id": 1, "method": "zener/evaluate", "params": {}}),
+            serde_json::json!({"method": "textDocument/didClose", "params": {}}),
+            serde_json::json!({"method": "workspace/didChangeWatchedFiles", "params": {"changes": "invalid"}}),
+        ] {
+            let (client, server) = Connection::memory();
+            client.sender.send(notification(vec![second.clone()]))?;
+            client.sender.send(notification(vec![third.clone()]))?;
+            client
+                .sender
+                .send(serde_json::from_value(boundary.clone())?)?;
+            let after = notification(vec![first.clone()]);
+            client.sender.send(after.clone())?;
+
+            let mut pending = VecDeque::new();
+            let result = super::coalesce_watched_file_changes(
+                &server,
+                DidChangeWatchedFilesParams {
+                    changes: vec![first.clone()],
+                },
+                &mut pending,
+            );
+            assert_eq!(
+                result.changes,
+                vec![first.clone(), second.clone(), third.clone()]
+            );
+            assert_eq!(pending.len(), 1);
+            // Message serialization includes jsonrpc; compare parsed messages.
+            assert_eq!(
+                serde_json::to_value(pending.pop_front().unwrap())?,
+                serde_json::to_value(serde_json::from_value::<Message>(boundary)?)?
+            );
+            assert_eq!(
+                serde_json::to_value(server.receiver.try_recv()?)?,
+                serde_json::to_value(after)?
+            );
+            let unchanged =
+                super::coalesce_watched_file_changes(&server, result.clone(), &mut pending);
+            assert_eq!(unchanged.changes, result.changes);
+            assert!(pending.is_empty());
+        }
+        Ok(())
     }
 
     #[test]

--- a/crates/pcb-starlark-lsp/src/server.rs
+++ b/crates/pcb-starlark-lsp/src/server.rs
@@ -24,7 +24,6 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
 use derivative::Derivative;
@@ -68,19 +67,15 @@ use lsp_types::MarkupContent;
 use lsp_types::MarkupKind;
 use lsp_types::MessageType;
 use lsp_types::OneOf;
-use lsp_types::Pattern;
 use lsp_types::PublishDiagnosticsParams;
 use lsp_types::Range;
 use lsp_types::Registration;
 use lsp_types::RegistrationParams;
-use lsp_types::RelativePattern;
 use lsp_types::ServerCapabilities;
 use lsp_types::TextDocumentSyncCapability;
 use lsp_types::TextDocumentSyncKind;
 use lsp_types::TextDocumentSyncOptions;
 use lsp_types::TextDocumentSyncSaveOptions;
-use lsp_types::Unregistration;
-use lsp_types::UnregistrationParams;
 use lsp_types::Uri;
 use lsp_types::WatchKind;
 use lsp_types::WorkDoneProgressOptions;
@@ -480,12 +475,6 @@ pub trait LspContext {
         Ok(None)
     }
 
-    /// Return absolute file paths that should be watched via
-    /// `workspace/didChangeWatchedFiles`.
-    fn watched_file_paths(&self) -> Vec<PathBuf> {
-        Vec::new()
-    }
-
     /// Handle custom LSP request messages that are not recognised by the core `starlark_lsp`
     /// implementation. Return [`Some(Response)`] when `req.method` is handled. Return [`None`]
     /// if the method is unsupported; the server then replies with JSON-RPC `MethodNotFound`.
@@ -566,11 +555,7 @@ pub(crate) struct Backend<T: LspContext> {
     published_diagnostics_by_origin: RwLock<HashMap<LspUri, HashMap<String, Vec<Diagnostic>>>>,
     /// Complete payload most recently emitted for each subscribed document.
     last_emitted_netlist_payloads: RwLock<HashMap<LspUri, JsonValue>>,
-    watched_file_paths: RwLock<HashSet<PathBuf>>,
-    watched_file_registration_id: RwLock<Option<String>>,
-    next_server_request_seq: AtomicU64,
     supports_dynamic_watched_files: bool,
-    supports_relative_watch_patterns: bool,
 }
 
 fn record_netlist_payload(
@@ -729,7 +714,6 @@ impl<T: LspContext> Backend<T> {
             .write()
             .unwrap()
             .remove(&lsp_url);
-        self.sync_watched_file_registrations();
 
         // In eager mode we keep the cached AST so that other features continue to work even
         // when the user closes the document in the editor.
@@ -1767,134 +1751,43 @@ impl<T: LspContext> Backend<T> {
                     .remove(uri);
             }
         }
-        self.sync_watched_file_registrations();
         Ok(())
     }
 
-    fn next_server_request_id(&self, prefix: &str) -> RequestId {
-        let seq = self.next_server_request_seq.fetch_add(1, Ordering::Relaxed);
-        RequestId::from(format!("{prefix}-{seq}"))
-    }
+    fn register_file_watchers(&self) {
+        if !self.supports_dynamic_watched_files {
+            return;
+        }
 
-    fn send_client_request<P: Serialize>(&self, method: &str, params: P) {
+        // Watch symbols before evaluation: a failed component must still observe
+        // the symbol edit that fixes it, even when no schematic was produced.
+        let kind = Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete);
         self.connection
             .sender
             .send(Message::Request(lsp_server::Request {
-                id: self.next_server_request_id("server-request"),
-                method: method.to_owned(),
-                params: serde_json::to_value(params).unwrap(),
+                id: RequestId::from("workspace-watched-files".to_owned()),
+                method: "client/registerCapability".to_owned(),
+                params: serde_json::to_value(RegistrationParams {
+                    registrations: vec![Registration {
+                        id: "workspace-watched-files".to_owned(),
+                        method: "workspace/didChangeWatchedFiles".to_owned(),
+                        register_options: Some(
+                            serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
+                                watchers: ["**/pcb.toml", "**/*.kicad_sym"]
+                                    .into_iter()
+                                    .map(|pattern| FileSystemWatcher {
+                                        glob_pattern: GlobPattern::String(pattern.to_owned()),
+                                        kind,
+                                    })
+                                    .collect(),
+                            })
+                            .unwrap(),
+                        ),
+                    }],
+                })
+                .unwrap(),
             }))
             .unwrap();
-    }
-
-    fn file_watcher_for_path(&self, watched_path: &Path) -> Option<FileSystemWatcher> {
-        let kind = Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete);
-
-        if self.supports_relative_watch_patterns
-            && let (Some(parent), Some(file_name)) =
-                (watched_path.parent(), watched_path.file_name())
-            && let Ok(base_uri) = Url::from_directory_path(parent)
-            && let Some(base_uri) = url_to_uri(&base_uri)
-        {
-            return Some(FileSystemWatcher {
-                glob_pattern: GlobPattern::Relative(RelativePattern {
-                    base_uri: OneOf::Right(base_uri),
-                    pattern: file_name.to_string_lossy().to_string(),
-                }),
-                kind,
-            });
-        }
-
-        let pattern: Pattern = watched_path.to_string_lossy().replace('\\', "/");
-        Some(FileSystemWatcher {
-            glob_pattern: GlobPattern::String(pattern),
-            kind,
-        })
-    }
-
-    fn register_manifest_watchers(&self) {
-        if !self.supports_dynamic_watched_files {
-            return;
-        }
-
-        let kind = Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete);
-        self.send_client_request(
-            "client/registerCapability",
-            RegistrationParams {
-                registrations: vec![Registration {
-                    id: "manifest-watched-files".to_owned(),
-                    method: "workspace/didChangeWatchedFiles".to_owned(),
-                    register_options: Some(
-                        serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
-                            watchers: vec![FileSystemWatcher {
-                                glob_pattern: GlobPattern::String("**/pcb.toml".to_owned()),
-                                kind,
-                            }],
-                        })
-                        .unwrap(),
-                    ),
-                }],
-            },
-        );
-    }
-
-    fn sync_watched_file_registrations(&self) {
-        if !self.supports_dynamic_watched_files {
-            return;
-        }
-
-        let desired_paths: HashSet<PathBuf> =
-            self.context.watched_file_paths().into_iter().collect();
-        let current_paths = self.watched_file_paths.read().unwrap().clone();
-        if desired_paths == current_paths {
-            return;
-        }
-
-        if let Some(registration_id) = self.watched_file_registration_id.write().unwrap().take() {
-            self.send_client_request(
-                "client/unregisterCapability",
-                UnregistrationParams {
-                    unregisterations: vec![Unregistration {
-                        id: registration_id,
-                        method: "workspace/didChangeWatchedFiles".to_owned(),
-                    }],
-                },
-            );
-        }
-
-        if !desired_paths.is_empty() {
-            let mut ordered_paths: Vec<PathBuf> = desired_paths.iter().cloned().collect();
-            ordered_paths.sort();
-            let watchers: Vec<FileSystemWatcher> = ordered_paths
-                .iter()
-                .filter_map(|path| self.file_watcher_for_path(path))
-                .collect();
-
-            if !watchers.is_empty() {
-                let registration_id = format!(
-                    "watched-files-{}",
-                    self.next_server_request_seq.fetch_add(1, Ordering::Relaxed)
-                );
-                self.send_client_request(
-                    "client/registerCapability",
-                    RegistrationParams {
-                        registrations: vec![Registration {
-                            id: registration_id.clone(),
-                            method: "workspace/didChangeWatchedFiles".to_owned(),
-                            register_options: Some(
-                                serde_json::to_value(DidChangeWatchedFilesRegistrationOptions {
-                                    watchers,
-                                })
-                                .unwrap(),
-                            ),
-                        }],
-                    },
-                );
-                *self.watched_file_registration_id.write().unwrap() = Some(registration_id);
-            }
-        }
-
-        *self.watched_file_paths.write().unwrap() = desired_paths;
     }
 
     fn coalesce_did_change(
@@ -1935,11 +1828,10 @@ impl<T: LspContext> Backend<T> {
         initialize_params: InitializeParams,
         started_at: Instant,
     ) -> Result<(), ProtocolError> {
-        self.register_manifest_watchers();
+        self.register_file_watchers();
 
         // Pre-parse relevant files.
         self.preload_workspace(&initialize_params);
-        self.sync_watched_file_registrations();
         self.log_startup_information(&initialize_params, started_at);
 
         let mut pending: VecDeque<Message> = VecDeque::new();
@@ -2003,11 +1895,6 @@ impl<T: LspContext> Backend<T> {
                 }
                 if let Some(resp) = self.context.handle_custom_request(&req, initialize_params) {
                     self.send_response(resp);
-                    // Custom requests (for example `zener/evaluate`) can
-                    // mutate watched-file subscriptions in the context.
-                    // Re-sync registrations immediately so subsequent
-                    // external file edits are observed.
-                    self.sync_watched_file_registrations();
                 } else {
                     self.send_response(Response::new_err(
                         req.id,
@@ -2125,10 +2012,9 @@ impl<T: LspContext> Backend<T> {
         self.log_message(
             MessageType::INFO,
             &format!(
-                "Startup mode: workspace preload={}, dynamic file watching={}, relative watch patterns={}",
+                "Startup mode: workspace preload={}, dynamic file watching={}",
                 enabled(self.context.is_eager()),
                 supported(self.supports_dynamic_watched_files),
-                supported(self.supports_relative_watch_patterns),
             ),
         );
     }
@@ -2204,9 +2090,6 @@ pub fn server_with_connection<T: LspContext>(
     let supports_dynamic_watched_files = watched_files_caps
         .and_then(|caps| caps.dynamic_registration)
         .unwrap_or(false);
-    let supports_relative_watch_patterns = watched_files_caps
-        .and_then(|caps| caps.relative_pattern_support)
-        .unwrap_or(false);
 
     Backend {
         connection,
@@ -2215,11 +2098,7 @@ pub fn server_with_connection<T: LspContext>(
         open_documents: RwLock::default(),
         published_diagnostics_by_origin: RwLock::default(),
         last_emitted_netlist_payloads: RwLock::default(),
-        watched_file_paths: RwLock::default(),
-        watched_file_registration_id: RwLock::default(),
-        next_server_request_seq: AtomicU64::new(1),
         supports_dynamic_watched_files,
-        supports_relative_watch_patterns,
     }
     .main_loop(initialization_params, started_at)?;
 
@@ -3597,7 +3476,7 @@ mod tests {
         assert_eq!(messages[2], "Workspace roots: none");
         assert_eq!(
             messages[3],
-            "Startup mode: workspace preload=enabled, dynamic file watching=unsupported, relative watch patterns=unsupported"
+            "Startup mode: workspace preload=enabled, dynamic file watching=unsupported"
         );
         Ok(())
     }

--- a/crates/pcb-starlark-lsp/src/server.rs
+++ b/crates/pcb-starlark-lsp/src/server.rs
@@ -578,10 +578,14 @@ fn coalesce_watched_file_changes(
 ) -> DidChangeWatchedFilesParams {
     // Stdio uses a zero-capacity channel: give its reader a brief chance to
     // hand over the next event. Requests and other messages remain barriers.
-    while let Ok(message) = connection
-        .receiver
-        .recv_timeout(std::time::Duration::from_millis(1))
-    {
+    // Limit each batch to 256 notifications so continuous events still refresh.
+    for _ in 1..256 {
+        let Ok(message) = connection
+            .receiver
+            .recv_timeout(std::time::Duration::from_millis(1))
+        else {
+            break;
+        };
         if let Message::Notification(notification) = &message
             && notification.method == DidChangeWatchedFiles::METHOD
             && let Ok(next) =
@@ -1786,6 +1790,8 @@ impl<T: LspContext> Backend<T> {
 
         // Watch symbols before evaluation: a failed component must still observe
         // the symbol edit that fixes it, even when no schematic was produced.
+        // String globs are workspace-scoped. Add editable external libraries to
+        // the editor workspace to receive their changes too.
         let kind = Some(WatchKind::Create | WatchKind::Change | WatchKind::Delete);
         self.connection
             .sender
@@ -2327,6 +2333,36 @@ mod tests {
             assert_eq!(unchanged.changes, result.changes);
             assert!(pending.is_empty());
         }
+        Ok(())
+    }
+
+    #[test]
+    fn file_event_batches_are_bounded_without_dropping_the_remainder() -> anyhow::Result<()> {
+        let (client, server) = lsp_server::Connection::memory();
+        let params = |index| lsp_types::DidChangeWatchedFilesParams {
+            changes: vec![FileEvent {
+                uri: protocol_uri(&temp_file_uri(&format!("{index}.kicad_sym"))),
+                typ: FileChangeType::CHANGED,
+            }],
+        };
+        for index in 1..=256 {
+            client
+                .sender
+                .send(lsp_server::Message::Notification(new_notification::<
+                    lsp_types::notification::DidChangeWatchedFiles,
+                >(params(
+                    index,
+                ))))?;
+        }
+        let mut pending = std::collections::VecDeque::new();
+        let result = super::coalesce_watched_file_changes(&server, params(0), &mut pending);
+        let expected: Vec<_> = (0..256).flat_map(|index| params(index).changes).collect();
+        assert_eq!(result.changes, expected);
+        assert!(pending.is_empty());
+        let lsp_server::Message::Notification(remainder) = server.receiver.try_recv()? else {
+            panic!("expected the next batch's notification");
+        };
+        assert_eq!(remainder.params, serde_json::to_value(params(256))?);
         Ok(())
     }
 

--- a/crates/pcb-zen/src/lsp/mod.rs
+++ b/crates/pcb-zen/src/lsp/mod.rs
@@ -21,7 +21,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 use serde_json::json;
 use starlark::docs::DocModule;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use url::Url;
@@ -62,7 +62,7 @@ pub struct LspEvalContext {
     resolution_cache: RwLock<HashMap<PathBuf, Arc<ResolutionResult>>>,
     workspace_root_cache: RwLock<HashMap<PathBuf, PathBuf>>,
     open_files: Arc<RwLock<HashMap<PathBuf, String>>>,
-    netlist_subscriptions: Arc<RwLock<HashMap<PathBuf, NetlistSubscription>>>,
+    netlist_subscriptions: Arc<RwLock<HashMap<PathBuf, HashMap<String, JsonValue>>>>,
     /// Per-file cache of the schematic computed right after evaluation, before
     /// the shared session module tree can be contaminated by other files.
     last_schematics: Arc<RwLock<HashMap<PathBuf, pcb_sch::Schematic>>>,
@@ -73,12 +73,6 @@ pub struct LspEvalContext {
 type CustomRequestHandler =
     dyn Fn(&str, &JsonValue) -> anyhow::Result<Option<JsonValue>> + Send + Sync;
 type SchematicHydrator = dyn Fn(&Path, &mut pcb_sch::Schematic) + Send + Sync;
-
-#[derive(Default)]
-struct NetlistSubscription {
-    inputs: HashMap<String, JsonValue>,
-    symbol_watch_paths: HashSet<PathBuf>,
-}
 
 struct OverlayFileProvider {
     base: Arc<dyn FileProvider>,
@@ -322,27 +316,7 @@ impl LspEvalContext {
         self.netlist_subscriptions
             .write()
             .unwrap()
-            .entry(key)
-            .or_default()
-            .inputs = inputs.clone();
-    }
-
-    fn set_symbol_watch_paths_for_netlist(&self, path: &Path, watched_paths: HashSet<PathBuf>) {
-        let key = self.normalize_path(path);
-        if let Some(subscription) = self.netlist_subscriptions.write().unwrap().get_mut(&key) {
-            subscription.symbol_watch_paths = watched_paths;
-        }
-    }
-
-    fn watched_symbol_paths(&self) -> Vec<PathBuf> {
-        let mut watched_paths = HashSet::new();
-        for subscription in self.netlist_subscriptions.read().unwrap().values() {
-            watched_paths.extend(subscription.symbol_watch_paths.iter().cloned());
-        }
-
-        let mut watched_paths: Vec<PathBuf> = watched_paths.into_iter().collect();
-        watched_paths.sort();
-        watched_paths
+            .insert(key, inputs.clone());
     }
 
     fn get_netlist_inputs(&self, path: &Path) -> Option<HashMap<String, JsonValue>> {
@@ -351,7 +325,7 @@ impl LspEvalContext {
             .read()
             .unwrap()
             .get(&key)
-            .map(|subscription| subscription.inputs.clone())
+            .cloned()
     }
 
     fn set_last_schematic(&self, path: &Path, schematic: pcb_sch::Schematic) {
@@ -367,46 +341,6 @@ impl LspEvalContext {
     fn clear_last_schematic(&self, path: &Path) {
         let key = self.normalize_path(path);
         self.last_schematics.write().unwrap().remove(&key);
-    }
-
-    fn maybe_update_symbol_watch_paths_from_response(
-        &self,
-        source_path: &Path,
-        response: &ZenerEvaluateResponse,
-    ) {
-        let Some(schematic) = &response.schematic else {
-            return;
-        };
-
-        let mut raw_symbol_paths = HashSet::new();
-        collect_symbol_paths(schematic, &mut raw_symbol_paths);
-        let watched_paths: HashSet<PathBuf> = raw_symbol_paths
-            .into_iter()
-            .filter_map(|raw_path| self.resolve_symbol_watch_path(source_path, &raw_path))
-            .collect();
-        self.set_symbol_watch_paths_for_netlist(source_path, watched_paths);
-    }
-
-    fn resolve_symbol_watch_path(&self, source_path: &Path, raw_path: &str) -> Option<PathBuf> {
-        if !raw_path.to_ascii_lowercase().ends_with(".kicad_sym") {
-            return None;
-        }
-
-        if Path::new(raw_path).is_absolute() {
-            return Some(PathBuf::from(raw_path));
-        }
-
-        if raw_path.starts_with(pcb_sch::PACKAGE_URI_PREFIX) {
-            return self
-                .resolution_for(source_path)
-                .resolve_package_uri(raw_path)
-                .ok();
-        }
-
-        self.config_for(source_path)
-            .resolve_path(raw_path, source_path)
-            .ok()
-            .filter(|resolved| is_kicad_symbol_file(resolved.extension()))
     }
 
     fn evaluate_with_inputs(
@@ -819,7 +753,6 @@ impl LspContext for LspEvalContext {
         let response = self
             .evaluate_with_inputs(path, &inputs)
             .map_err(|error| format!("{error:#}"))?;
-        self.maybe_update_symbol_watch_paths_from_response(path, &response);
         let params = ZenerNetlistUpdateParams {
             uri: uri.clone(),
             result: response,
@@ -832,10 +765,6 @@ impl LspContext for LspEvalContext {
         serde_json::to_value(params)
             .map(Some)
             .map_err(|error| error.to_string())
-    }
-
-    fn watched_file_paths(&self) -> Vec<PathBuf> {
-        self.watched_symbol_paths()
     }
 
     fn parse_file_with_contents(&self, uri: &LspUri, content: String) -> LspEvalResult {
@@ -1384,7 +1313,6 @@ impl LspEvalContext {
 
         let response = self.evaluate_with_inputs(path_buf, &params.inputs)?;
         self.set_netlist_subscription(path_buf, &params.inputs);
-        self.maybe_update_symbol_watch_paths_from_response(path_buf, &response);
         Ok(response)
     }
 }
@@ -1399,36 +1327,6 @@ fn position_edit_result_to_response(
             id,
             response_result: Err(error),
         },
-    }
-}
-
-fn collect_symbol_paths(value: &JsonValue, out: &mut HashSet<String>) {
-    match value {
-        JsonValue::Object(object) => {
-            if let Some(symbol_path_value) = object.get(pcb_zen_core::attrs::SYMBOL_PATH) {
-                match symbol_path_value {
-                    JsonValue::String(path) => {
-                        out.insert(path.clone());
-                    }
-                    JsonValue::Object(path_object) => {
-                        if let Some(JsonValue::String(path)) = path_object.get("String") {
-                            out.insert(path.clone());
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            for child in object.values() {
-                collect_symbol_paths(child, out);
-            }
-        }
-        JsonValue::Array(array) => {
-            for child in array {
-                collect_symbol_paths(child, out);
-            }
-        }
-        _ => {}
     }
 }
 
@@ -1567,25 +1465,147 @@ mod tests {
     use starlark::analysis::EvalSeverity;
     use starlark::codemap::ResolvedSpan;
     use std::collections::HashMap;
-    use std::collections::HashSet;
     use std::fs;
     use std::path::Path;
 
     #[test]
-    fn closing_document_removes_netlist_subscription_and_symbol_watches() {
+    fn closing_document_removes_netlist_subscription() {
         let ctx = LspEvalContext::default();
         let path = std::env::temp_dir().join("subscribed.zen");
         let uri = LspUri::File(path.clone());
-        let symbol_path = std::env::temp_dir().join("symbols.kicad_sym");
 
         ctx.set_netlist_subscription(&path, &HashMap::new());
-        ctx.set_symbol_watch_paths_for_netlist(&path, HashSet::from([symbol_path.clone()]));
-        assert_eq!(ctx.watched_symbol_paths(), vec![symbol_path]);
+        assert_eq!(ctx.get_netlist_inputs(&path), Some(HashMap::new()));
 
         ctx.did_close_file(&uri);
 
         assert_eq!(ctx.get_netlist_inputs(&path), None);
-        assert!(ctx.watched_symbol_paths().is_empty());
+    }
+
+    #[test]
+    fn symbol_watch_recovers_failed_evaluation_without_reopening_document() -> anyhow::Result<()> {
+        use lsp_server::{Connection, Message};
+        use std::time::Duration;
+
+        let dir = tempfile::tempdir()?;
+        let root = dir.path().canonicalize()?;
+        let source_path = root.join("main.zen");
+        let symbol_path = root.join("Part.kicad_sym");
+        let uri = url::Url::from_file_path(&source_path).unwrap().to_string();
+        let symbol_uri = url::Url::from_file_path(&symbol_path).unwrap().to_string();
+        let source = r#"Component(
+    name = "U1", skip_bom = True,
+    symbol = Symbol(library = "Part.kicad_sym", name = "Part"),
+    pins = {"P": builtin.net_type("Net")("N")},
+)
+"#;
+        let symbol = r#"(kicad_symbol_lib (version 20211014) (generator kicad_symbol_editor)
+  (symbol "Part" (in_bom yes) (on_board yes)
+    (property "Reference" "U" (at 0 0 0))
+    (property "Footprint" "Part" (at 0 0 0))
+    (symbol "Part_1_1"
+      (pin passive line (at 0 0 0) (length 2.54)
+        (name "P" (effects (font (size 1.27 1.27))))
+        (number "1" (effects (font (size 1.27 1.27))))))))
+"#;
+        fs::write(
+            root.join("pcb.toml"),
+            "[workspace]\npcb-version = \"0.4\"\n",
+        )?;
+        fs::write(&source_path, source)?;
+        fs::write(
+            &symbol_path,
+            symbol.replace("\"Footprint\" \"Part\"", "\"Footprint\" \"Part.kicad_mod\""),
+        )?;
+        fs::write(
+            root.join("Part.kicad_mod"),
+            r#"(footprint "Part"
+  (version 20240108) (generator "pcbnew") (layer "F.Cu")
+  (pad "1" smd rect (at 0 0) (size 1 1) (layers "F.Cu" "F.Paste" "F.Mask")))"#,
+        )?;
+
+        let (client, server) = Connection::memory();
+        let thread = std::thread::spawn(move || {
+            super::server::server_with_connection(
+                server,
+                LspEvalContext::default().set_offline(true),
+            )
+        });
+        let send = |value| -> anyhow::Result<()> {
+            client
+                .sender
+                .send(serde_json::from_value::<Message>(value)?)?;
+            Ok(())
+        };
+        let receive =
+            |field: &str, expected: serde_json::Value| -> anyhow::Result<serde_json::Value> {
+                loop {
+                    let message = client.receiver.recv_timeout(Duration::from_secs(10))?;
+                    let value = serde_json::to_value(message)?;
+                    if value[field] == expected {
+                        return Ok(value);
+                    }
+                }
+            };
+        send(json!({"id": 1, "method": "initialize", "params": {
+            "rootUri": url::Url::from_directory_path(&root).unwrap().as_str(),
+            "capabilities": {"workspace": {"didChangeWatchedFiles": {"dynamicRegistration": true}}}
+        }}))?;
+        receive("id", json!(1))?;
+        send(json!({"method": "initialized", "params": {}}))?;
+        let registration = receive("method", json!("client/registerCapability"))?;
+        let watchers = &registration["params"]["registrations"][0]["registerOptions"]["watchers"];
+        // These watches must exist before the first evaluation, and include
+        // creation/deletion so missing or recreated symbols can recover too.
+        assert_eq!(
+            watchers,
+            &json!([
+                {"globPattern": "**/pcb.toml", "kind": 7},
+                {"globPattern": "**/*.kicad_sym", "kind": 7}
+            ])
+        );
+        send(json!({"id": registration["id"], "result": null}))?;
+        send(
+            json!({"method": "textDocument/didOpen", "params": {"textDocument": {
+                "uri": uri, "languageId": "starlark", "version": 1, "text": source
+            }}}),
+        )?;
+        send(json!({"id": 2, "method": "zener/evaluate", "params": {"uri": uri, "inputs": {}}}))?;
+        let failed = receive("id", json!(2))?;
+        assert_eq!(failed["result"]["success"], false, "{failed}");
+        assert!(
+            failed["result"]["diagnostics"]
+                .to_string()
+                .contains("Part.kicad_mod.kicad_mod"),
+            "{failed}"
+        );
+
+        // Only the dependency changes; the open .zen buffer and subscription
+        // stay unchanged. Watch notifications must push fresh netlists.
+        for (change_type, success) in [(2, true), (3, false), (1, true)] {
+            if change_type == 3 {
+                fs::remove_file(&symbol_path)?;
+            } else {
+                fs::write(&symbol_path, symbol)?;
+            }
+            send(
+                json!({"method": "workspace/didChangeWatchedFiles", "params": {"changes": [
+                    {"uri": symbol_uri, "type": change_type}
+                ]}}),
+            )?;
+            let update = receive("method", json!("zener/netlistUpdated"))?;
+            assert_eq!(update["params"]["uri"], uri);
+            assert_eq!(update["params"]["result"]["success"], success, "{update}");
+            if success {
+                assert_eq!(update["params"]["result"]["diagnostics"], json!([]));
+            }
+        }
+
+        send(json!({"id": 3, "method": "shutdown", "params": null}))?;
+        receive("id", json!(3))?;
+        send(json!({"method": "exit", "params": null}))?;
+        thread.join().unwrap()?;
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
Register workspace symbol watches at startup and remove per-document watch tracking to fix ENG-1500. Coalesce adjacent file changes with a 1 ms read-ahead; release-build registry testing reduces 100 separate notifications from 4.57 seconds to 55 ms, and all 161 release-mode tests pass. Automatic refresh for editable libraries outside the client workspace remains unverified.