### PR TITLE
Add finite-area mesh mechanics adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add a pure mesh-to-mechanics adapter with finite-area elastic connections and explicit board/frame support selection inputs.
+- Add mesh-based elastic support selection with finite-area connections.
 - Support KiCad 9 schematics, saving edited pages as KiCad 10.
 - Add `--accuracy-um` to set the geometry accuracy for Gerber, IPC-2581, and release output.
 - Keep circles and ellipses exact in exports and rendering.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add a pure mesh-to-mechanics adapter with finite-area elastic connections and explicit board/frame support selection inputs.
 - Support KiCad 9 schematics, saving edited pages as KiCad 10.
 - Add `--accuracy-um` to set the geometry accuracy for Gerber, IPC-2581, and release output.
 - Keep circles and ellipses exact in exports and rendering.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4419,6 +4419,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "pcb-mechanics"
+version = "0.4.51"
+dependencies = [
+ "pcb-elastic",
+ "pcb-ir",
+]
+
+[[package]]
 name = "pcb-native-dialog"
 version = "0.4.51"
 dependencies = [

--- a/crates/pcb-mechanics/Cargo.toml
+++ b/crates/pcb-mechanics/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "pcb-mechanics"
+version.workspace = true
+edition.workspace = true
+repository.workspace = true
+description = "Pure mesh-to-elastic adapter for finite-footprint support selection"
+
+[dependencies]
+pcb-ir.workspace = true
+pcb-elastic = { path = "../pcb-elastic" }

--- a/crates/pcb-mechanics/README.md
+++ b/crates/pcb-mechanics/README.md
@@ -1,0 +1,126 @@
+# pcb-mechanics
+
+Pure geometry-to-mechanics adapter for explicit support candidates (including
+calibrated mouse-bite connections). Depends on `pcb-ir` and `pcb-elastic`; neither
+foundation crate depends on this integration layer. No importer, eligibility,
+tab generation, material inference, fixtures policy, CLI, or manufacturing output.
+
+## Inputs and use
+
+`Assembly::new(plates, tolerances)` gives each board/frame mesh its own Morley
+plate DOFs and assembles the immutable base `Model`. Supply an SPD bending tensor
+per plate in global axes, and characteristic displacement/slope scales. Mesh
+component identities also separate coincident vertices/edges. Normal-slope DOFs
+use the right normal of the edge directed from smaller to larger vertex index;
+incident CCW triangles receive opposite signs. `Dof` and `element_dofs` map
+snapshot-local geometry identities to global response/load/fixture indices.
+Meshes must have valid CCW topology from `AnalysisMesh`; approximation/refinement
+status remains caller evidence, not a mechanical acceptance criterion.
+
+Each `Connection` names two finite-area footprints and a shared reference point.
+`candidate` returns the existing additive numerical candidate, preserving its ID.
+Both ends remain flexible: board/frame and board/board connections are identical
+operations. There is no implicit ground. Fixtures are explicit selected DOFs;
+selection accepts homogeneous Dirichlet constraints only. Numerical nodal loads
+can be supplied directly; a footprint resultant `[Fz, Mx, My]` maps with `Pᵀ f`.
+The same rows give fitted displacement/rotation diagnostics `P u` after solving.
+
+```rust
+use pcb_elastic::{Error, selection::{self, LoadCase, Report}};
+use pcb_mechanics::{Assembly, Connection, Dof};
+
+fn choose(
+    assembly: &Assembly,
+    connections: &[Connection],
+    cases: &[LoadCase], // global loads and explicit positive compliance limits
+    fixtures: &[Dof],
+    max_subsets: usize,
+) -> Result<Report, Error> {
+    let candidates = connections.iter()
+        .map(|c| assembly.candidate(c)).collect::<Result<Vec<_>, _>>()?;
+    let fixed = fixtures.iter()
+        .map(|&d| assembly.dof(d)).collect::<Result<Vec<_>, _>>()?;
+    selection::select(&assembly.model, &candidates, &[], cases, &fixed, max_subsets)
+}
+```
+
+Pass supplied candidate-ID conflicts instead of `&[]` when applicable. The
+existing budgeted exhaustive selector minimizes support count, then worst
+normalized compliance. Its unchanged `Report` includes selected IDs, spectral
+deformations/compliance/energy/reactions/residuals/modes, independent Cholesky
+responses, budget state and unresolved subsets. An unsupported smaller subset
+withholds an optimum certificate even if a feasible incumbent exists. Never
+interpret absence of an incumbent as infeasibility or a projected singular
+response as a physical restraint. This is not continuum/global physical optimality.
+
+## Finite-area connection model
+
+A footprint is a caller-supplied nonoverlapping partition into positive-area
+triangular `Patch` pieces. Each piece names its plate, incident element, and three
+barycentric vertices inside that element. Use mesh attachment/search APIs to
+construct these locations; the weights locate points, not P1 bending values.
+Splitting/clipping a physical landing against the mesh belongs to the caller.
+Line/point footprints are rejected. Overlapping pieces are not unioned or
+detected: repeated area would change the integration measure. A footprint may
+span elements, but not physical components. Geometry IDs must be regenerated
+after remeshing; boundary provenance and eligibility do not imply a footprint.
+
+For reference r, define the rigid-plane row
+`b(x,y) = [1, y-r_y, -(x-r_x)]`. The port is the area-L² projection
+
+`P = (∫ bᵀ b dA)⁻¹ ∫ bᵀ N_e dA`,
+
+where `N_e` is the explicitly sided Morley quadratic displacement row, scattered
+to global DOFs. Thus `P u = [w(r), theta_x, theta_y]` of the best-fit plane.
+It reproduces affine fields exactly; for those fields physical Kirchhoff
+rotations are `[w_y, -w_x]`. For warped fields these are fitted rotations, not
+point gradients or an average of element gradients. Degree-three quadrature
+integrates both polynomial products exactly. The implementation centers the fit
+at its area centroid, scales by sqrt(area), then transports to r; this avoids
+conditioning the fit on a distant reference. Extremely thin/ill-conditioned
+footprints and coordinate precision still require caller scrutiny.
+
+For two footprints at the **same** reference, `H = P_a - P_b` and the connection
+energy is `1/2 (H u)ᵀ C (H u)`. Its stiffness is `Hᵀ C H`, and force pullback
+is `Hᵀ f`; these preserve virtual work and common rigid motion even when the
+landings are separated. `C` must refer to that reference and the global rotation
+axes; transporting/rotating a calibration requires the corresponding congruence
+transform, not retaining an unrelated diagonal stiffness.
+
+Units are N and mm: w in mm, rotations/slopes dimensionless, bending tensor in
+N·mm, Cww in N/mm, Cwθ in N, Cθθ in N·mm, moments/compliance/energy in N·mm.
+`C` is checked with the existing PSD validator using unit mm/radian channel
+scales and supplied numerical tolerances; selection additionally validates the
+global contribution using the plate DOF scales. No stiffness is inferred from
+holes, tab width, thickness, a material name, or a beam approximation.
+
+This is a three-channel elastic port idealization, **not** a rigid area constraint
+or a pointwise spring bed: footprint warping orthogonal to the fitted plane is
+unrestrained by the connection. Footprint shape/extent, reference and C jointly
+define the calibration. Small footprints can be mesh-sensitive. Use physical
+validation and shape-regular refinement of a fixed finite footprint. Classical
+thin-plate bending only: no membrane, transverse shear, fracture, nonlinear
+failure, or mouse-bite breaking certification. Existing tab geometry is unchanged.
+
+## Verification and scale
+
+`cargo nextest run -p pcb-mechanics` checks analytical asymmetric quadratic
+area projection under refinement; force/moment virtual work; common motion;
+rotated stiffness/normal signs; partial-patch subdivision/reference transport;
+invalid footprints and hidden negative C; unsupported/free-frame configurations;
+candidate non-accumulation; and selection against independent complete assembly
+using physical polynomial interpolation, positive Gauss/Duffy integration and
+direct Cholesky. That path shares only mesh and DOF identities with the adapter.
+
+A ν=0 cantilever frame with a floating board and whole-area ports has exact
+compliance `F²/Cww + F² L³/(20 D width) = 0.5158461538461538 N·mm` for the test
+inputs. Refining the frame (38, 115, 371 total DOFs) gives absolute errors
+0.03756668, 0.00911049, 0.00226478. This exercises solved finite-area coupling,
+not a single-point convergence claim. These synthetic results do not certify
+real PCB accuracy or any other attachment geometry/calibration.
+
+Dense candidate storage is O(m n²), and exhaustive search has exponential subset
+count with cubic full solves. No scalability upgrade or large-panel claim is
+made. Small synthetic models are the intended current scope. Production wiring
+still must supply landing partitions, calibrated stiffness, real fixtures/loads,
+limits, geometry evidence, and independent selected-model acceptance.

--- a/crates/pcb-mechanics/src/lib.rs
+++ b/crates/pcb-mechanics/src/lib.rs
@@ -1,0 +1,296 @@
+#![doc = include_str!("../README.md")]
+use std::collections::BTreeMap;
+
+use pcb_elastic::{Contribution, DMatrix, Error, Model, Tolerances, elements::MorleyTriangle};
+use pcb_ir::geom::mesh::AnalysisMesh;
+
+/// All coordinates are mm. Bending tensor acts on [w,xx, w,yy, 2w,xy], in N·mm,
+/// in the mesh's global axes (rotate orthotropic tensors before supplying them).
+pub struct Plate<'a> {
+    pub mesh: &'a AnalysisMesh,
+    pub bending: DMatrix<f64>,
+    /// Characteristic [w (mm), normal slope] for numerical scaling, not restraints.
+    pub scales: [f64; 2],
+}
+
+/// Snapshot-local, component-separated DOF identity. Edge endpoints are sorted;
+/// their canonical normal is (dy,-dx)/length from the smaller to larger index.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Dof {
+    Vertex {
+        plate: usize,
+        component: usize,
+        vertex: usize,
+    },
+    Slope {
+        plate: usize,
+        component: usize,
+        edge: [usize; 2],
+    },
+}
+
+/// A positive-area triangular part of an attachment, wholly inside one named
+/// element. Vertices are barycentric locations, not bending shape weights.
+/// Patches must partition the physical footprint without overlap; no snapping,
+/// clipping, union, or incident-side choice is performed by this adapter.
+#[derive(Clone, Debug)]
+pub struct Patch {
+    pub plate: usize,
+    pub element: usize,
+    pub vertices: [[f64; 3]; 3],
+}
+
+/// One candidate, counted once by the existing selector. Neither side is ground.
+pub struct Connection {
+    pub id: usize,
+    pub a: Vec<Patch>,
+    pub b: Vec<Patch>,
+    /// Shared global reference for both fitted rigid planes, in mm.
+    pub reference: [f64; 2],
+    /// Symmetric PSD stiffness on relative [w, theta_x, theta_y]. Energy is
+    /// 1/2 dᵀ C d. Units: Cww N/mm, Cwθ N, Cθθ N·mm. Explicit calibration input.
+    pub stiffness: DMatrix<f64>,
+}
+
+struct Element {
+    triangle: MorleyTriangle,
+    vertices: [[f64; 2]; 3],
+    dofs: [usize; 6],
+    component: usize,
+}
+
+/// Immutable plate base and snapshot-local mappings. Loads and fixtures use
+/// `dof`/`element_dofs`; footprint resultants use `port(...).transpose() * f`.
+/// Feed `model`, `candidate` results and numerical load cases to
+/// `pcb_elastic::selection::select`; its report retains all budget/failure status.
+pub struct Assembly {
+    pub model: Model,
+    elements: Vec<Vec<Element>>,
+    dofs: BTreeMap<Dof, usize>,
+    tolerances: Tolerances,
+}
+
+impl Assembly {
+    pub fn new(plates: &[Plate<'_>], tolerances: Tolerances) -> Result<Self, Error> {
+        let mut dofs = BTreeMap::new();
+        let mut scales = Vec::new();
+        let mut base = Vec::new();
+        let mut elements = Vec::new();
+        for (plate, p) in plates.iter().enumerate() {
+            if p.mesh.elements.is_empty() || p.scales.iter().any(|s| !s.is_finite() || *s <= 0.0) {
+                return Err(Error::InvalidInput);
+            }
+            let mut local = Vec::new();
+            for e in &p.mesh.elements {
+                let mut vertices = [[0.0; 2]; 3];
+                let mut indices = [0; 6];
+                let mut signs = [0.0; 3];
+                for i in 0..3 {
+                    let v = e.vertices[i];
+                    let point = p.mesh.vertices.get(v).ok_or(Error::InvalidInput)?;
+                    vertices[i] = [point.x, point.y];
+                    let mut edge = [v, e.vertices[(i + 1) % 3]];
+                    signs[i] = if edge[0] < edge[1] { 1.0 } else { -1.0 };
+                    edge.sort();
+                    for (slot, key, scale) in [
+                        (
+                            i,
+                            Dof::Vertex {
+                                plate,
+                                component: e.component,
+                                vertex: v,
+                            },
+                            p.scales[0],
+                        ),
+                        (
+                            3 + i,
+                            Dof::Slope {
+                                plate,
+                                component: e.component,
+                                edge,
+                            },
+                            p.scales[1],
+                        ),
+                    ] {
+                        indices[slot] = *dofs.entry(key).or_insert_with(|| {
+                            scales.push(scale);
+                            scales.len() - 1
+                        });
+                    }
+                }
+                let triangle = MorleyTriangle::new(vertices, signs)?;
+                base.push(Contribution {
+                    dofs: indices.to_vec(),
+                    stiffness: triangle.stiffness(&p.bending)?,
+                });
+                local.push(Element {
+                    triangle,
+                    vertices,
+                    dofs: indices,
+                    component: e.component,
+                });
+            }
+            elements.push(local);
+        }
+        Ok(Self {
+            model: Model::new(scales, &base, tolerances)?,
+            elements,
+            dofs,
+            tolerances,
+        })
+    }
+
+    pub fn dof(&self, key: Dof) -> Result<usize, Error> {
+        self.dofs.get(&key).copied().ok_or(Error::InvalidInput)
+    }
+
+    pub fn ndofs(&self) -> usize {
+        self.dofs.len()
+    }
+
+    pub fn element_dofs(&self, plate: usize, element: usize) -> Result<[usize; 6], Error> {
+        Ok(self.element(plate, element)?.dofs)
+    }
+
+    fn element(&self, plate: usize, element: usize) -> Result<&Element, Error> {
+        self.elements
+            .get(plate)
+            .and_then(|p| p.get(element))
+            .ok_or(Error::InvalidInput)
+    }
+
+    /// Area L² projection of the element-sided quadratic w onto the rigid plane
+    /// w(x,y) = z + theta_x (y-ref_y) - theta_y (x-ref_x).
+    /// Returns global rows for [z, theta_x, theta_y]. Integrals are exact for P2
+    /// fields; rotations come from the fitted displacement, NOT averaged gradients.
+    /// Each footprint must belong to one physical plate/component. Non-affine
+    /// warping orthogonal to this fit is unrestrained by the connection.
+    pub fn port(&self, patches: &[Patch], reference: [f64; 2]) -> Result<DMatrix<f64>, Error> {
+        if patches.is_empty() || reference.iter().any(|x| !x.is_finite()) {
+            return Err(Error::InvalidInput);
+        }
+        let mut gram = DMatrix::<f64>::zeros(3, 3);
+        let mut rhs = DMatrix::<f64>::zeros(3, self.ndofs());
+        let mut owner = None;
+        let origin = self.element(patches[0].plate, patches[0].element)?.vertices[0];
+        let mut prepared = Vec::new();
+        let mut total_area = 0.0;
+        let mut centroid = [0.0; 2];
+        for patch in patches {
+            let e = self.element(patch.plate, patch.element)?;
+            let identity = (patch.plate, e.component);
+            if owner.is_some_and(|o| o != identity) {
+                return Err(Error::InvalidInput);
+            }
+            owner = Some(identity);
+            let mut points = [[0.0; 2]; 3];
+            for (i, bary) in patch.vertices.iter().enumerate() {
+                e.triangle.attachment(*bary)?; // validate each patch vertex
+                points[i] = [0, 1].map(|axis| {
+                    (0..3)
+                        .map(|j| bary[j] * (e.vertices[j][axis] - origin[axis]))
+                        .sum()
+                });
+            }
+            let [a, b, c] = points;
+            let area = ((b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])).abs() / 2.0;
+            if !area.is_finite() || area <= 0.0 {
+                return Err(Error::InvalidInput);
+            }
+            total_area += area;
+            for axis in 0..2 {
+                centroid[axis] += area * points.iter().map(|p| p[axis]).sum::<f64>() / 3.0;
+            }
+            prepared.push((patch, e, points, area));
+        }
+        if !total_area.is_finite() {
+            return Err(Error::NumericalFailure);
+        }
+        let length = total_area.sqrt();
+        centroid.iter_mut().for_each(|x| *x /= total_area);
+        for (patch, e, points, area) in prepared {
+            // Degree-three triangle rule: exact for plane × quadratic shape.
+            for (q, weight) in [
+                ([1.0 / 3.0; 3], -27.0 / 48.0),
+                ([0.6, 0.2, 0.2], 25.0 / 48.0),
+                ([0.2, 0.6, 0.2], 25.0 / 48.0),
+                ([0.2, 0.2, 0.6], 25.0 / 48.0),
+            ] {
+                let bary = [0, 1, 2].map(|i| (0..3).map(|j| q[j] * patch.vertices[j][i]).sum());
+                let point: [f64; 2] = [0, 1].map(|i| (0..3).map(|j| q[j] * points[j][i]).sum());
+                // Fit near the footprint, in dimensionless coordinates. Changing
+                // the requested reference then transports a plane, rather than
+                // solving nearly dependent columns for a small distant footprint.
+                let plane = [
+                    1.0,
+                    (point[1] - centroid[1]) / length,
+                    (centroid[0] - point[0]) / length,
+                ];
+                let shape = e.triangle.attachment(bary)?.rows;
+                for i in 0..3 {
+                    for j in 0..3 {
+                        gram[(i, j)] += area * weight * plane[i] * plane[j];
+                    }
+                    for j in 0..6 {
+                        rhs[(i, e.dofs[j])] += area * weight * plane[i] * shape[(0, j)];
+                    }
+                }
+            }
+        }
+        let fit = gram.cholesky().ok_or(Error::NumericalFailure)?.solve(&rhs);
+        let transport = DMatrix::from_row_slice(
+            3,
+            3,
+            &[
+                1.0,
+                (reference[1] - origin[1] - centroid[1]) / length,
+                (origin[0] - reference[0] + centroid[0]) / length,
+                0.0,
+                1.0 / length,
+                0.0,
+                0.0,
+                0.0,
+                1.0 / length,
+            ],
+        );
+        let rows = transport * fit;
+        if rows.iter().any(|x| !x.is_finite()) {
+            return Err(Error::NumericalFailure);
+        }
+        Ok(rows)
+    }
+
+    pub fn candidate(
+        &self,
+        connection: &Connection,
+    ) -> Result<pcb_elastic::selection::Candidate, Error> {
+        let c = &connection.stiffness;
+        if c.shape() != (3, 3) || c.iter().any(|x| !x.is_finite()) {
+            return Err(Error::InvalidInput);
+        }
+        // Validate C itself, not just its pullback (a null H can hide negative C).
+        // Channel validation uses unit mm/radian scales and the supplied solver
+        // tolerances. The selector additionally validates the scaled global K.
+        Model::new(
+            vec![1.0; 3],
+            &[Contribution {
+                dofs: vec![0, 1, 2],
+                stiffness: c.clone(),
+            }],
+            self.tolerances,
+        )?;
+        let h = self.port(&connection.a, connection.reference)?
+            - self.port(&connection.b, connection.reference)?;
+        let stiffness = h.transpose() * c * h;
+        if stiffness.iter().any(|x| !x.is_finite()) {
+            return Err(Error::NumericalFailure);
+        }
+        Ok(pcb_elastic::selection::Candidate {
+            id: connection.id,
+            contributions: vec![Contribution {
+                dofs: (0..self.ndofs()).collect(),
+                stiffness: (&stiffness + stiffness.transpose()) * 0.5,
+            }],
+        })
+    }
+}

