### PR TITLE
fix(schematic): reconnect all nets on relocated symbols (ENG-1503)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Reconnect all affected nets when schematic repair moves symbols out of a short.
 - Preserve curves that continue after a closed subpath during polygon preparation.
 - Require experimental tab anchors and witnesses to be resolved interior points of the original regions.
 - Reject experimental tab perforations that overlap support or lack resolved clearance from it.

--- a/crates/pcb-kicad-sch/src/connectivity/kicad.rs
+++ b/crates/pcb-kicad-sch/src/connectivity/kicad.rs
@@ -74,6 +74,10 @@ impl PhysicalPinRef {
             point: point.into(),
         }
     }
+
+    pub(crate) fn is_on_symbol(&self, location: &SymbolLocation) -> bool {
+        self.page_id == location.page_id && self.symbol_id == location.symbol_id
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/crates/pcb-kicad-sch/src/repair.rs
+++ b/crates/pcb-kicad-sch/src/repair.rs
@@ -309,6 +309,16 @@ pub(crate) fn plan_connectivity_repair_core(
             }
             for location in locations {
                 if relocate_symbols.insert(location.clone()) {
+                    // Relocation detaches every pin, not just the pin in the
+                    // short. Rebuild the other nets that were valid before
+                    // repair as well, using the original physical provenance.
+                    for island in observed
+                        .islands
+                        .values()
+                        .filter(|island| island.pins.iter().any(|pin| pin.is_on_symbol(&location)))
+                    {
+                        reconnect_nets.extend(expected_names_for_island(expected, island));
+                    }
                     remove_items(
                         &mut simulated,
                         &BTreeSet::from([ConnectivityItemRef::Symbol {

--- a/crates/pcb-kicad-sch/tests/issue_repair.rs
+++ b/crates/pcb-kicad-sch/tests/issue_repair.rs
@@ -202,6 +202,82 @@ fn complete_reconciliation_recovers_from_invalid_initial_analysis() {
 }
 
 #[test]
+fn relocating_shorted_symbols_reconnects_their_other_nets() {
+    let netlist = common::compile_fixture("analysis", "simple.zen");
+    let mut document = plan_reconciliation(None, &netlist, "simple.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    // Touch only R1's LEFT pin to R2's RIGHT pin. Their other pins carry
+    // MID, which is valid before repair and must survive moving the symbols.
+    document.pages[0]
+        .items
+        .retain(|item| matches!(item, SchItem::Symbol(_)));
+    let target = common::pin_point(&document, "R1.R", "1");
+    let source = common::pin_point(&document, "R2.R", "2");
+    let symbol = managed_symbol_mut(&mut document, "R2.R");
+    let new_at = Point::new(
+        symbol.at.x + target.x - source.x,
+        symbol.at.y + target.y - source.y,
+    );
+    move_symbol(symbol, new_at);
+    for (path, pin, net) in [
+        ("R1.R", "1", "LEFT"),
+        ("R1.R", "2", "MID"),
+        ("R2.R", "1", "MID"),
+        ("R2.R", "2", "RIGHT"),
+    ] {
+        let point = common::pin_point(&document, path, pin);
+        document.pages[0]
+            .items
+            .push(SchItem::Label(pcb_kicad_sch::Label::new(
+                format!("{path}-{pin}"),
+                net,
+                point,
+            )));
+    }
+    let inspection = inspect_schematic(&document, &netlist).unwrap();
+    assert_eq!(inspection.issues.len(), 1, "{:#?}", inspection.issues);
+    let issue = &inspection.issues[0];
+    assert!(
+        matches!(&issue.issue, SchematicIssue::Shorted { net_names, .. }
+        if net_names == &BTreeSet::from(["LEFT".into(), "RIGHT".into()]))
+    );
+    let selected = BTreeSet::from([issue.key.clone()]);
+    let intent = plan_connectivity_repair(
+        &document,
+        &netlist,
+        &inspection,
+        &selected,
+        &BTreeSet::new(),
+    )
+    .unwrap();
+    assert!(!intent.relocated_symbols().is_empty());
+    assert_eq!(
+        intent.reconnect_nets(),
+        &BTreeSet::from(["LEFT".into(), "MID".into(), "RIGHT".into()])
+    );
+    assert!(intent.driver_kind("MID", &document.pages[0].id).is_some());
+
+    let plan = plan_reconciliation(Some(&document), &netlist, "simple.kicad_sch").unwrap();
+    let repaired = plan.apply(Some(&document)).unwrap();
+    assert!(
+        inspect_schematic(&repaired, &netlist)
+            .unwrap()
+            .analysis
+            .is_equivalent()
+    );
+    assert_eq!(plan.revert(&repaired).unwrap(), document);
+    let scoped = plan_repairs(&document, &netlist, &inspection, selected)
+        .unwrap()
+        .apply(Some(&document))
+        .unwrap();
+    assert_eq!(scoped, repaired);
+    pcb_kicad_sch::verify_connectivity_repair(&document, &inspection, &netlist, &intent, &scoped)
+        .unwrap();
+}
+
+#[test]
 fn directly_overlapping_component_pins_relocate_the_affected_symbols() {
     let netlist = common::compile_fixture("analysis", "simple.zen");
     let mut document = plan_reconciliation(None, &netlist, "simple.kicad_sch")


### PR DESCRIPTION
## Problem
Repairing a short can relocate a symbol and disconnect its otherwise-valid pins. The repair plan previously rebuilt only the nets involved in the short, so repairing the Albatross TEMP_ADC/GND merge introduced an M2.NSLEEP split and caused pcb apply to fail.

## Fix
Use the original physical pin provenance to reconnect every affected net on each relocated symbol. Add a regression covering complete and selected repairs, reversibility, and preservation of the previously-valid third net.

## Validation
- Regression failed before the fix and passes afterward.
- cargo nextest run -p pcb-kicad-sch: 196 tests passed; rerun after rebasing onto main.
- Scoped Clippy, formatting, and doctests passed before rebase.
- Built CLI repaired the original broken Albatross export; independent KiCad netlist comparison found 202/202 connectivity partitions correct, with zero mismatches.
- Second apply reported schematic unchanged.

Connectivity is repaired; this does not claim ERC-clean output. KiCad still reports library/annotation warnings and one dangling old NSLEEP label.

Related: ENG-1503. The diode editor fix prevents the original auto-placement overlap; this change repairs existing affected schematics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes KiCad schematic connectivity repair planning, which can affect `pcb apply schematic` outcomes on broken exports; scope is narrow and covered by a targeted regression test.
> 
> **Overview**
> **Schematic short repair** no longer leaves valid nets broken when it **relocates symbols** to break an overlap. Relocation detaches every pin on the symbol, not only the pins in the short; the repair planner now queues **reconnection for every net** that touched those pins in the **pre-repair** connectivity graph, not just the shorted net names.
> 
> Implementation adds **`PhysicalPinRef::is_on_symbol`** and, in **`plan_connectivity_repair`**, walks original **`observed`** islands for each new relocation target and extends **`reconnect_nets`** via **`expected_names_for_island`**. A regression test asserts **`LEFT`**, **`MID`**, and **`RIGHT`** are all scheduled when overlapping pins short **`LEFT`**/`**RIGHT**` while **`MID`** was fine beforehand, including full apply, revert, and **`verify_connectivity_repair`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab9c545586c1c6f230aa6153a985411c6fa2d07b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Companion editor prevention fix: https://github.com/diodeinc/diode/pull/2881