### PR TITLE
Preserve native KiCad fiducial and bare test-point metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Mark standard-library fiducial pads as global fiducials in KiCad layouts.
 - Preserve curves that continue after a closed subpath during polygon preparation.
 - Require experimental tab anchors and witnesses to be resolved interior points of the original regions.
 - Reject experimental tab perforations that overlap support or lack resolved clearance from it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Mark standard-library bare test pads and plated test holes as native KiCad test points.
 - Mark standard-library fiducial pads as global fiducials in KiCad layouts.
 - Preserve curves that continue after a closed subpath during polygon preparation.
 - Require experimental tab anchors and witnesses to be resolved interior points of the original regions.

--- a/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_0.5mm_Mask1.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_0.5mm_Mask1.5mm.kicad_mod
@@ -71,6 +71,7 @@
 		(at 0 0)
 		(size 0.5 0.5)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(solder_mask_margin 0.5)
 		(clearance 0.6)
 	)

--- a/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_0.5mm_Mask1mm.kicad_mod
+++ b/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_0.5mm_Mask1mm.kicad_mod
@@ -71,6 +71,7 @@
 		(at 0 0)
 		(size 0.5 0.5)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(solder_mask_margin 0.25)
 		(clearance 0.35)
 	)

--- a/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_0.75mm_Mask1.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_0.75mm_Mask1.5mm.kicad_mod
@@ -71,6 +71,7 @@
 		(at 0 0)
 		(size 0.75 0.75)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(solder_mask_margin 0.375)
 		(clearance 0.475)
 	)

--- a/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_0.75mm_Mask2.25mm.kicad_mod
+++ b/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_0.75mm_Mask2.25mm.kicad_mod
@@ -71,6 +71,7 @@
 		(at 0 0)
 		(size 0.75 0.75)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(solder_mask_margin 0.75)
 		(clearance 0.85)
 	)

--- a/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_1.5mm_Mask3mm.kicad_mod
+++ b/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_1.5mm_Mask3mm.kicad_mod
@@ -71,6 +71,7 @@
 		(at 0 0)
 		(size 1.5 1.5)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(solder_mask_margin 0.75)
 		(clearance 0.85)
 	)

--- a/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_1.5mm_Mask4.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_1.5mm_Mask4.5mm.kicad_mod
@@ -71,6 +71,7 @@
 		(at 0 0)
 		(size 1.5 1.5)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(solder_mask_margin 1.5)
 		(clearance 1.6)
 	)

--- a/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_1mm_Mask2mm.kicad_mod
+++ b/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_1mm_Mask2mm.kicad_mod
@@ -71,6 +71,7 @@
 		(at 0 0)
 		(size 1 1)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(solder_mask_margin 0.5)
 		(clearance 0.6)
 	)

--- a/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_1mm_Mask3mm.kicad_mod
+++ b/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_1mm_Mask3mm.kicad_mod
@@ -71,6 +71,7 @@
 		(at 0 0)
 		(size 1 1)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(solder_mask_margin 1)
 		(clearance 1.1)
 	)

--- a/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_Cross_1.5mm_Mask2mm.kicad_mod
+++ b/lib/std/kicad-footprints/Fiducial.pretty/Fiducial_Cross_1.5mm_Mask2mm.kicad_mod
@@ -71,6 +71,7 @@
 		(at 0 0)
 		(size 0.25 0.25)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(solder_mask_margin 0.875)
 		(clearance 0.975)
 	)
@@ -78,6 +79,7 @@
 		(at 0 0)
 		(size 0.25 0.25)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_fiducial_glob)
 		(options
 			(clearance outline)
 			(anchor circle)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_ICT.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_ICT.kicad_mod
@@ -92,6 +92,7 @@
 		(at 0 0)
 		(size 1 1)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "dc163b13-3996-5ab5-a562-90ba25935229")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_1.0x1.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_1.0x1.0mm.kicad_mod
@@ -150,6 +150,7 @@
 		(at 0 0)
 		(size 1 1)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "c7a53b80-2670-4411-8770-45df62759000")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_1.5x1.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_1.5x1.5mm.kicad_mod
@@ -150,6 +150,7 @@
 		(at 0 0)
 		(size 1.5 1.5)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "e5642a5f-309a-4ecd-bf25-2a009f38b2c6")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_2.0x2.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_2.0x2.0mm.kicad_mod
@@ -150,6 +150,7 @@
 		(at 0 0)
 		(size 2 2)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "fe8ce89d-a8a3-4dc0-8bc8-0e7ade183b61")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_2.5x2.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_2.5x2.5mm.kicad_mod
@@ -150,6 +150,7 @@
 		(at 0 0)
 		(size 2.5 2.5)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "b11b67ec-9c15-43e0-b865-46b16298f9a9")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_3.0x3.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_3.0x3.0mm.kicad_mod
@@ -150,6 +150,7 @@
 		(at 0 0)
 		(size 3 3)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "4c71b9bb-be46-454d-a6f7-e76ef8e43736")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_4.0x4.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_4.0x4.0mm.kicad_mod
@@ -150,6 +150,7 @@
 		(at 0 0)
 		(size 4 4)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "43827c83-1685-422b-a4da-6da706d0d8fe")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D1.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D1.0mm.kicad_mod
@@ -92,6 +92,7 @@
 		(at 0 0)
 		(size 1 1)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "bab732e9-e79a-410d-8a2b-e7d9e8d299bb")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D1.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D1.5mm.kicad_mod
