### PR TITLE
fix(dfm): measure widths on analytic boundary bisectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Run ngspice correctly when `pcb sim` is given a bare filename in the current directory.
 - Reconnect all affected nets when schematic repair moves symbols out of a short.
 - Refresh stale schematics when workspace symbol files change.
+- Require resolved opposing contacts for DFM width findings instead of sample-dependent disk pruning.
 - Mark standard-library bare test pads and plated test holes as native KiCad test points.
 - Mark standard-library fiducial pads as global fiducials in KiCad layouts.
 - Preserve curves that continue after a closed subpath during polygon preparation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Run ngspice correctly when `pcb sim` is given a bare filename in the current directory.
 - Reconnect all affected nets when schematic repair moves symbols out of a short.
 - Refresh stale schematics when workspace symbol files change.
-- Require resolved opposing contacts for DFM width findings instead of sample-dependent disk pruning.
+- Fix false DFM width violations at corners.
 - Mark standard-library bare test pads and plated test holes as native KiCad test points.
 - Mark standard-library fiducial pads as global fiducials in KiCad layouts.
 - Preserve curves that continue after a closed subpath during polygon preparation.

--- a/crates/pcb-ipc2581-tools/docs/dfm.md
+++ b/crates/pcb-ipc2581-tools/docs/dfm.md
@@ -213,15 +213,23 @@ thickness source. Witness separation does not encode the ratio.
 
 Morphological opening and closing are deliberately candidate stages for width
 and soldermask-web checks. Each candidate residue is measured on the medial
-axis of the boundary around it — the Voronoi diagram of the nearby boundary
-segments — as the diameter of its narrowest maximal inscribed disk. Disks
-tangent only to incident segments are corner spokes and carry no width, so
-one-sided residue (the bite an isolated corner sheds) measures nothing; disks
-that a larger disk contains within the flattening tolerance are branches the
-tessellation sprouted and are pruned, so a flattened arc measures its diameter
-while a tapered spur still measures its tip. Bounds and spatial indices have
-the same one-way contract: they can prove work unnecessary, but they cannot
-emit a finding without the exact geometric measurement.
+axis of the unsnapped prepared boundary, as an inscribed disk diameter. The
+checker constructs the analytic point/point, point/line, and line/line
+bisectors of nearby nonincident segments. Quadratic roots delimit valid
+contact domains, nearest-boundary intervals, residue crossings, and radius
+limits. Vertices and spans share this construction; no snap-grid repair,
+sample-dependent disk pruning, or angular tuning margin decides eligibility.
+The contacts must be equidistant, globally nearest, and strictly obtuse from
+the center beyond numerical roundoff. Endpoint normal cones exclude corner
+contacts shadowed by adjoining edges. The disk radius must exceed its recorded
+boundary uncertainty. The minimum and its evidence come from the same analytic
+axis; flattening is used only to draw it, not to measure it.
+This is a resolved-contact measurement of the prepared geometry, not a
+reconstruction of intended curves from an already polygonal input. Source
+boundary uncertainty contributes to scalar width, but does not bound contact
+direction or certify source-branch correspondence or topology. Bounds and
+spatial indices can prove work unnecessary, but cannot emit a finding without
+the geometric measurement.
 
 Copper-clearance ownership is retained through that same ordered artwork
 composition. Dark features add material to their owner; clears and final

--- a/crates/pcb-ir/src/geom/accuracy.rs
+++ b/crates/pcb-ir/src/geom/accuracy.rs
@@ -56,6 +56,8 @@
 //! rounding. Every operation checks the accumulated total against the
 //! region's budget and fails rather than return a region it cannot certify;
 //! combining regions prepared at different budgets takes the tighter one.
+//! This bounds positional error, not nearest-contact motion, normals, or
+//! correspondence between individual source and prepared boundary branches.
 //!
 //! The band is about the *source* boundary, not the boundary of the exactly
 //! composed set. Two source features that adjoin or overlap along a curve

--- a/crates/pcb-ir/src/geom/dfm.rs
+++ b/crates/pcb-ir/src/geom/dfm.rs
@@ -9,7 +9,6 @@ use crate::geom::{AccuracyError, Resolution};
 use std::collections::BTreeMap;
 
 use crate::geom::bbox::BBox;
-use crate::geom::dist;
 use crate::geom::grid::CellGrid;
 use crate::geom::point::Point;
 use crate::geom::region::{ContourSet, PreparedRegion, TwoSidedResidualComponent, ring_edges};