--- a/crates/pcb-mechanics/tests/adapter.rs
+++ b/crates/pcb-mechanics/tests/adapter.rs
@@ -1,0 +1,509 @@
+use pcb_elastic::{
+    DMatrix, DVector, Status, Tolerances,
+    selection::{self, LoadCase, Proof},
+};
+use pcb_ir::geom::{
+    BBox, ContourSet, Point, Resolution,
+    mesh::{AnalysisMesh, MeshOptions},
+};
+use pcb_mechanics::{Assembly, Connection, Dof, Patch, Plate};
+
+fn tolerances() -> Tolerances {
+    Tolerances {
+        rank_relative: 1e-10,
+        rank_absolute: 1e-12,
+        residual_relative: 1e-9,
+        residual_absolute: 1e-10,
+    }
+}
+
+fn mesh(x: f64, area: f64) -> AnalysisMesh {
+    AnalysisMesh::new(
+        &ContourSet::rectangle(
+            BBox::new(Point::new(x, -0.3), Point::new(x + 2.4, 1.0)),
+            Resolution::default(),
+        ),
+        MeshOptions {
+            max_area_mm2: area,
+            min_angle_degrees: 25.0,
+            max_additional_vertices: 1000,
+        },
+    )
+    .unwrap()
+}
+
+fn bending() -> DMatrix<f64> {
+    DMatrix::from_row_slice(3, 3, &[2.0, 0.3, 0.0, 0.3, 2.0, 0.0, 0.0, 0.0, 0.85])
+}
+
+fn assembly(meshes: &[AnalysisMesh]) -> Assembly {
+    Assembly::new(
+        &meshes
+            .iter()
+            .map(|mesh| Plate {
+                mesh,
+                bending: bending(),
+                scales: [0.7, 0.4],
+            })
+            .collect::<Vec<_>>(),
+        tolerances(),
+    )
+    .unwrap()
+}
+
+fn footprint(plate: usize, mesh: &AnalysisMesh) -> Vec<Patch> {
+    (0..mesh.elements.len())
+        .map(|element| Patch {
+            plate,
+            element,
+            vertices: [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        })
+        .collect()
+}
+
+fn stiffness() -> DMatrix<f64> {
+    DMatrix::from_row_slice(3, 3, &[4.0, 0.3, -0.7, 0.3, 2.0, 0.2, -0.7, 0.2, 3.0])
+}
+
+fn connection(meshes: &[AnalysisMesh], id: usize, factor: f64) -> Connection {
+    Connection {
+        id,
+        a: footprint(0, &meshes[0]),
+        b: footprint(1, &meshes[1]),
+        reference: [2.7, 0.15],
+        stiffness: stiffness() * factor,
+    }
+}
+
+fn close(a: &DMatrix<f64>, b: &DMatrix<f64>, tolerance: f64) {
+    assert!(
+        (a - b).norm() < tolerance * (1.0 + b.norm()),
+        "error {}",
+        (a - b).norm()
+    );
+}
+
+// Independent physical polynomial DOFs, including canonical midpoint normals.
+fn polynomial(a: &Assembly, meshes: &[AnalysisMesh], c: [f64; 6]) -> DVector<f64> {
+    let mut u = DVector::zeros(a.ndofs());
+    for (plate, mesh) in meshes.iter().enumerate() {
+        for e in &mesh.elements {
+            for i in 0..3 {
+                let v = e.vertices[i];
+                let p = mesh.vertices[v];
+                u[a.dof(Dof::Vertex {
+                    plate,
+                    component: e.component,
+                    vertex: v,
+                })
+                .unwrap()] = c[0]
+                    + c[1] * p.x
+                    + c[2] * p.y
+                    + c[3] * p.x * p.x
+                    + c[4] * p.x * p.y
+                    + c[5] * p.y * p.y;
+                let mut edge = [v, e.vertices[(i + 1) % 3]];
+                edge.sort();
+                let p = mesh.vertices[edge[0]];
+                let q = mesh.vertices[edge[1]];
+                let (x, y) = ((p.x + q.x) / 2.0, (p.y + q.y) / 2.0);
+                let length = p.distance_to(q);
+                u[a.dof(Dof::Slope {
+                    plate,
+                    component: e.component,
+                    edge,
+                })
+                .unwrap()] = ((q.y - p.y) * (c[1] + 2.0 * c[3] * x + c[4] * y)
+                    - (q.x - p.x) * (c[2] + c[4] * x + 2.0 * c[5] * y))
+                    / length;
+            }
+        }
+    }
+    u
+}
+
+#[test]
+fn finite_area_projection_and_virtual_work_under_refinement() {
+    // Exact rectangular L² projection of a quadratic. Centroid/point evaluation
+    // gives a different translation; averaging gradients is not this operator.
+    for area in [2.0, 0.3, 0.08] {
+        let meshes = [mesh(0.2, area)];
+        let a = assembly(&meshes);
+        let c = [0.8, -0.4, 0.7, 0.9, -0.6, 0.2];
+        let u = polynomial(&a, &meshes, c);
+        let reference = [-0.7, 1.4];
+        let p = a.port(&footprint(0, &meshes[0]), reference).unwrap();
+        let (x, y) = (1.4, 0.35);
+        let gx = c[1] + 2.0 * c[3] * x + c[4] * y;
+        let gy = c[2] + c[4] * x + 2.0 * c[5] * y;
+        let mean = c[0]
+            + c[1] * x
+            + c[2] * y
+            + c[3] * (x * x + 2.4_f64.powi(2) / 12.0)
+            + c[4] * x * y
+            + c[5] * (y * y + 1.3_f64.powi(2) / 12.0);
+        let expected = DVector::from_vec(vec![
+            mean + gx * (reference[0] - x) + gy * (reference[1] - y),
+            gy,
+            -gx,
+        ]);
+        assert!((&p * &u - &expected).norm() < 1e-10);
+        let f = DVector::from_vec(vec![1.2, -0.8, 0.35]);
+        assert!((u.dot(&(p.transpose() * &f)) - expected.dot(&f)).abs() < 1e-10);
+        // Force/moment resultants against three independent rigid test fields.
+        for c in [
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+        ] {
+            let rigid = polynomial(&a, &meshes, c);
+            let expected = f[0] * (c[0] + c[1] * reference[0] + c[2] * reference[1]) + f[1] * c[2]
+                - f[2] * c[1];
+            assert!((rigid.dot(&(p.transpose() * &f)) - expected).abs() < 1e-10);
+        }
+    }
+}
+
+#[test]
+fn common_motion_energy_and_rotation_covariance() {
+    let meshes = [mesh(0.2, 2.0), mesh(3.1, 2.0)];
+    let a = assembly(&meshes);
+    let c = connection(&meshes, 7, 1.0);
+    let candidate = a.candidate(&c).unwrap();
+    let k = &candidate.contributions[0].stiffness;
+    let u = polynomial(&a, &meshes, [0.7, -0.4, 1.3, 0.0, 0.0, 0.0]);
+    assert!(
+        (k * &u).norm() < 1e-9,
+        "separated footprints must share a reference"
+    );
+    let u = DVector::from_iterator(a.ndofs(), (0..a.ndofs()).map(|i| (i as f64 * 1.7).sin()));
+    let delta = (a.port(&c.a, c.reference).unwrap() - a.port(&c.b, c.reference).unwrap()) * &u;
+    assert!((u.dot(&(k * &u)) - delta.dot(&(&c.stiffness * &delta))).abs() < 1e-9);
+    let angle: f64 = 0.63;
+    let (s, co) = angle.sin_cos();
+    let rotate = |p: [f64; 2]| [co * p[0] - s * p[1], s * p[0] + co * p[1]];
+    let mut rotated = meshes.clone();
+    for mesh in &mut rotated {
+        for p in &mut mesh.vertices {
+            let q = rotate([p.x, p.y]);
+            *p = Point::new(q[0], q[1]);
+        }
+    }
+    let ar = assembly(&rotated);
+    let t = DMatrix::from_row_slice(3, 3, &[1.0, 0.0, 0.0, 0.0, co, -s, 0.0, s, co]);
+    let mut cr = connection(&rotated, 7, 1.0);
+    cr.reference = rotate(c.reference);
+    cr.stiffness = &t * &c.stiffness * t.transpose();
+    // Canonical slopes are scalar normal derivatives: simultaneous mesh/normal
+    // rotation leaves the global DOF coordinates unchanged.
+    close(
+        k,
+        &ar.candidate(&cr).unwrap().contributions[0].stiffness,
+        1e-10,
+    );
+    let fixed: Vec<_> = (0..a.ndofs()).map(|i| (i, u[i])).collect();
+    let e = a
+        .model
+        .evaluate(&[], &vec![0.0; a.ndofs()], &fixed)
+        .unwrap()
+        .strain_energy;
+    let er = ar
+        .model
+        .evaluate(&[], &vec![0.0; a.ndofs()], &fixed)
+        .unwrap()
+        .strain_energy;
+    assert!((e - er).abs() < 1e-9);
+}
+
+// An independent complete-model path: physical-coordinate Vandermonde inverse,
+// positive 3x3 Gauss/Duffy integration, global assembly, and direct Cholesky.
+// It does not call MorleyTriangle, Assembly::port, or candidate composition.
+fn independent(
+    meshes: &[AnalysisMesh],
+    a: &Assembly,
+    reference: [f64; 2],
+) -> (DMatrix<f64>, Vec<DMatrix<f64>>) {
+    let mut k = DMatrix::zeros(a.ndofs(), a.ndofs());
+    let mut ports = Vec::new();
+    for (plate, mesh) in meshes.iter().enumerate() {
+        let mut gram = DMatrix::zeros(3, 3);
+        let mut rhs = DMatrix::zeros(3, a.ndofs());
+        for (element, e) in mesh.elements.iter().enumerate() {
+            let points = e.vertices.map(|v| mesh.vertices[v]);
+            let mut v = DMatrix::zeros(6, 6);
+            for i in 0..3 {
+                let p = points[i];
+                v.row_mut(i).copy_from(
+                    &DMatrix::from_row_slice(
+                        1,
+                        6,
+                        &[1.0, p.x, p.y, p.x * p.x, p.x * p.y, p.y * p.y],
+                    )
+                    .row(0),
+                );
+                let j = (i + 1) % 3;
+                let (p, q) = if e.vertices[i] < e.vertices[j] {
+                    (points[i], points[j])
+                } else {
+                    (points[j], points[i])
+                };
+                let (nx, ny) = (
+                    (q.y - p.y) / p.distance_to(q),
+                    (p.x - q.x) / p.distance_to(q),
+                );
+                let (x, y) = ((p.x + q.x) / 2.0, (p.y + q.y) / 2.0);
+                v.row_mut(3 + i).copy_from(
+                    &DMatrix::from_row_slice(
+                        1,
+                        6,
+                        &[0.0, nx, ny, 2.0 * x * nx, y * nx + x * ny, 2.0 * y * ny],
+                    )
+                    .row(0),
+                );
+            }
+            let inv = v.try_inverse().unwrap();
+            let hessian = DMatrix::from_row_slice(
+                3,
+                6,
+                &[
+                    0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0,
+                    2.0, 0.0,
+                ],
+            ) * &inv;
+            let [p, q, r] = points;
+            let jac = (q.x - p.x) * (r.y - p.y) - (q.y - p.y) * (r.x - p.x);
+            let ke = hessian.transpose() * bending() * hessian * (jac / 2.0);
+            let indices = a.element_dofs(plate, element).unwrap();
+            for i in 0..6 {
+                for j in 0..6 {
+                    k[(indices[i], indices[j])] += ke[(i, j)];
+                }
+            }
+            let rule = [
+                (0.5 - (0.6_f64).sqrt() / 2.0, 5.0 / 18.0),
+                (0.5, 4.0 / 9.0),
+                (0.5 + (0.6_f64).sqrt() / 2.0, 5.0 / 18.0),
+            ];
+            for (u, wu) in rule {
+                for (v, wv) in rule {
+                    let x = p.x + u * (q.x - p.x) + (1.0 - u) * v * (r.x - p.x);
+                    let y = p.y + u * (q.y - p.y) + (1.0 - u) * v * (r.y - p.y);
+                    let w = jac * (1.0 - u) * wu * wv;
+                    let plane = DVector::from_vec(vec![1.0, y - reference[1], reference[0] - x]);
+                    gram += &plane * plane.transpose() * w;
+                    let shape =
+                        DMatrix::from_row_slice(1, 6, &[1.0, x, y, x * x, x * y, y * y]) * &inv;
+                    for i in 0..3 {
+                        for j in 0..6 {
+                            rhs[(i, indices[j])] += plane[i] * shape[(0, j)] * w;
+                        }
+                    }
+                }
+            }
+        }
+        ports.push(gram.lu().solve(&rhs).unwrap());
+    }
+    (k, ports)
+}
+
+fn clamp_frame(a: &Assembly, frame: &AnalysisMesh) -> Vec<usize> {
+    let mut fixed = Vec::new();
+    for edge in &frame.boundary {
+        if edge
+            .vertices
+            .iter()
+            .all(|&v| (frame.vertices[v].x - 3.1).abs() < 1e-10)
+        {
+            for &vertex in &edge.vertices {
+                fixed.push(
+                    a.dof(Dof::Vertex {
+                        plate: 1,
+                        component: 0,
+                        vertex,
+                    })
+                    .unwrap(),
+                );
+            }
+            let mut vertices = edge.vertices;
+            vertices.sort();
+            fixed.push(
+                a.dof(Dof::Slope {
+                    plate: 1,
+                    component: 0,
+                    edge: vertices,
+                })
+                .unwrap(),
+            );
+        }
+    }
+    fixed.sort();
+    fixed.dedup();
+    assert!(fixed.len() >= 3);
+    fixed
+}
+
+#[test]
+fn selection_matches_independent_complete_frame_model_and_does_not_accumulate() {
+    let meshes = [mesh(0.2, 1.0), mesh(3.1, 1.0)];
+    let a = assembly(&meshes);
+    let c = connection(&meshes, 19, 1.0);
+    let (base, ports) = independent(&meshes, &a, c.reference);
+    let f = ports[0].transpose() * DVector::from_vec(vec![0.4, -0.15, 0.2]);
+    // Clamp one end of the actual flexible frame; board is not fixed.
+    let fixed = clamp_frame(&a, &meshes[1]);
+    let prescribed: Vec<_> = fixed.iter().map(|&d| (d, 0.0)).collect();
+    let empty = a.model.evaluate(&[], f.as_slice(), &prescribed).unwrap();
+    assert_eq!(empty.status, Status::SingularIncompatible);
+    assert!(!empty.unsupported_modes.is_empty());
+    let candidates = [
+        a.candidate(&c).unwrap(),
+        a.candidate(&connection(&meshes, 3, 0.3)).unwrap(),
+    ];
+    let h = &ports[0] - &ports[1];
+    let full = base + h.transpose() * stiffness() * h;
+    let free: Vec<_> = (0..a.ndofs()).filter(|d| !fixed.contains(d)).collect();
+    let kff = DMatrix::from_fn(free.len(), free.len(), |i, j| full[(free[i], free[j])]);
+    let ff = DVector::from_iterator(free.len(), free.iter().map(|&d| f[d]));
+    let u = kff.cholesky().unwrap().solve(&ff);
+    let compliance = ff.dot(&u);
+    let cases = [LoadCase {
+        loads: f.as_slice().to_vec(),
+        compliance_limit: compliance * 1.1,
+    }];
+    let report = selection::select(&a.model, &candidates, &[], &cases, &fixed, 4).unwrap();
+    let selected = report.selected.unwrap();
+    assert_eq!(selected.ids, vec![19]);
+    assert_eq!(report.proof, Proof::Unresolved); // empty disconnected set is unresolved
+    for (i, &d) in free.iter().enumerate() {
+        assert!((selected.analyses[0].displacement[d] - u[i]).abs() < 1e-7);
+    }
+    assert!((selected.analyses[0].compliance - compliance).abs() < 1e-8);
+    let frame_response = &ports[1] * &selected.analyses[0].displacement;
+    assert!(
+        frame_response.norm() > 1e-3,
+        "frame must flex, not act as ground"
+    );
+    let again = a.model.evaluate(&[], f.as_slice(), &prescribed).unwrap();
+    assert_eq!(again.status, empty.status);
+    assert!((again.displacement - empty.displacement).norm() < 1e-12);
+    let budget = selection::select(&a.model, &candidates, &[], &cases, &fixed, 1).unwrap();
+    assert_eq!(budget.proof, Proof::BudgetExhausted);
+    assert!(budget.selected.is_none());
+    assert_eq!(budget.unresolved.len(), 1);
+    let unsupported = a
+        .model
+        .evaluate(&candidates[0].contributions, f.as_slice(), &[])
+        .unwrap();
+    assert_eq!(unsupported.status, Status::SingularIncompatible);
+}
+
+#[test]
+fn finite_footprint_response_converges_to_uniform_cantilever_solution() {
+    // ν=0 makes the rectangular Kirchhoff plate's uniform-y solution exactly
+    // the 1D cantilever solution D w''''=q. No beam element is used here.
+    // The port load at the frame centroid is uniform pressure. The floating
+    // board undergoes rigid motion; its extra compliance is exactly F²/Cww.
+    // Integrating w=q*x²*(6L²-4Lx+x²)/(24D) gives F² L³/(20 D width).
+    let exact = 1.0 / 4.0 + 2.4_f64.powi(3) / (20.0 * 2.0 * 1.3);
+    let mut errors = Vec::new();
+    for area in [0.5, 0.125, 0.03125] {
+        let meshes = [mesh(0.2, 2.0), mesh(3.1, area)];
+        let a = Assembly::new(
+            &meshes
+                .iter()
+                .map(|mesh| Plate {
+                    mesh,
+                    bending: DMatrix::from_diagonal(&DVector::from_vec(vec![2.0, 2.0, 1.0])),
+                    scales: [0.7, 0.4],
+                })
+                .collect::<Vec<_>>(),
+            tolerances(),
+        )
+        .unwrap();
+        let mut c = connection(&meshes, 1, 1.0);
+        c.reference = [4.3, 0.35];
+        c.stiffness = DMatrix::from_diagonal(&DVector::from_vec(vec![4.0, 2.0, 3.0]));
+        let f = a.port(&c.a, c.reference).unwrap().row(0).transpose();
+        let fixed: Vec<_> = clamp_frame(&a, &meshes[1])
+            .into_iter()
+            .map(|d| (d, 0.0))
+            .collect();
+        let response = a
+            .model
+            .evaluate(
+                &a.candidate(&c).unwrap().contributions,
+                f.as_slice(),
+                &fixed,
+            )
+            .unwrap();
+        assert_eq!(response.status, Status::Stable);
+        errors.push((response.compliance - exact).abs());
+        eprintln!(
+            "area={area}, dofs={}, compliance={}, exact={exact}, error={}",
+            a.ndofs(),
+            response.compliance,
+            errors.last().unwrap()
+        );
+    }
+    assert!(errors.windows(2).all(|e| e[1] < 0.7 * e[0]), "{errors:?}");
+    assert!(errors[2] < 0.01 * exact, "{errors:?}");
+}
+
+#[test]
+fn partial_patch_partition_and_reference_transport() {
+    let meshes = [mesh(0.2, 2.0)];
+    let a = assembly(&meshes);
+    let vertices = [[0.8, 0.1, 0.1], [0.1, 0.7, 0.2], [0.2, 0.2, 0.6]];
+    let patch = Patch {
+        plate: 0,
+        element: 0,
+        vertices,
+    };
+    let center = [0, 1, 2].map(|i| vertices.iter().map(|v| v[i]).sum::<f64>() / 3.0);
+    let pieces: Vec<_> = (0..3)
+        .map(|i| Patch {
+            vertices: [vertices[i], vertices[(i + 1) % 3], center],
+            ..patch.clone()
+        })
+        .collect();
+    let reference = [0.4, 0.2];
+    let p = a.port(&[patch], reference).unwrap();
+    close(&p, &a.port(&pieces, reference).unwrap(), 1e-11);
+    let far = [1e8, -2e8];
+    let t = DMatrix::from_row_slice(
+        3,
+        3,
+        &[
+            1.0,
+            far[1] - reference[1],
+            reference[0] - far[0],
+            0.0,
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            1.0,
+        ],
+    );
+    close(&a.port(&pieces, far).unwrap(), &(t * p), 1e-11);
+}
+
+#[test]
+fn invalid_footprints_and_hidden_negative_stiffness_are_rejected() {
+    let meshes = [mesh(0.2, 2.0), mesh(3.1, 2.0)];
+    let a = assembly(&meshes);
+    let mut c = connection(&meshes, 1, 1.0);
+    assert!(a.port(&[], [0.0, 0.0]).is_err());
+    let mut bad = c.a[0].clone();
+    bad.vertices = [[1.0, 0.0, 0.0]; 3];
+    assert!(a.port(&[bad], [0.0, 0.0]).is_err());
+    let mut mixed = c.a.clone();
+    mixed.push(c.b[0].clone());
+    assert!(a.port(&mixed, [0.0, 0.0]).is_err());
+    c.b = c.a.clone();
+    c.stiffness = -DMatrix::identity(3, 3);
+    assert!(
+        a.candidate(&c).is_err(),
+        "zero pullback must not hide negative material stiffness"
+    );
+}


### PR DESCRIPTION
Add a mesh-to-mechanics adapter that couples flexible boards and frames through finite-area elastic connections. Use explicit stiffness, loads, and fixtures with the existing support selector to preserve relative motion and solver diagnostics. Verify the model with analytical refinement cases and independent complete-model assembly.