@@ -92,6 +92,7 @@
 		(at 0 0)
 		(size 1.5 1.5)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "8a03cd79-fadf-4c81-9b59-724c470e191a")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D2.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D2.0mm.kicad_mod
@@ -92,6 +92,7 @@
 		(at 0 0)
 		(size 2 2)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "66dd818e-46c3-4cc6-8165-861578cda9d2")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D2.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D2.5mm.kicad_mod
@@ -92,6 +92,7 @@
 		(at 0 0)
 		(size 2.5 2.5)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "197dbe30-be8e-4a1d-bec3-2484ff4b9b67")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D3.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D3.0mm.kicad_mod
@@ -92,6 +92,7 @@
 		(at 0 0)
 		(size 3 3)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "574d0af7-7c3d-487a-b8a3-151bbe335c9b")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D4.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Pad_D4.0mm.kicad_mod
@@ -92,6 +92,7 @@
 		(at 0 0)
 		(size 4 4)
 		(layers "F.Cu" "F.Mask")
+		(property pad_prop_testpoint)
 		(uuid "0572d10f-fccc-4a2c-8c9b-3e84c3068dc0")
 	)
 	(embedded_fonts no)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Plated_Hole_D2.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Plated_Hole_D2.0mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 3 3)
 		(drill 2)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "936e6bac-0238-4c98-a76c-2557e8ed141f")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Plated_Hole_D3.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Plated_Hole_D3.0mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 4 4)
 		(drill 3)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "09407444-9845-4c19-b12c-3dce0705f8ed")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Plated_Hole_D4.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Plated_Hole_D4.0mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 5 5)
 		(drill 4)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "e7f0837b-66ed-4ca0-8cad-53cea8e84e78")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Plated_Hole_D5.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_Plated_Hole_D5.0mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 6 6)
 		(drill 5)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "c2038118-c25d-4536-bf57-72f2a80f2185")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_1.0x1.0mm_Drill0.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_1.0x1.0mm_Drill0.5mm.kicad_mod
@@ -151,6 +151,7 @@
 		(size 1 1)
 		(drill 0.5)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "a7db0445-5907-4c33-b453-1bc5a8ee576a")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_1.5x1.5mm_Drill0.7mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_1.5x1.5mm_Drill0.7mm.kicad_mod
@@ -151,6 +151,7 @@
 		(size 1.5 1.5)
 		(drill 0.7)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "82de9b62-46f0-4453-8901-7f3bad47a7a7")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_2.0x2.0mm_Drill1.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_2.0x2.0mm_Drill1.0mm.kicad_mod
@@ -151,6 +151,7 @@
 		(size 2 2)
 		(drill 1)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "4c0db315-c5e6-4b9a-8e7e-fcc8fc5d5da2")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_2.5x2.5mm_Drill1.2mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_2.5x2.5mm_Drill1.2mm.kicad_mod
@@ -151,6 +151,7 @@
 		(size 2.5 2.5)
 		(drill 1.2)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "e05bc3cf-b2bc-46d6-9b92-9d0512ee0465")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_3.0x3.0mm_Drill1.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_3.0x3.0mm_Drill1.5mm.kicad_mod
@@ -151,6 +151,7 @@
 		(size 3 3)
 		(drill 1.5)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "52588805-7bcd-4b54-b27e-5cc9ed181ca1")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_4.0x4.0mm_Drill2.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_4.0x4.0mm_Drill2.0mm.kicad_mod
@@ -151,6 +151,7 @@
 		(size 4 4)
 		(drill 2)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "b072fcff-ad17-410c-820c-f12dc48dc3aa")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D1.0mm_Drill0.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D1.0mm_Drill0.5mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 1 1)
 		(drill 0.5)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "8e467c9f-6e54-4e17-913d-8a170d878962")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D1.5mm_Drill0.7mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D1.5mm_Drill0.7mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 1.5 1.5)
 		(drill 0.7)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "d4c59acd-c0ea-4830-8b44-6dc762ed1a14")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D2.0mm_Drill1.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D2.0mm_Drill1.0mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 2 2)
 		(drill 1)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "89e425b7-7ac9-4512-ba98-94aa32b4624a")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D2.5mm_Drill1.2mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D2.5mm_Drill1.2mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 2.5 2.5)
 		(drill 1.2)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "3a80aa7f-2be2-4706-bf64-f991edd9504b")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D3.0mm_Drill1.5mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D3.0mm_Drill1.5mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 3 3)
 		(drill 1.5)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "2a1ad79e-a81e-4dca-8e65-42ebcbbafc64")
 	)

--- a/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D4.0mm_Drill2.0mm.kicad_mod
+++ b/lib/std/kicad-footprints/TestPoint.pretty/TestPoint_THTPad_D4.0mm_Drill2.0mm.kicad_mod
@@ -93,6 +93,7 @@
 		(size 4 4)
 		(drill 2)
 		(layers "*.Cu" "*.Mask")
+		(property pad_prop_testpoint)
 		(remove_unused_layers no)
 		(uuid "14196f45-7632-4497-ad05-5876deb10a71")
 	)


### PR DESCRIPTION
Add native KiCad pad properties to standard-library global fiducials and bare test points so generated layouts retain their fabrication roles. Keep geometry, installed test-point hardware, and BOM and position settings unchanged. This addresses the source-library portion of ENG-1487; IPC-2581 export support remains separate.