@@ -644,8 +643,8 @@ fn connected_line_groups(lines: &[(Point, Point)]) -> Vec<Vec<usize>> {
 pub struct ThinPiece {
     pub bbox: BBox,
     pub area_mm2: f64,
-    /// Exact separation of the two opposing source-boundary branches in the
-    /// flattened polygon representation; both branches count as flattened.
+    /// Minimum separation of the two opposing source-boundary branches,
+    /// carrying the uncertainty of both prepared boundaries.
     pub width: Distance,
     /// Approximate longitudinal extent (half the residue perimeter).
     pub length_mm: f64,
@@ -669,12 +668,13 @@ pub struct WidthDisk {
 pub struct ThinSite {
     pub bbox: BBox,
     pub disk: WidthDisk,
-    /// Cells of the verified medial axis. A zero-dimensional cell repeats
-    /// its point so vertices and spans share one representation.
+    /// Display polylines of the verified analytic medial-axis curves. A
+    /// zero-dimensional curve repeats its point so vertices and spans share
+    /// one representation; measurement does not use this flattening.
     pub axis: Vec<Vec<Point>>,
-    /// Actual source-boundary contacts along the verified axis. A vertex
-    /// contact is a zero-length segment; these also retain isolated disk
-    /// tangencies so occurrence attribution can prove the entire construction.
+    /// Source-boundary contact motion along the same analytic curves. A
+    /// vertex contact is a zero-length segment; these also retain isolated
+    /// disk tangencies so occurrence attribution can prove the construction.
     pub walls: Vec<(Point, Point)>,
 }
 
@@ -724,108 +724,43 @@ pub fn min_width_disk(region: &ContourSet) -> Result<Option<WidthDisk>, Accuracy
         .min_by(|left, right| left.width.mm.total_cmp(&right.width.mm)))
 }
 
-/// Convert the conservative opening/closing candidates into authoritative
-/// measurements. A candidate is reportable only when the exact distance
-/// between its opposing source-boundary branches is certainly below the
-/// requested minimum; this is what prevents offset tessellation from
-/// creating findings.
+/// Measure the retained analytic bisectors and their opposing source contacts.
+/// Only widths below the requested minimum beyond their scalar boundary
+/// uncertainty are reportable. This does not recover topology lost in
+/// preparation.
 fn pieces(components: Vec<TwoSidedResidualComponent>, minimum_mm: f64) -> Vec<ThinPiece> {
     let mut pieces = components
         .into_iter()
-        .filter(|component| component.width.certainly_below(minimum_mm))
         .filter_map(|component| {
             let narrow_axis = component
                 .axis
                 .iter()
                 .flat_map(|axis| {
-                    let reach = (minimum_mm
-                        - component.width.uncertainty_mm
-                        - 2.0 * axis.uncertainty_mm
-                        - 1e-6)
-                        / 2.0;
-                    if reach <= 0.0 {
+                    let reach = (minimum_mm - 2.0 * component.boundary_uncertainty_mm) / 2.0;
+                    let minimum_radius = component.boundary_uncertainty_mm.next_up();
+                    let maximum_radius = reach.next_down();
+                    if maximum_radius < minimum_radius {
                         return Vec::new();
                     }
-                    let first = segment_capsule_intervals(
-                        axis.start,
-                        axis.end,
-                        axis.first_wall.0,
-                        axis.first_wall.1,
-                        reach,
-                    );
-                    let second = segment_capsule_intervals(
-                        axis.start,
-                        axis.end,
-                        axis.second_wall.0,
-                        axis.second_wall.1,
-                        reach,
-                    );
-                    let delta = axis.end - axis.start;
-                    first
-                        .iter()
-                        .flat_map(|&first| {
-                            second
-                                .iter()
-                                .filter_map(move |&second| intersect_interval(first, second))
-                        })
-                        .map(|(start, end)| {
-                            let (start, end) =
-                                (axis.start + delta * start, axis.start + delta * end);
-                            let at = |t| start + (end - start) * t;
-                            let radius_at = |t| {
-                                let center = at(t);
-                                (dist::point_segment(center, axis.first_wall.0, axis.first_wall.1)
-                                    .0
-                                    + dist::point_segment(
-                                        center,
-                                        axis.second_wall.0,
-                                        axis.second_wall.1,
-                                    )
-                                    .0)
-                                    / 2.0
-                            };
-                            let (mut low, mut high) = (0.0, 1.0);
-                            for _ in 0..40 {
-                                let a = (2.0 * low + high) / 3.0;
-                                let b = (low + 2.0 * high) / 3.0;
-                                if radius_at(a) < radius_at(b) {
-                                    high = b;
-                                } else {
-                                    low = a;
-                                }
-                            }
-                            let t = [0.0, (low + high) / 2.0, 1.0]
-                                .into_iter()
-                                .min_by(|&a, &b| radius_at(a).total_cmp(&radius_at(b)))
-                                .unwrap();
-                            let center = at(t);
-                            let radius_mm = radius_at(t);
-                            let first =
-                                dist::point_segment(center, axis.first_wall.0, axis.first_wall.1).1;
-                            let second =
-                                dist::point_segment(center, axis.second_wall.0, axis.second_wall.1)
-                                    .1;
-                            let walls = [axis.first_wall, axis.second_wall].map(|(a, b)| {
-                                (
-                                    dist::point_segment(start, a, b).1,
-                                    dist::point_segment(end, a, b).1,
-                                )
-                            });
-                            let mut width = Distance::with_uncertainty(
+                    axis.clipped_radius(minimum_radius, maximum_radius)
+                        .into_iter()
+                        .map(|axis| {
+                            let (center, radius_mm, first, second) = axis.minimum();
+                            let width = Distance::with_uncertainty(
                                 2.0 * radius_mm,
                                 first,
                                 second,
-                                component.width.uncertainty_mm,
+                                2.0 * component.boundary_uncertainty_mm,
                             );
-                            width.uncertainty_mm += 2.0 * axis.uncertainty_mm;
                             (
-                                (start, end),
+                                axis.endpoints(),
                                 WidthDisk {
                                     center,
                                     radius_mm,
                                     width,
                                 },
-                                walls,
+                                axis.walls(),
+                                axis.polyline(component.region.budget().max_error_mm()),
                             )
                         })
                         .collect::<Vec<_>>()
@@ -833,7 +768,7 @@ fn pieces(components: Vec<TwoSidedResidualComponent>, minimum_mm: f64) -> Vec<Th
                 .collect::<Vec<_>>();
             let lines = narrow_axis
                 .iter()
-                .map(|(line, _, _)| *line)
+                .map(|(line, _, _, _)| *line)
                 .collect::<Vec<_>>();
             let sites = connected_line_groups(&lines)
                 .into_iter()
@@ -862,7 +797,7 @@ fn pieces(components: Vec<TwoSidedResidualComponent>, minimum_mm: f64) -> Vec<Th
                             let (start, end) = lines[index];
                             bbox.include_point(start);
                             bbox.include_point(end);
-                            vec![start, end]
+                            narrow_axis[index].3.clone()
                         })
                         .collect();
                     ThinSite {
@@ -873,15 +808,14 @@ fn pieces(components: Vec<TwoSidedResidualComponent>, minimum_mm: f64) -> Vec<Th
                     }
                 })
                 .collect::<Vec<_>>();
-            let disk = WidthDisk {
-                center: component.disk.center,
-                radius_mm: component.disk.radius,
-                width: component.width,
-            };
-            (!sites.is_empty()).then_some(ThinPiece {
+            let disk = sites
+                .iter()
+                .map(|site| site.disk)
+                .min_by(|left, right| left.width.mm.total_cmp(&right.width.mm))?;
+            Some(ThinPiece {
                 bbox: component.region.bbox,
                 area_mm2: component.region.area(),
-                width: component.width,
+                width: disk.width,
                 length_mm: region_perimeter(&component.region) / 2.0,
                 disk,
                 sites,
@@ -1224,10 +1158,10 @@ mod tests {
     }
 
     #[test]
-    fn sub_resolution_backtracking_does_not_create_opposing_walls() {
-        // A real zone boundary can contain a tiny reversal inside an otherwise
-        // smooth clearance wall. The opening sheds the resulting nib, but its
-        // two locally reversed edges are still one wall, not a copper width.
+    fn exact_backtracking_does_not_inherit_unrecorded_grid_uncertainty() {
+        // This polygon states an approximately 2.1 µm narrowing. Its exact
+        // contacts qualify, even though the former snap-grid construction
+        // suppressed it. Only recorded boundary error can make it unresolved.
         let hole_points = [
             (139.5, -98.5),
             (140.5, -98.5),
@@ -1266,7 +1200,7 @@ mod tests {
             .chain(std::iter::once(PathCmd::close()))
             .collect(),
         );
-        let region = ContourSet::from_contours(
+        let mut region = ContourSet::from_contours(
             &[rect_at(139.0, -101.0, 141.0, -98.0), hole],
             FillRule::NonZero,
             res(tol::REGION_MM),
@@ -1280,8 +1214,12 @@ mod tests {
                 .difference(&region.disk_open(candidate_radius).unwrap())
                 .unwrap()
                 .is_empty(),
-            "the opening must still localize the one-sided nib"
+            "the opening must still localize the nib"
         );
+        let pieces = thin_features(&region, 0.127).unwrap();
+        assert_eq!(pieces.len(), 1);
+        assert!((0.002..0.003).contains(&pieces[0].width.mm));
+        region.uncertainty_mm = 0.002;
         assert!(thin_features(&region, 0.127).unwrap().is_empty());
     }
 
@@ -1419,6 +1357,50 @@ mod tests {
                 .unwrap()
                 .is_empty()
         );
+    }
+
+    #[test]
+    fn faceted_copper_cap_requires_resolved_opposing_contacts() {
+        // Reduced from a KiCad GND fill and its identical IPC polygon. The
+        // straight tongue is 0.134 mm wide; its cap has nearly perpendicular
+        // facets. The uncertainty is the imported layer's recorded value,
+        // not a tolerance chosen to suppress this fixture.
+        let ring = [
+            [147.5, -105.8405],
+            [148.678434, -105.8405],
+            [148.722628, -105.858806],
+            [148.740934, -105.903],
+            [148.722628, -105.947194],
+            [148.713628, -105.956194],
+            [148.669434, -105.9745],
+            [147.5, -105.9745],
+        ];
+        for scale in [1.0, 0.5] {
+            for first in 0..ring.len() {
+                let points = ring
+                    .iter()
+                    .cycle()
+                    .skip(first)
+                    .take(ring.len())
+                    .map(|&[x, y]| [x, -105.9 + (y + 105.9) * scale])
+                    .collect();
+                let mut region =
+                    ContourSet::from_rings(vec![points], FillRule::NonZero, Resolution::default())
+                        .unwrap();
+                region.uncertainty_mm = 0.003246093757;
+                let findings = thin_features(&region, 0.127).unwrap();
+                if scale == 1.0 {
+                    assert!(findings.is_empty(), "cap rotation {first}: {findings:?}");
+                } else {
+                    assert!(!findings.is_empty(), "a genuinely narrow tongue must fail");
+                    assert!(
+                        findings
+                            .iter()
+                            .all(|piece| piece.width.certainly_below(0.127))
+                    );
+                }
+            }
+        }
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/region.rs
+++ b/crates/pcb-ir/src/geom/region.rs
@@ -15,14 +15,13 @@ mod query;
 mod simplification;
 #[cfg(test)]
 mod tests;
+mod widths;
 
 pub use booleans::PaintComposer;
 pub(crate) use booleans::difference_shapes;
 pub use flattening::rings_to_contours;
+pub(crate) use gaps::TwoSidedResidualComponent;
 pub use gaps::{DiskGapRegularization, GapRegularizationError};
-// Preserve the existing crate-visible type paths, including inferred result types.
-#[allow(unused_imports)]
-pub(crate) use gaps::{InscribedDisk, TwoSidedResidualComponent, WidthAxisSegment};
 pub use query::PreparedRegion;
 pub(crate) use simplification::{decimate_rings_inward, simplify_rings};
 pub use simplification::{simplify_shapes, simplify_shapes_on_grid};

--- a/crates/pcb-ir/src/geom/region/gaps.rs
+++ b/crates/pcb-ir/src/geom/region/gaps.rs
@@ -1,11 +1,11 @@
 //! Two-sided morphology residues, local widths, and void-gap regularization.
 
+use super::widths::WidthAxis;
 use super::{
-    ContourSet, PreparedRegion, Ring, ring_edges, ring_signed_area, ring_winding,
-    segment_inside_intervals, simplify_rings,
+    ContourSet, PreparedRegion, Ring, ring_edges, ring_signed_area, ring_winding, simplify_rings,
 };
 use crate::geom::accuracy::numerical_error;
-use crate::geom::dist::{self, Distance};
+use crate::geom::dist;
 use crate::geom::path::{ContourBuf, PathCmd};
 use crate::geom::store::PathArena;
 use crate::geom::{AccuracyError, BBox, FillRule, Paint, Point, tol};
@@ -18,59 +18,6 @@ use boostvoronoi::prelude::{
 };
 use boostvoronoi::utils::visual_utils::SimpleAffine;
 
-/// Sublevel set of a continuous convex function on [0, 1]. The geometric
-/// uses here are sums of point-to-segment distances, so there is at most one
-/// interval and bisection locates its ends independently of render sampling.
-fn convex_sublevel_interval(value: impl Fn(f64) -> f64, limit: f64) -> Option<(f64, f64)> {
-    let (first, last) = (value(0.0), value(1.0));
-    if first <= limit && last <= limit {
-        return Some((0.0, 1.0));
-    }
-    let (mut low, mut high) = (0.0, 1.0);
-    for _ in 0..48 {
-        let a = (2.0 * low + high) / 3.0;
-        let b = (low + 2.0 * high) / 3.0;
-        if value(a) < value(b) {
-            high = b;
-        } else {
-            low = a;
-        }
-    }
-    let minimum = (low + high) / 2.0;
-    if value(minimum) >= limit {
-        return None;
-    }
-    let left = if first <= limit {
-        0.0
-    } else {
-        let (mut outside, mut inside) = (0.0, minimum);
-        for _ in 0..48 {
-            let middle = (outside + inside) / 2.0;
-            if value(middle) < limit {
-                inside = middle;
-            } else {
-                outside = middle;
-            }
-        }
-        inside
-    };
-    let right = if last <= limit {
-        1.0
-    } else {
-        let (mut inside, mut outside) = (minimum, 1.0);
-        for _ in 0..48 {
-            let middle = (inside + outside) / 2.0;
-            if value(middle) < limit {
-                inside = middle;
-            } else {
-                outside = middle;
-            }
-        }
-        inside
-    };
-    Some((left, right))
-}
-
 /// Result of enforcing a minimum width for every two-sided void gap.
 #[derive(Debug, Clone)]
 pub struct DiskGapRegularization {
@@ -80,17 +27,14 @@ pub struct DiskGapRegularization {
     pub removed: ContourSet,
 }
 
-/// One connected opening/closing residue that two distinct source boundary
-/// branches wall. `width` is the diameter of the narrowest maximal inscribed
-/// disk inside it — the local width of the material or void `region`
-/// represents, exact for the flattened polygon representation — counting
-/// both branches as flattened inputs.
+/// One connected opening/closing residue with resolved opposing contacts
+/// on its medial axis. The caller measures only these axis cells, not the
+/// conservative residue or a separate set of sampled disks.
 #[derive(Debug, Clone)]
 pub(crate) struct TwoSidedResidualComponent {
     pub region: ContourSet,
-    pub width: Distance,
-    pub disk: InscribedDisk,
-    pub axis: Vec<WidthAxisSegment>,
+    pub boundary_uncertainty_mm: f64,
+    pub axis: Vec<WidthAxis>,
 }
 
 /// Failure to construct a narrow void's medial axis for gap regularization.
@@ -409,10 +353,10 @@ impl ContourSet {
         // its walls, and the disks through a residue point reach a diameter
         // from it, so only the material within a few radii of facing walls
         // decides the residue there. Separate components share a width only
-        // where they touch within tolerance. The snap-rounded width
-        // construction moves walls by a tolerance, and `M \ (X ∩ M)` is
-        // `M \ X`, so the opening's clip to the source is not needed to
-        // find what the opening removed.
+        // where they touch within tolerance. The analytic width construction
+        // uses the source walls directly, and `M \ (X ∩ M)` is `M \ X`, so
+        // the opening's clip to the source is not needed to find what the
+        // opening removed.
         self.two_sided_residual(radius, |region, radius| {
             let facing = width_mm + 4.0 * region.tolerance();
             let touching = 3.0 * region.tolerance() + region.uncertainty_mm;
@@ -456,7 +400,6 @@ impl ContourSet {
             self,
             &residual(self, radius)?,
             radius,
-            self.budget().allowance(self.uncertainty_mm)?,
         ))
     }
 }
@@ -579,16 +522,15 @@ impl<'a> RingArcLength<'a> {
 /// A point of the residue is nearer than `reach` to the source boundary —
 /// no disk of that radius covers it — so the boundary segments within
 /// `reach` of the component are every segment its inscribed disks can
-/// touch, and their Voronoi diagram restricted to the component is the
-/// medial axis there. The narrowest maximal inscribed disk on that axis is
-/// the component's width. Disks tangent only to incident segments are
+/// touch. Their pairwise analytic bisectors restricted to the component
+/// form the medial axis there. The narrowest maximal inscribed disk on that
+/// axis is the component's width. Disks tangent only to incident segments are
 /// corner spokes, not widths: discarding those leaves one-sided residue —
 /// the bite an isolated corner sheds — with no width at all.
 fn two_sided_residual_components(
     source: &ContourSet,
     residual: &ContourSet,
     reach: f64,
-    approximation_mm: f64,
 ) -> Vec<TwoSidedResidualComponent> {
     if residual.is_empty() {
         return Vec::new();
@@ -601,257 +543,52 @@ fn two_sided_residual_components(
             .collect(),
         source.uncertainty_mm,
     );
-    let contact_tolerance = source
-        .tolerance()
-        .max(residual.tolerance())
-        .max(numerical_error(source.bbox));
-    let boundary_uncertainty = source.uncertainty_mm + std::f64::consts::SQRT_2 * contact_tolerance;
+    let complete_boundary = source.prepare_query();
+    let boundary_uncertainty = source.uncertainty_mm + numerical_error(source.bbox);
     residual
         .connected_components()
         .into_iter()
         .filter_map(|component| {
+            // Preserve the source-boundary index: candidate axes use the
+            // nearby subset, while validation sees every (including short)
+            // source edge through `complete_boundary`.
             let sites = boundary
                 .segment_ids_meeting(component.bbox.expand(reach))
                 .into_iter()
                 .map(|id| segments[id])
                 .collect::<Vec<_>>();
-            component_width(
-                &sites,
-                &component,
-                reach,
-                contact_tolerance,
-                approximation_mm,
-                boundary_uncertainty,
-            )
-            .map(|geometry| TwoSidedResidualComponent {
+            let axis = component_axis(&sites, &component, &complete_boundary, reach);
+            (!axis.is_empty()).then_some(TwoSidedResidualComponent {
                 region: component,
-                width: geometry
-                    .disk
-                    .width()
-                    .also_uncertain(2.0 * boundary_uncertainty),
-                disk: geometry.disk,
-                axis: geometry.axis,
+                boundary_uncertainty_mm: boundary_uncertainty,
+                axis,
             })
         })
         .collect()
 }
 
-/// A boundary segment snapped to the tolerance grid, with its topology.
-type GridSite = (VoronoiLine<i32>, OrientedBoundarySegment);
-
-/// The sites snap-rounded to a planar set on the tolerance grid. The
-/// Voronoi builder accepts segments that meet only at endpoints, while
-/// regularized rings may touch along a seam (two rings sharing an edge),
-/// at a vertex on another ring's edge, or fold into hairpins narrower than
-/// the tolerance. On the grid, points within tolerance are one point:
-/// zero-length and duplicate segments drop, a segment splits where another
-/// endpoint lies on it, and of two segments that still cross — noise at
-/// tolerance scale — the shorter drops. Pieces keep their parent's topology
-/// and so remain incident to each other and to its neighbors.
-fn planar_grid_sites(
-    sites: &[OrientedBoundarySegment],
-    quantize: impl Fn(Point) -> VoronoiPoint<i32>,
-) -> Vec<GridSite> {
-    let orient = |a: VoronoiPoint<i32>, b: VoronoiPoint<i32>, c: VoronoiPoint<i32>| -> i128 {
-        (i128::from(b.x) - i128::from(a.x)) * (i128::from(c.y) - i128::from(a.y))
-            - (i128::from(b.y) - i128::from(a.y)) * (i128::from(c.x) - i128::from(a.x))
-    };
-    let on_interior = |line: &VoronoiLine<i32>, point: VoronoiPoint<i32>| {
-        point != line.start
-            && point != line.end
-            && orient(line.start, line.end, point) == 0
-            && (line.start.x.min(line.end.x)..=line.start.x.max(line.end.x)).contains(&point.x)
-            && (line.start.y.min(line.end.y)..=line.start.y.max(line.end.y)).contains(&point.y)
-    };
-    let length2 = |line: &VoronoiLine<i32>| {
-        let dx = i128::from(line.end.x) - i128::from(line.start.x);
-        let dy = i128::from(line.end.y) - i128::from(line.start.y);
-        dx * dx + dy * dy
-    };
-    let crosses = |a: &VoronoiLine<i32>, b: &VoronoiLine<i32>| {
-        orient(a.start, a.end, b.start).signum() * orient(a.start, a.end, b.end).signum() < 0
-            && orient(b.start, b.end, a.start).signum() * orient(b.start, b.end, a.end).signum() < 0
-    };
-    // Sites keep their ring's traversal direction; a segment and its
-    // reverse are one site.
-    let key = |line: &VoronoiLine<i32>| {
-        let (a, b) = ((line.start.x, line.start.y), (line.end.x, line.end.y));
-        (a.min(b), a.max(b))
-    };
-    let snapped = sites
-        .iter()
-        .map(|site| {
-            (
-                VoronoiLine::new(quantize(site.start), quantize(site.end)),
-                *site,
-            )
-        })
-        .filter(|(line, _)| line.start != line.end)
-        .collect::<Vec<_>>();
-    let endpoints = snapped
-        .iter()
-        .flat_map(|(line, _)| [line.start, line.end])
-        .collect::<Vec<_>>();
-    let mut seen = std::collections::HashSet::new();
-    let split = snapped
-        .iter()
-        .flat_map(|&(line, source)| {
-            let mut stations = endpoints
-                .iter()
-                .copied()
-                .filter(|&point| on_interior(&line, point))
-                .collect::<Vec<_>>();
-            // Collinear with the segment, so distance from its start orders
-            // them along it whichever way it runs.
-            let along = |point: &VoronoiPoint<i32>| {
-                (i64::from(point.x) - i64::from(line.start.x)).abs()
-                    + (i64::from(point.y) - i64::from(line.start.y)).abs()
-            };
-            stations.sort_by_key(along);
-            stations.dedup();
-            std::iter::once(line.start)
-                .chain(stations)
-                .chain(std::iter::once(line.end))
-                .collect::<Vec<_>>()
-                .windows(2)
-                .map(|pair| (VoronoiLine::new(pair[0], pair[1]), source))
-                .collect::<Vec<_>>()
-        })
-        .filter(|(line, _)| seen.insert(key(line)))
-        .collect::<Vec<_>>();
-    split
-        .iter()
-        .enumerate()
-        .filter(|(index, (line, _))| {
-            !split.iter().enumerate().any(|(other_index, (other, _))| {
-                other_index != *index
-                    && crosses(line, other)
-                    && (length2(other), other_index) > (length2(line), *index)
-            })
-        })
-        .map(|(_, site)| *site)
-        .collect()
-}
-
-/// Whether every two sites are incident, and so one wall: segments of one
-/// ring that are adjacent or turned no more than a quarter turn from each
-/// other, the same judgement the width construction makes of a wall pair.
-/// Nothing in such a set faces anything else, so a residue it walls alone
-/// is the bite of one corner or gentle arc and has no width. A sharp tip
-/// turns its walls to face each other and is measured.
-fn one_wall(sites: &[OrientedBoundarySegment]) -> bool {
-    sites.iter().enumerate().all(|(position, left)| {
-        sites[position + 1..].iter().all(|right| {
-            left.topology.ring == right.topology.ring
-                && (boundary_segments_are_incident(left.topology, right.topology)
-                    || left.tangent.x * right.tangent.x + left.tangent.y * right.tangent.y >= 0.0)
-        })
-    })
-}
-
-/// A maximal inscribed disk of the boundary's Voronoi diagram: its center,
-/// radius, and the two tangency points on distinct walls.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct InscribedDisk {
-    pub center: Point,
-    pub radius: f64,
-    pub first: Point,
-    pub second: Point,
-}
-
-impl InscribedDisk {
-    fn width(self) -> Distance {
-        Distance::exact(2.0 * self.radius, self.first, self.second)
-    }
-}
-
-/// One cell of the boundary medial axis, with the two walls defining it.
-/// A vertex has equal start/end points; curved edges are polylines within the
-/// shared flattening tolerance. These are candidates until clipped to the
-/// residue and the requested width.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct WidthAxisSegment {
-    pub start: Point,
-    pub end: Point,
-    pub first_wall: (Point, Point),
-    pub second_wall: (Point, Point),
-    pub uncertainty_mm: f64,
-}
-
-struct ComponentWidth {
-    disk: InscribedDisk,
-    axis: Vec<WidthAxisSegment>,
-}
-
-/// The narrowest maximal inscribed disk of `sites` inside `component`, as a
-/// width between its two tangency points.
-///
-/// Candidates are the Voronoi vertices, and every non-incident edge sampled
-/// along its length, at the apex of a parabolic or point–point edge, and
-/// where it crosses the component boundary — the clearance along an edge is
-/// linear or convex, so its minimum over the inside is at one of those.
-/// Flattening a curve sprouts axis branches the source does not have, whose
-/// disks sit inside a neighbor's disk up to the flattening tolerance; those
-/// are pruned, so a flattened arc measures its diameter and a taper keeps
-/// its tip.
-fn component_width(
+/// Enumerate exact bisectors of every reachable pair of nonincident walls,
+/// then let the analytic axis clip and validate itself against the residue
+/// and the complete source boundary.
+fn component_axis(
     sites: &[OrientedBoundarySegment],
     component: &ContourSet,
+    complete_boundary: &PreparedRegion,
     reach: f64,
-    contact_tolerance: f64,
-    approximation_mm: f64,
-    boundary_uncertainty: f64,
-) -> Option<ComponentWidth> {
-    if one_wall(sites) {
-        return None;
+) -> Vec<WidthAxis> {
+    if sites.len() < 2 {
+        return Vec::new();
     }
-    let origin = component.bbox.min;
-    let units_per_mm = 1.0 / contact_tolerance;
-    let quantize = |point: Point| {
-        VoronoiPoint::new(
-            ((point.x - origin.x) * units_per_mm).round() as i32,
-            ((point.y - origin.y) * units_per_mm).round() as i32,
-        )
-    };
-    let unquantize =
-        |[x, y]: [f64; 2]| Point::new(x / units_per_mm + origin.x, y / units_per_mm + origin.y);
-    let grid = planar_grid_sites(sites, quantize);
-    let lines = grid.iter().map(|(line, _)| *line).collect::<Vec<_>>();
-    let sites = grid
-        .iter()
-        .map(|(line, source)| {
-            let start = unquantize([f64::from(line.start.x), f64::from(line.start.y)]);
-            let end = unquantize([f64::from(line.end.x), f64::from(line.end.y)]);
-            OrientedBoundarySegment {
-                topology: source.topology,
-                start,
-                end,
-                tangent: source.tangent,
-                bbox: BBox::spanning(start, end),
-            }
-        })
-        .collect::<Vec<_>>();
-    if lines.len() < 2 {
-        return None;
-    }
-    // Which sites are one wall. A ring's two sides of a channel are
-    // traversed in opposite directions, so two segments of one ring face
-    // each other only when their directions oppose; ring-adjacent segments
-    // and segments whose resolution-scale tangents are no more than a
-    // quarter turn apart are the same wall, as a disk touching both edges
-    // of a square corner is a corner disk, not a width. The averaged
-    // tangent prevents a microscopic reversal from manufacturing an
-    // opposing branch. Segments of different rings are one wall only where
-    // they touch.
+    let error = numerical_error(component.bbox);
     let incident = |i: usize, j: usize| {
-        let (a, b) = (&sites[i], &sites[j]);
+        let a = &sites[i];
+        let b = &sites[j];
         if a.topology.ring == b.topology.ring {
             boundary_segments_are_incident(a.topology, b.topology)
-                || a.tangent.x * b.tangent.x + a.tangent.y * b.tangent.y >= 0.0
         } else {
-            [lines[i].start, lines[i].end]
+            [a.start, a.end]
                 .iter()
-                .any(|point| [lines[j].start, lines[j].end].contains(point))
+                .any(|point| [b.start, b.end].contains(point))
         }
     };
     let component_edges = component
@@ -859,17 +596,9 @@ fn component_width(
         .iter()
         .flat_map(ring_edges)
         .collect::<Vec<_>>();
-    // A maximal disk centered in the component is no larger than the
-    // component's clearance to its nearest wall, which the farthest vertex
-    // from that wall bounds. Both walls of a width therefore lie within that
-    // reach of the component; a corner's own bite is walled by its two edges
-    // alone and never reaches the far side of the feature. Any disk within
-    // the morphology reach that touches two eligible walls also proves those
-    // walls are no farther apart than its diameter. Allow one contact
-    // tolerance at each wall for the snap-rounded residual, and the chord
-    // deviation of a sampled curved axis, then leave every surviving
-    // measurement to the Voronoi construction below.
-    let candidate_diameter = 2.0 * (reach + contact_tolerance);
+    // A component disk is no larger than its clearance to its nearest
+    // source site. The farthest component vertex from that site is an exact
+    // upper bound, so walls farther from the component cannot participate.
     let farthest_vertex = |site: &OrientedBoundarySegment| {
         component
             .rings
@@ -882,8 +611,7 @@ fn component_width(
         .iter()
         .map(farthest_vertex)
         .fold(f64::INFINITY, f64::min)
-        + 2.0 * contact_tolerance
-        + approximation_mm;
+        + error;
     let within_reach = sites
         .iter()
         .map(|site| {
@@ -892,267 +620,29 @@ fn component_width(
             })
         })
         .collect::<Vec<_>>();
-    let has_reachable_wall_pair = (0..sites.len())
-        .flat_map(|first| (first + 1..sites.len()).map(move |second| (first, second)))
-        .any(|(first, second)| {
-            within_reach[first]
-                && within_reach[second]
-                && !incident(first, second)
-                && dist::segments(
-                    sites[first].start,
-                    sites[first].end,
-                    sites[second].start,
-                    sites[second].end,
-                )
-                .0 <= candidate_diameter
-        });
-    if !has_reachable_wall_pair {
-        return None;
-    }
-    let diagram = VoronoiBuilder::<i32>::default()
-        .with_segments(lines.iter())
-        .and_then(VoronoiBuilder::build)
-        .expect("snap-rounded boundary segments do not cross");
-    // A cell's site index, and its point when the site is a segment end.
-    let site_of = |cell: VoronoiCellIndex| {
-        let cell = diagram.cell(cell).expect("diagram cell");
-        let index = cell.source_index().usize();
-        let point = match cell.source_category() {
-            SourceCategory::SegmentStart => Some(sites[index].start),
-            SourceCategory::SegmentEnd => Some(sites[index].end),
-            SourceCategory::Segment | SourceCategory::SinglePoint => None,
-        };
-        (index, point)
-    };
-    let disk = |center: Point, first: usize, second: usize| {
-        let (first_distance, first) =
-            dist::point_segment(center, sites[first].start, sites[first].end);
-        let (second_distance, second) =
-            dist::point_segment(center, sites[second].start, sites[second].end);
-        InscribedDisk {
-            center,
-            radius: (first_distance + second_distance) / 2.0,
-            first,
-            second,
-        }
-    };
+    let candidate_diameter = 2.0 * reach + error;
 
-    // Vertices: tangent to every site around them; a width needs two that
-    // are not incident.
-    let at_vertices = diagram
-        .vertices()
-        .iter()
-        .filter_map(|vertex| {
-            let around = diagram
-                .edge_rot_next_iterator(vertex.get_incident_edge().ok()?)
-                .filter_map(|edge| diagram.edge(edge).ok()?.cell().ok())
-                .map(|cell| site_of(cell).0)
-                .collect::<Vec<_>>();
-            around
-                .iter()
-                .enumerate()
-                .flat_map(|(position, &first)| {
-                    around[position + 1..]
-                        .iter()
-                        .map(move |&second| (first, second))
-                })
-                .find(|&(first, second)| !incident(first, second))
-                .map(|(first, second)| {
-                    let center = unquantize([vertex.x(), vertex.y()]);
-                    (
-                        disk(center, first, second),
-                        WidthAxisSegment {
-                            start: center,
-                            end: center,
-                            first_wall: (sites[first].start, sites[first].end),
-                            second_wall: (sites[second].start, sites[second].end),
-                            uncertainty_mm: 0.0,
-                        },
-                    )
-                })
-        })
-        .collect::<Vec<_>>();
-
-    // Edges between non-incident sites, sampled along their length and at
-    // the apex of a parabola (reflex vertex against a segment) or of a
-    // point–point bisector; plus where they cross the component boundary.
-    let (mut on_axis, mut on_boundary) = (Vec::new(), Vec::new());
-    let mut axis = Vec::new();
-    for edge in diagram.edges() {
-        let twin = edge.twin().expect("diagram edge twin");
-        let (first, first_point) = site_of(edge.cell().expect("diagram edge cell"));
-        let (second, second_point) = site_of(
-            diagram
-                .edge(twin)
-                .and_then(|twin| twin.cell())
-                .expect("twin cell"),
-        );
-        if edge.id() > twin || !edge.is_primary() || incident(first, second) {
-            continue;
-        }
-        let samples = voronoi_edge_samples(
-            &diagram,
-            edge.id(),
-            &lines,
-            component,
-            reach,
-            units_per_mm,
-            approximation_mm,
-        )
-        .expect("voronoi edge samples")
-        .into_iter()
-        .map(unquantize)
-        .collect::<Vec<_>>();
-        axis.extend(samples.windows(2).map(|pair| WidthAxisSegment {
-            start: pair[0],
-            end: pair[1],
-            first_wall: (sites[first].start, sites[first].end),
-            second_wall: (sites[second].start, sites[second].end),
-            uncertainty_mm: if edge.is_curved() {
-                approximation_mm
-            } else {
-                0.0
-            },
-        }));
-        let foot = |point: Point, site: usize| {
-            dist::point_segment(point, sites[site].start, sites[site].end).1
-        };
-        let apex = match (first_point, second_point) {
-            (Some(point), Some(other)) => Some(point.midpoint(other)),
-            (Some(point), None) => Some(point.midpoint(foot(point, second))),
-            (None, Some(point)) => Some(point.midpoint(foot(point, first))),
-            (None, None) => None,
-        };
-        on_boundary.extend(samples.windows(2).flat_map(|pair| {
-            component_edges.iter().filter_map(move |&(start, end)| {
-                let (distance, on_edge, _) = dist::segments(pair[0], pair[1], start, end);
-                (distance <= contact_tolerance).then(|| disk(on_edge, first, second))
-            })
-        }));
-        on_axis.extend(
-            samples
-                .into_iter()
-                .chain(apex)
-                .map(|center| disk(center, first, second)),
-        );
-    }
-    on_axis.extend(at_vertices.iter().map(|(disk, _)| *disk));
-
-    // A disk is maximal only if its radius is its clearance to every site;
-    // the builder's degenerate edges can put a center next to a wall it
-    // does not touch.
-    let clearance = |center: Point| {
-        sites
-            .iter()
-            .map(|site| dist::point_segment(center, site.start, site.end).0)
-            .fold(f64::INFINITY, f64::min)
-    };
-    let centers = on_axis.iter().map(|disk| disk.center).collect::<Vec<_>>();
-    let present = on_axis
-        .into_iter()
-        .zip(component.contains_points_batch(&centers))
-        .filter_map(|(disk, inside)| inside.then_some(disk))
-        .chain(on_boundary)
-        .filter(|disk| disk.radius <= clearance(disk.center) + contact_tolerance)
-        .collect::<Vec<_>>();
-    // A disk inside a larger present disk up to the flattening tolerance is
-    // a branch the flattening sprouted, not a width of the source. Only
-    // present disks prune: a void's exterior axis must not swallow a slit
-    // thinner than the tolerance.
-    let pruned = |disk: &InscribedDisk| {
-        present.iter().any(|other| {
-            other.radius > disk.radius
-                && disk.center.distance_to(other.center) + disk.radius
-                    <= other.radius + approximation_mm
-        })
-    };
-    let minimum = present
-        .iter()
-        .filter(|disk| !pruned(disk))
-        // The disk must survive the uncertainty of its boundary sites.
-        .filter(|disk| disk.radius > boundary_uncertainty)
-        .min_by(|left, right| left.width().mm.total_cmp(&right.width().mm))
-        .copied()?;
-    // Retain the actual interior axis, removing the portions rejected by the
-    // same maximal-disk pruning. Both containment inequalities are convex
-    // along a straight axis piece, so their endpoints can be located without
-    // turning the candidate's bounding box into a claimed violation region.
-    let span_axis = axis.into_iter().flat_map(|segment| {
-        let delta = segment.end - segment.start;
-        let at = |t| segment.start + delta * t;
-        let radius = |t| {
-            let point = at(t);
-            (dist::point_segment(point, segment.first_wall.0, segment.first_wall.1).0
-                + dist::point_segment(point, segment.second_wall.0, segment.second_wall.1).0)
-                / 2.0
-        };
-        let mut retained = segment_inside_intervals(component, segment.start, segment.end);
-        for other in &present {
-            if retained.is_empty() {
-                break;
+    let mut axes = Vec::new();
+    for first in 0..sites.len() {
+        for second in first + 1..sites.len() {
+            if !within_reach[first] || !within_reach[second] || incident(first, second) {
+                continue;
             }
-            if dist::point_segment(other.center, segment.start, segment.end).0
-                > other.radius + approximation_mm
+            let first_wall = (sites[first].start, sites[first].end);
+            let second_wall = (sites[second].start, sites[second].end);
+            if dist::segments(first_wall.0, first_wall.1, second_wall.0, second_wall.1).0
+                > candidate_diameter
             {
                 continue;
             }
-            let Some(larger) = convex_sublevel_interval(radius, other.radius - tol::EPSILON_MM)
-            else {
-                continue;
-            };
-            let Some(contained) = convex_sublevel_interval(
-                |t| at(t).distance_to(other.center) + radius(t),
-                other.radius + approximation_mm,
-            ) else {
-                continue;
-            };
-            let removed = (larger.0.max(contained.0), larger.1.min(contained.1));
-            if removed.0 >= removed.1 {
-                continue;
-            }
-            retained = retained
-                .into_iter()
-                .flat_map(|(start, end)| {
-                    let mut pieces = Vec::with_capacity(2);
-                    if start < removed.0 {
-                        pieces.push((start, end.min(removed.0)));
-                    }
-                    if end > removed.1 {
-                        pieces.push((start.max(removed.1), end));
-                    }
-                    pieces
-                })
-                .collect();
+            axes.extend(
+                WidthAxis::between(first_wall, second_wall, component.bbox)
+                    .into_iter()
+                    .flat_map(|axis| axis.in_region(component, complete_boundary)),
+            );
         }
-        retained
-            .into_iter()
-            .filter_map(move |(start, end)| {
-                let (start, end) = (at(start), at(end));
-                (start.distance_to(end) > contact_tolerance).then_some(WidthAxisSegment {
-                    start,
-                    end,
-                    ..segment
-                })
-            })
-            .collect::<Vec<_>>()
-    });
-    // Voronoi vertices are the zero-dimensional cells of the same medial-axis
-    // complex. Preserve the maximal ones as zero-length axis segments so
-    // islands and symmetric tips use the exact same construction as spans.
-    let vertex_axis = at_vertices
-        .into_iter()
-        .filter(|(disk, _)| {
-            component.contains_point(disk.center)
-                && disk.radius <= clearance(disk.center) + contact_tolerance
-                && disk.width().mm > 2.0 * contact_tolerance
-                && !pruned(disk)
-        })
-        .map(|(_, segment)| segment);
-    let axis = span_axis.chain(vertex_axis).collect();
-    Some(ComponentWidth {
-        disk: minimum,
-        axis,
-    })
+    }
+    axes
 }
 
 /// The closing residue kept only where two distinct source-boundary
@@ -1668,26 +1158,6 @@ mod tests {
     use super::super::tests::{rect, res};
     use super::*;
     #[test]
-    fn component_width_prunes_only_beyond_grid_uncertainty() {
-        let measure = |height| {
-            let component = ContourSet::rectangle(rect(0.0, 0.0, 1.0, height), res(tol::REGION_MM));
-            component_width(
-                &source_boundary_segments(&component),
-                &component,
-                0.05,
-                tol::REGION_MM,
-                0.0025,
-                std::f64::consts::SQRT_2 * tol::REGION_MM,
-            )
-        };
-
-        let width = measure(0.101).expect("grid uncertainty keeps the reachable opposing walls");
-        assert!((width.disk.width().mm - 0.101).abs() < 1e-9);
-
-        assert!(measure(0.103).is_none());
-    }
-
-    #[test]
     fn ring_components_group_holes_with_the_smallest_outer_ring_around_them() {
         let region = ContourSet::rectangle(rect(0.0, 0.0, 10.0, 10.0), res(tol::REGION_MM))
             .difference(&ContourSet::rectangle(
@@ -1798,41 +1268,5 @@ mod tests {
         assert!(!nearby_web.contains_point(Point::new(6.5, 2.0)));
         assert!(!nearby_web.contains_point(Point::new(5.0, 3.5)));
         assert!(webbed.facing_components(0.0, 0.15, 1.0).unwrap().is_empty());
-    }
-
-    #[test]
-    fn planar_sites_split_along_the_segment_whichever_way_it_runs() {
-        let site = |start: (f64, f64), end: (f64, f64), index: usize| OrientedBoundarySegment {
-            topology: BoundarySegment {
-                ring: index / 10,
-                index,
-                ring_len: 10,
-            },
-            start: Point::new(start.0, start.1),
-            end: Point::new(end.0, end.1),
-            tangent: Point::new(end.0 - start.0, end.1 - start.1),
-            bbox: BBox::spanning(Point::new(start.0, start.1), Point::new(end.0, end.1)),
-        };
-        // A right-to-left host touched at two interior points by other rings.
-        let sites = [
-            site((10.0, 0.0), (0.0, 0.0), 0),
-            site((7.0, 5.0), (7.0, 0.0), 10),
-            site((3.0, 5.0), (3.0, 0.0), 20),
-        ];
-        let grid = planar_grid_sites(&sites, |point| {
-            VoronoiPoint::new(point.x as i32, point.y as i32)
-        });
-
-        let host = grid
-            .iter()
-            .filter(|(_, site)| site.topology.index == 0)
-            .map(|(line, _)| line)
-            .collect::<Vec<_>>();
-        assert_eq!(host.len(), 3);
-        assert_eq!(host[0].start, VoronoiPoint::new(10, 0));
-        for pair in host.windows(2) {
-            assert_eq!(pair[0].end, pair[1].start, "pieces chain along the host");
-        }
-        assert_eq!(host[2].end, VoronoiPoint::new(0, 0));
     }
 }

--- a/crates/pcb-ir/src/geom/region/widths.rs
+++ b/crates/pcb-ir/src/geom/region/widths.rs
@@ -1,0 +1,648 @@
+//! Widths on unsnapped segment bisectors. All classification boundaries are
+//! quadratic roots; polylines are made only after measurement, for display.
+
+use super::{ContourSet, PreparedRegion, ring_edges, ring_winding};
+use crate::geom::{BBox, Point, accuracy::numerical_error, dist};
+
+type Polynomial = [f64; 3];
+
+fn dot(a: Point, b: Point) -> f64 {
+    a.x * b.x + a.y * b.y
+}
+
+fn perpendicular(p: Point) -> Point {
+    Point::new(-p.y, p.x)
+}
+
+fn value(p: Polynomial, t: f64) -> f64 {
+    p[2].mul_add(t, p[1]).mul_add(t, p[0])
+}
+
+fn roots([c, b, a]: Polynomial) -> Vec<f64> {
+    if a == 0.0 {
+        return if b == 0.0 { vec![] } else { vec![-c / b] };
+    }
+    let discriminant = b.mul_add(b, -4.0 * a * c);
+    if discriminant < 0.0 {
+        return vec![];
+    }
+    let q = -0.5 * (b + discriminant.sqrt().copysign(b));
+    if q == 0.0 {
+        vec![-b / (2.0 * a)]
+    } else {
+        vec![q / a, c / q]
+    }
+}
+
+/// The same polynomials supply both cell cuts and open-cell membership.
+struct SegmentClearance {
+    projection: Polynomial,
+    length: f64,
+    endpoints: [Polynomial; 2],
+    line: Vec<Polynomial>,
+}
+
+impl SegmentClearance {
+    fn contains(&self, t: f64) -> bool {
+        let projection = value(self.projection, t);
+        if projection <= 0.0 {
+            value(self.endpoints[0], t) >= 0.0
+        } else if projection >= self.length {
+            value(self.endpoints[1], t) >= 0.0
+        } else {
+            self.line.iter().map(|&p| value(p, t)).product::<f64>() >= 0.0
+        }
+    }
+}
+
+/// A line or parabola, with its active point/interior-segment contacts.
+/// Degenerate contact segments denote endpoints, not short supporting lines.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct WidthAxis {
+    center: [Point; 3],
+    radius: Polynomial,
+    squared_radius: bool,
+    contacts: [(Point, Point); 2],
+    range: (f64, f64),
+}
+
+impl WidthAxis {
+    pub fn between(first: (Point, Point), second: (Point, Point), bounds: BBox) -> Vec<Self> {
+        let features = |(a, b)| {
+            if a == b {
+                vec![(a, a)]
+            } else {
+                vec![(a, a), (b, b), (a, b)]
+            }
+        };
+        let mut axes = Vec::new();
+        for first in features(first) {
+            for second in features(second) {
+                let (mut first, mut second) = (first, second);
+                // Put the point first in point/line pairs.
+                if first.0 != first.1 && second.0 == second.1 {
+                    std::mem::swap(&mut first, &mut second);
+                }
+                let contacts = [first, second];
+                if first.0 == first.1 && second.0 == second.1 {
+                    let across = second.0 - first.0;
+                    let diameter = across.length();
+                    if diameter > 0.0 {
+                        let half = diameter / 2.0;
+                        axes.push(Self {
+                            center: [
+                                first.0.midpoint(second.0),
+                                perpendicular(across) / diameter,
+                                Point::ZERO,
+                            ],
+                            radius: [half * half, 0.0, 1.0],
+                            squared_radius: true,
+                            contacts,
+                            range: (-half, half),
+                        });
+                    }
+                } else if first.0 == first.1 {
+                    let along = (second.1 - second.0) / second.0.distance_to(second.1);
+                    let foot = second.0 + along * dot(first.0 - second.0, along);
+                    let height = first.0.distance_to(foot);
+                    if height > numerical_error(bounds) {
+                        let normal = (first.0 - foot) / height;
+                        axes.push(Self {
+                            center: [foot.midpoint(first.0), along, normal / (2.0 * height)],
+                            radius: [height / 2.0, 0.0, 1.0 / (2.0 * height)],
+                            squared_radius: false,
+                            contacts,
+                            range: (-height, height),
+                        });
+                    }
+                } else {
+                    let edges = contacts.map(|(a, b)| b - a);
+                    let normals = contacts.map(|(a, b)| perpendicular(b - a) / a.distance_to(b));
+                    // Each edge subtracts two coordinates. Propagate their
+                    // numerical error through the unnormalized dot product;
+                    // normalizing first would hide cancellation in short edges.
+                    let edge_error = 2.0
+                        * numerical_error(
+                            BBox::spanning(first.0, first.1)
+                                .union(BBox::spanning(second.0, second.1)),
+                        );
+                    let dot_error = edge_error * (edges[0].length() + edges[1].length())
+                        + edge_error * edge_error;
+                    for sign in [-1.0, 1.0] {
+                        // Signed-distance equality fixes the contact angle on
+                        // this branch. Right-angle line pairs never qualify.
+                        if sign * dot(edges[0], edges[1]) >= -dot_error {
+                            continue;
+                        }
+                        let normal = normals[0] - normals[1] * sign;
+                        let norm2 = dot(normal, normal);
+                        if norm2 == 0.0 {
+                            continue;
+                        }
+                        let middle = bounds.center();
+                        let offset = sign * dot(normals[1], first.0 - second.0);
+                        let origin =
+                            middle + normal * ((offset - dot(normal, middle - first.0)) / norm2);
+                        let direction = perpendicular(normal) / norm2.sqrt();
+                        let extent = bounds.min.distance_to(bounds.max) / 2.0;
+                        axes.push(Self {
+                            center: [origin, direction, Point::ZERO],
+                            radius: [
+                                dot(normals[0], origin - first.0),
+                                dot(normals[0], direction),
+                                0.0,
+                            ],
+                            squared_radius: false,
+                            contacts,
+                            range: (-extent, extent),
+                        });
+                    }
+                }
+            }
+        }
+        axes
+    }
+
+    fn at(self, t: f64) -> Point {
+        self.center[0] + (self.center[1] + self.center[2] * t) * t
+    }
+
+    fn radius_at(self, t: f64) -> f64 {
+        let r = value(self.radius, t);
+        if self.squared_radius {
+            r.max(0.0).sqrt()
+        } else {
+            r.abs()
+        }
+    }
+
+    fn projection(self, origin: Point, direction: Point) -> Polynomial {
+        [
+            dot(self.center[0] - origin, direction),
+            dot(self.center[1], direction),
+            dot(self.center[2], direction),
+        ]
+    }
+
+    fn bounds(self) -> BBox {
+        let (start, end) = self.endpoints();
+        let mut bounds = BBox::spanning(start, end);
+        for (linear, quadratic) in [
+            (self.center[1].x, self.center[2].x),
+            (self.center[1].y, self.center[2].y),
+        ] {
+            if quadratic != 0.0 {
+                bounds.include_point(
+                    self.at((-linear / (2.0 * quadratic)).clamp(self.range.0, self.range.1)),
+                );
+            }
+        }
+        bounds
+    }
+
+    /// Partition by every predicate root, keeping valid singleton intersections
+    /// as well as intervals. Identically zero polynomials need no subdivision.
+    fn clip(self, mut cuts: Vec<f64>, valid: impl Fn(f64, bool) -> bool) -> Vec<Self> {
+        cuts.retain(|t| t.is_finite() && *t > self.range.0 && *t < self.range.1);
+        cuts.extend([self.range.0, self.range.1]);
+        cuts.sort_by(f64::total_cmp);
+        cuts.dedup();
+        let mut kept: Vec<Self> = Vec::new();
+        let mut add = |start, end| {
+            if let Some(last) = kept.last_mut()
+                && last.range.1 == start
+            {
+                last.range.1 = end;
+            } else {
+                kept.push(Self {
+                    range: (start, end),
+                    ..self
+                });
+            }
+        };
+        for (index, &start) in cuts.iter().enumerate() {
+            if valid(start, true) {
+                add(start, start);
+            }
+            if let Some(&end) = cuts.get(index + 1)
+                && valid(start.midpoint(end), false)
+            {
+                add(start, end);
+            }
+        }
+        kept
+    }
+
+    pub fn clipped_radius(self, minimum: f64, maximum: f64) -> Vec<Self> {
+        let mut cuts = Vec::new();
+        for limit in [minimum, maximum] {
+            for sign in [-1.0, 1.0] {
+                let mut polynomial = self.radius;
+                polynomial[0] -= if self.squared_radius {
+                    limit * limit
+                } else {
+                    sign * limit
+                };
+                cuts.extend(roots(polynomial));
+            }
+        }
+        self.clip(cuts, |t, _| {
+            (minimum..=maximum).contains(&self.radius_at(t))
+        })
+    }
+
+    /// Squared distance to a point minus the squared common radius. Using
+    /// a point contact cancels the fourth-degree terms of a parabola exactly.
+    fn point_clearance(self, point: Point) -> Polynomial {
+        if self.contacts[0].0 == self.contacts[0].1 {
+            let contact = self.contacts[0].0;
+            let delta = contact - point;
+            [
+                dot(delta, (self.center[0] - contact) * 2.0 + delta),
+                2.0 * dot(delta, self.center[1]),
+                2.0 * dot(delta, self.center[2]),
+            ]
+        } else {
+            let delta = self.center[0] - point;
+            let [r0, r1, _] = self.radius;
+            [
+                dot(delta, delta) - r0 * r0,
+                2.0 * (dot(delta, self.center[1]) - r0 * r1),
+                dot(self.center[1], self.center[1]) - r1 * r1,
+            ]
+        }
+    }
+
+    pub fn in_region(self, region: &ContourSet, boundary: &PreparedRegion) -> Vec<Self> {
+        let bounds = self.bounds();
+        if !bounds.intersects(region.bbox) {
+            return Vec::new();
+        }
+        let error = numerical_error(bounds.union(region.bbox));
+        let maximum_radius = self
+            .radius_at(self.range.0)
+            .max(self.radius_at(self.range.1));
+        let nearby = boundary
+            .segments_meeting(bounds.expand(maximum_radius + error))
+            .collect::<Vec<_>>();
+        let mut constraints = Vec::new();
+        for (a, b) in self.contacts {
+            if a != b {
+                let length = a.distance_to(b);
+                let projection = self.projection(a, (b - a) / length);
+                constraints.push(projection);
+                constraints.push([length - projection[0], -projection[1], -projection[2]]);
+            } else {
+                // Endpoint normal cone, including adjacent source edges. A
+                // shadowed endpoint is not a nearest contact even when the
+                // distance difference rounds to zero at a corner transition.
+                for &(start, end) in &nearby {
+                    let direction = if a == start {
+                        end - start
+                    } else if a == end {
+                        start - end
+                    } else {
+                        continue;
+                    };
+                    if direction.length() > 0.0 {
+                        constraints.push(self.projection(a, -direction / direction.length()));
+                    }
+                }
+            }
+        }
+        let mut cuts = constraints
+            .iter()
+            .flat_map(|&polynomial| roots(polynomial))
+            .collect::<Vec<_>>();
+        cuts.extend(roots(self.radius));
+        for (a, b) in region.rings.iter().flat_map(ring_edges) {
+            cuts.extend(roots(self.projection(a, perpendicular(b - a))));
+        }
+        let mut clearance = Vec::new();
+        for &(a, b) in &nearby {
+            // These equalities hold by construction, including endpoint
+            // contacts after their incident normal-cone constraints above.
+            if self.contacts.iter().any(|&(p, q)| {
+                (p == a && q == b) || (p == b && q == a) || (p == q && (p == a || p == b))
+            }) {
+                continue;
+            }
+            let endpoints = [self.point_clearance(a), self.point_clearance(b)];
+            cuts.extend(endpoints.into_iter().flat_map(roots));
+            let length = a.distance_to(b);
+            let direction = if length == 0.0 {
+                Point::ZERO
+            } else {
+                (b - a) / length
+            };
+            let projection = self.projection(a, direction);
+            cuts.extend(roots(projection));
+            cuts.extend(roots([
+                projection[0] - length,
+                projection[1],
+                projection[2],
+            ]));
+            let distance = self.projection(a, perpendicular(direction));
+            let line = if self.squared_radius {
+                vec![[
+                    distance[0] * distance[0] - self.radius[0],
+                    2.0 * distance[0] * distance[1] - self.radius[1],
+                    distance[1] * distance[1] - self.radius[2],
+                ]]
+            } else {
+                // d²-r² = (d-r)(d+r); both factors are quadratic.
+                [-1.0, 1.0]
+                    .map(|sign| std::array::from_fn(|i| distance[i] + sign * self.radius[i]))
+                    .to_vec()
+            };
+            cuts.extend(line.iter().copied().flat_map(roots));
+            clearance.push(SegmentClearance {
+                projection,
+                length,
+                endpoints,
+                line,
+            });
+        }
+        self.clip(cuts, |t, isolated| {
+            let center = self.at(t);
+            let radius = self.radius_at(t);
+            let inside = region
+                .rings
+                .iter()
+                .map(|ring| ring_winding(ring, center))
+                .sum::<i32>()
+                != 0
+                || region.rings.iter().flat_map(ring_edges).any(|(a, b)| {
+                    dot(center - a, perpendicular(b - a)) == 0.0
+                        && dot(center - a, center - b) <= 0.0
+                });
+            if isolated {
+                let vectors = self
+                    .contacts
+                    .map(|(a, b)| dist::point_segment(center, a, b).1 - center);
+                radius > error
+                    && inside
+                    && constraints.iter().all(|&p| value(p, t) >= -error)
+                    && dot(vectors[0], vectors[1])
+                        < -error * (vectors[0].length() + vectors[1].length())
+                    && nearby
+                        .iter()
+                        .all(|&(a, b)| dist::point_segment(center, a, b).0 >= radius - error)
+            } else {
+                // Tolerant point checks must never certify an open interval:
+                // its membership is constant only for these exact root predicates.
+                radius > 0.0
+                    && inside
+                    && constraints.iter().all(|&p| value(p, t) >= 0.0)
+                    && clearance.iter().all(|wall| wall.contains(t))
+            }
+        })
+    }
+
+    pub fn endpoints(self) -> (Point, Point) {
+        (self.at(self.range.0), self.at(self.range.1))
+    }
+
+    pub fn minimum(self) -> (Point, f64, Point, Point) {
+        let mut candidates = vec![self.range.0, self.range.1];
+        if self.radius[2] != 0.0 {
+            candidates
+                .push((-self.radius[1] / (2.0 * self.radius[2])).clamp(self.range.0, self.range.1));
+        }
+        if !self.squared_radius {
+            candidates.extend(
+                roots(self.radius)
+                    .into_iter()
+                    .filter(|t| (self.range.0..=self.range.1).contains(t)),
+            );
+        }
+        let t = candidates
+            .into_iter()
+            .min_by(|&a, &b| self.radius_at(a).total_cmp(&self.radius_at(b)))
+            .unwrap();
+        let center = self.at(t);
+        let contacts = self
+            .contacts
+            .map(|(a, b)| dist::point_segment(center, a, b).1);
+        (center, self.radius_at(t), contacts[0], contacts[1])
+    }
+
+    pub fn walls(self) -> [(Point, Point); 2] {
+        let (start, end) = self.endpoints();
+        self.contacts.map(|(a, b)| {
+            (
+                dist::point_segment(start, a, b).1,
+                dist::point_segment(end, a, b).1,
+            )
+        })
+    }
+
+    pub fn polyline(self, tolerance_mm: f64) -> Vec<Point> {
+        let mut points = vec![self.at(self.range.0)];
+        let mut pending = vec![self.range];
+        while let Some((start, end)) = pending.pop() {
+            let middle = start.midpoint(end);
+            // Exact maximum deviation of a quadratic from its chord.
+            let deviation = self.center[2].length() * (end - start).powi(2) / 4.0;
+            if deviation > tolerance_mm && middle != start && middle != end {
+                pending.push((middle, end));
+                pending.push((start, middle));
+            } else {
+                points.push(self.at(end));
+            }
+        }
+        points
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geom::Resolution;
+
+    fn region() -> ContourSet {
+        ContourSet::rectangle(
+            BBox::new(Point::new(-2.0, -2.0), Point::new(2.0, 2.0)),
+            Resolution::default(),
+        )
+    }
+
+    #[test]
+    fn off_grid_parallel_walls_have_equal_radii() {
+        let first = (Point::new(-3.0, 0.00037), Point::new(3.0, 0.00037));
+        let second = (Point::new(-3.0, 0.00837), Point::new(3.0, 0.00837));
+        let region = region();
+        let boundary = PreparedRegion::from_segments(vec![first, second], 0.0);
+        let axes = WidthAxis::between(first, second, region.bbox)
+            .into_iter()
+            .flat_map(|a| a.in_region(&region, &boundary))
+            .collect::<Vec<_>>();
+        assert!(!axes.is_empty());
+        for axis in axes {
+            let (center, radius, first, second) = axis.minimum();
+            assert!((radius - 0.004).abs() < 1e-12);
+            assert!((center.y - 0.00437).abs() < 1e-12);
+            assert!((center.distance_to(first) - radius).abs() < 1e-12);
+            assert!((center.distance_to(second) - radius).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn oblique_bisectors_remain_equidistant_throughout_their_spans() {
+        let transform = |p: Point| {
+            Point::new(
+                123.4567 + 0.6 * p.x - 0.8 * p.y,
+                -98.7654 + 0.8 * p.x + 0.6 * p.y,
+            )
+        };
+        let point = Point::new(0.0, 0.7);
+        for (first, second) in [
+            (
+                (Point::new(-2.0, -0.3), Point::new(2.0, -0.1)),
+                (Point::new(-2.0, 0.4), Point::new(2.0, 0.2)),
+            ),
+            (
+                (point, point),
+                (Point::new(-2.0, -0.1), Point::new(2.0, 0.2)),
+            ),
+            (
+                (point, point),
+                (Point::new(0.4, -0.3), Point::new(0.4, -0.3)),
+            ),
+        ] {
+            let walls = [first, second].map(|(a, b)| (transform(a), transform(b)));
+            let region = ContourSet::rectangle(
+                BBox::from_point(transform(Point::ZERO)).expand(1.5),
+                Resolution::default(),
+            );
+            let boundary = PreparedRegion::from_segments(walls.to_vec(), 0.0);
+            let axes = WidthAxis::between(walls[0], walls[1], region.bbox)
+                .into_iter()
+                .flat_map(|a| a.in_region(&region, &boundary))
+                .collect::<Vec<_>>();
+            assert!(!axes.is_empty());
+            for axis in axes {
+                for i in 0..=7 {
+                    let t = axis.range.0 + (axis.range.1 - axis.range.0) * i as f64 / 7.0;
+                    let center = axis.at(t);
+                    let radius = axis.radius_at(t);
+                    for (a, b) in walls {
+                        assert!((dist::point_segment(center, a, b).0 - radius).abs() < 1e-10);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_shadowed_step_endpoint_cannot_establish_width() {
+        // On the point/line parabola y=(h²-x²)/(2h), obtuse contacts require
+        // y>0, but the adjoining vertical wall makes the point valid only
+        // for y<=0. No vertex or span satisfies both conditions.
+        let q = Point::ZERO;
+        let wall = (Point::new(-1.0, 0.05), Point::new(1.0, 0.05));
+        let boundary = PreparedRegion::from_segments(
+            vec![wall, (q, Point::new(0.0, 0.05)), (q, Point::new(1.0, 0.0))],
+            0.0,
+        );
+        let region = ContourSet::rectangle(
+            BBox::new(Point::new(-0.2, -0.1), Point::new(0.2, 0.1)),
+            Resolution::default(),
+        );
+        let axes = WidthAxis::between((q, q), wall, region.bbox);
+        assert!(
+            axes.into_iter()
+                .flat_map(|a| a.in_region(&region, &boundary))
+                .next()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn third_wall_clips_the_interior_not_just_endpoints() {
+        let first = (Point::new(-3.0, -1.0), Point::new(3.0, -1.0));
+        let second = (Point::new(-3.0, 1.0), Point::new(3.0, 1.0));
+        let boundary = PreparedRegion::from_segments(
+            vec![first, second, (Point::new(0.0, 0.5), Point::new(0.0, 0.6))],
+            0.0,
+        );
+        let region = region();
+        let axes = WidthAxis::between(first, second, region.bbox)
+            .into_iter()
+            .flat_map(|a| a.in_region(&region, &boundary))
+            .collect::<Vec<_>>();
+        assert_eq!(axes.len(), 2);
+        for axis in axes {
+            let (start, end) = axis.endpoints();
+            let nearer = start.x.abs().min(end.x.abs());
+            assert!((nearer - 0.75_f64.sqrt()).abs() < 1e-12);
+            assert!(start.x * end.x > 0.0);
+        }
+    }
+
+    #[test]
+    fn a_nearly_coincident_wall_cannot_validate_a_root_free_span() {
+        let point = (Point::new(0.0, 1.0), Point::new(0.0, 1.0));
+        let wall = (Point::new(-3.0, 0.0), Point::new(3.0, 0.0));
+        let region = region();
+        for displacement in [-1e-14, 0.0, 1e-8] {
+            let third = (
+                Point::new(-3.0, 1.0 + displacement),
+                Point::new(3.0, 1.0 + displacement),
+            );
+            let boundary = PreparedRegion::from_segments(vec![point, wall, third], 0.0);
+            let axes = WidthAxis::between(point, wall, region.bbox)
+                .into_iter()
+                .flat_map(|a| a.in_region(&region, &boundary))
+                .collect::<Vec<_>>();
+            if displacement < 0.0 {
+                assert!(axes.is_empty());
+            } else {
+                assert_eq!(axes.len(), 1);
+                let (start, end) = axes[0].endpoints();
+                assert!((start.x + displacement.sqrt()).abs() < 1e-10);
+                assert!((end.x - displacement.sqrt()).abs() < 1e-10);
+            }
+            for axis in axes {
+                // Checking only the minimum misses the original defect:
+                // at t=.5 its reported radius .625 exceeded clearance .375.
+                for fraction in [0.0, 0.25, 0.75, 1.0] {
+                    let t = axis.range.0 + fraction * (axis.range.1 - axis.range.0);
+                    assert!(
+                        dist::point_segment(axis.at(t), third.0, third.1).0
+                            >= axis.radius_at(t) - 1e-12
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parabola_measurement_is_independent_of_display_flattening() {
+        let point = (Point::new(0.0, 1.0), Point::new(0.0, 1.0));
+        let wall = (Point::new(-3.0, 0.0), Point::new(3.0, 0.0));
+        let boundary = PreparedRegion::from_segments(vec![point, wall], 0.0);
+        let region = region();
+        let axes = WidthAxis::between(point, wall, region.bbox)
+            .into_iter()
+            .flat_map(|a| a.in_region(&region, &boundary))
+            .collect::<Vec<_>>();
+        assert_eq!(axes.len(), 1);
+        let axis = axes[0];
+        assert!((axis.minimum().1 - 0.5).abs() < 1e-12);
+        assert!(axis.polyline(0.001).len() > axis.polyline(0.1).len());
+        let clipped = axis.clipped_radius(0.0, 0.625);
+        assert_eq!(clipped.len(), 1);
+        let (start, end) = clipped[0].endpoints();
+        assert!((start.x + 0.5).abs() < 1e-12 && (end.x - 0.5).abs() < 1e-12);
+        assert!((start.y - 0.625).abs() < 1e-12);
+        // A genuinely nearest, barely obtuse pair is not discarded by a
+        // significance-sized angular margin: t=.999 lies strictly inside.
+        let center = axis.at(0.999);
+        let region = ContourSet::rectangle(
+            BBox::from_point(center).expand(1e-5),
+            Resolution::default().with_tolerance(1e-7),
+        );
+        assert!(!axis.in_region(&region, &boundary).is_empty());
+    }
+}


### PR DESCRIPTION
Measure DFM widths on analytic bisectors of the prepared boundary. Replace snap-grid construction and sampled disk pruning so corner contacts do not produce false width failures. Add regression checks for equal-radius contacts, nearby boundaries, and interval validity.