### PR TITLE
fix(sim): handle bare source filenames (ENG-1527)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Run ngspice correctly when `pcb sim` is given a bare filename in the current directory.
 - Reconnect all affected nets when schematic repair moves symbols out of a short.
 - Refresh stale schematics when workspace symbol files change.
 - Mark standard-library bare test pads and plated test holes as native KiCad test points.

--- a/crates/pcbc/src/sim.rs
+++ b/crates/pcbc/src/sim.rs
@@ -119,7 +119,10 @@ fn simulate_one(
     }
 
     // Write .cir next to the zen file so ngspice resolves relative paths correctly
-    let zen_dir = zen_path.parent().unwrap_or(std::path::Path::new("."));
+    let zen_dir = zen_path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or(std::path::Path::new("."));
     let mut tmp = tempfile::Builder::new()
         .suffix(".cir")
         .tempfile_in(zen_dir)?;

--- a/crates/pcbc/tests/integration.rs
+++ b/crates/pcbc/tests/integration.rs
@@ -21,6 +21,7 @@ mod path;
 mod release;
 mod schematic_apply_common;
 mod schematic_apply_flow;
+mod sim;
 mod simple;
 mod sync;
 mod tag;

--- a/crates/pcbc/tests/sim.rs
+++ b/crates/pcbc/tests/sim.rs
@@ -1,0 +1,56 @@
+#![cfg(unix)]
+
+use pcb_test_utils::sandbox::Sandbox;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+
+#[test]
+fn sim_runs_ngspice_in_source_directory() {
+    let mut sandbox = Sandbox::new().with_workspace();
+    let source = r#"
+builtin.set_sim_setup(content="V1 vin 0 DC 5\nR1 vin 0 1000\n.op\n.end\n")
+"#;
+    sandbox
+        .write("bench.zen", source)
+        .write("nested/bench.zen", source)
+        .write(
+            "ngspice",
+            r#"#!/bin/sh
+set -eu
+if [ "$1" = "--version" ]; then
+    exit 0
+fi
+test "$#" -eq 2
+test "$1" = "-b"
+grep -q '^R1 vin 0 1000$' "$2"
+printf 'ngspice workdir: '
+pwd -P
+"#,
+        );
+    let ngspice = sandbox.root_path().join("ngspice");
+    fs::set_permissions(&ngspice, fs::Permissions::from_mode(0o755)).unwrap();
+    sandbox.env("NGSPICE", ngspice.to_str().unwrap());
+
+    let root = sandbox.root_path().canonicalize().unwrap();
+    let absolute_source = root.join("bench.zen");
+    for (path, expected_dir) in [
+        ("bench.zen", root.clone()),
+        ("./bench.zen", root.clone()),
+        (absolute_source.to_str().unwrap(), root.clone()),
+        ("nested/bench.zen", root.join("nested")),
+    ] {
+        let output = sandbox
+            .run("pcbc", ["sim", "--offline", "--verbose", path])
+            .stdout_capture()
+            .stderr_capture()
+            .unchecked()
+            .run()
+            .expect("run pcb sim");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "pcb sim {path} failed: {stderr}");
+        assert!(
+            stderr.contains(&format!("ngspice workdir: {}\n", expected_dir.display())),
+            "pcb sim {path} used the wrong working directory: {stderr}"
+        );
+    }
+}


### PR DESCRIPTION
## Problem

Fixes [ENG-1527](https://linear.app/diodeinc/issue/ENG-1527).

For `pcb sim bench.zen`, `Path::parent()` returns `Some("")`, so the existing `unwrap_or(".")` fallback never applies. The ngspice installation check succeeds, but the simulation subprocess then attempts `chdir("")` and fails with ENOENT before executing ngspice. Installing ngspice or setting `NGSPICE` cannot fix this working-directory error.

## Fix

Treat an empty source parent as `.`. Preserve source-directory behavior for explicit relative and absolute paths. Add a Unix integration regression test covering bare filenames, `./` paths, absolute paths, and nested directories. The stand-in ngspice executable validates the batch arguments, generated netlist contents, and actual working directory without requiring ngspice in CI.

Sandbox packaging is unchanged; the missing ngspice executable in the image is a separate issue.

## Verification

- The new regression test failed before the fix with the exact reported spawn error and passed afterward.
- `cargo fmt --all --check` passed.
- `cargo nextest run -p pcbc --test integration -E "test(sim::) | test(netlist::) | test(build::)" --locked`: 54 passed.
- `cargo clippy -p pcbc --all-targets --locked -- -D warnings` passed.
- Rebuilt CLI with real ngspice 39: all four source-path forms passed; the 5 V source / 1 kΩ resistor circuit reported 5 V.
- No snapshot changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small path-resolution fix in `pcb sim` with a focused regression test; no auth, data, or broader simulation pipeline changes.
> 
> **Overview**
> **`pcb sim`** no longer fails when the source path is a bare filename in the current directory (e.g. `bench.zen`). Previously `Path::parent()` could yield an empty path, so ngspice was launched with an invalid working directory instead of `.`.
> 
> The sim command now treats an empty parent like `.` when placing the temporary `.cir` file and setting ngspice’s working directory, while keeping behavior for `./`, absolute, and nested paths unchanged. **CHANGELOG** documents the fix, and a **Unix integration test** uses a stub `NGSPICE` to assert the correct workdir and netlist for several path forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac0bde6755d25f32483895d7f920c9ac85dc464. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->