### PR TITLE
feat(publish): add structured release preflight checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Add `pcb publish board.zen --check` for structured release preflight results without publishing or generating manufacturing exports; supports `--exclude` and `--suppress`.
+- Add `pcb publish --check` to run release preflight without publishing.
 - Add mesh-based elastic support selection with finite-area connections.
 - Add analysis-only `board-array create --mouse-bite` outline eligibility reports.
 - Support KiCad 9 schematics, saving edited pages as KiCad 10.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `pcb publish board.zen --check` for structured release preflight results without publishing or generating manufacturing exports; supports `--exclude` and `--suppress`.
 - Add mesh-based elastic support selection with finite-area connections.
 - Add analysis-only `board-array create --mouse-bite` outline eligibility reports.
 - Support KiCad 9 schematics, saving edited pages as KiCad 10.

--- a/crates/pcbc/src/publish.rs
+++ b/crates/pcbc/src/publish.rs
@@ -140,6 +140,10 @@ impl fmt::Display for BumpStrategy {
 #[derive(Args, Debug)]
 #[command(about = "Publish packages or board releases")]
 pub struct PublishArgs {
+    /// Check a board's release preflight and print JSON, without publishing
+    #[arg(long, conflicts_with_all = ["bump", "force", "no_push", "no_build"])]
+    pub check: bool,
+
     /// Skip preflight checks (uncommitted changes, branch, remote)
     #[arg(long, short = 'f', hide = true)]
     pub force: bool,
@@ -468,6 +472,10 @@ pub fn execute(args: PublishArgs, resolution: Resolution) -> Result<()> {
         return publish_board(&path, &args, resolution);
     }
 
+    if args.check {
+        bail!("--check requires an explicit board .zen target");
+    }
+
     // Otherwise, publish packages
     publish_packages(&path, &args)
 }
@@ -518,17 +526,17 @@ fn publish_board(zen_path: &Path, args: &PublishArgs, resolution: Resolution) ->
 
     ensure_board_publish_has_no_workspace_overrides(&workspace)?;
 
-    // Local hash release: no --bump, just build the archive
+    let mut options = release::BoardReleaseOptions {
+        version: None,
+        suppress: args.suppress.clone(),
+        exclude: args.exclude.clone(),
+        geometry_resolution: resolution,
+        check: args.check,
+    };
+
+    // Local hash release: --check stops the build after preflight.
     if args.bump.is_none() {
-        let _zip_path = release::build_board_release(
-            workspace,
-            board_path,
-            board_name,
-            args.suppress.clone(),
-            None, // version = None means use git hash
-            args.exclude.clone(),
-            resolution,
-        )?;
+        release::build_board_release(&workspace.root, board_path, board_name, options)?;
         return Ok(());
     }
 
@@ -568,22 +576,19 @@ fn publish_board(zen_path: &Path, args: &PublishArgs, resolution: Resolution) ->
     let tag_name = tags::build_tag_name(&tag_prefix, &next_version);
 
     // Build the release archive
-    let _zip_path = release::build_board_release(
-        workspace.clone(),
-        board_path,
-        board_name.clone(),
-        args.suppress.clone(),
-        Some(format!("v{}", next_version)),
-        args.exclude.clone(),
-        resolution,
-    )?;
+    options.version = Some(format!("v{}", next_version));
+    let Some(zip_path) =
+        release::build_board_release(&workspace.root, board_path, board_name.clone(), options)?
+    else {
+        return Ok(());
+    };
 
     // Upload to API (must succeed before creating tag)
     if !args.no_push {
         let ws_name = release_workspace_name(&workspace)?;
         let ctx = pcb_diode_api::WorkspaceContext::from_workspace_root(&workspace.root);
         eprintln!("Uploading release to Diode...");
-        let result = pcb_diode_api::upload_release(&_zip_path, &ws_name, &ctx)?;
+        let result = pcb_diode_api::upload_release(&zip_path, &ws_name, &ctx)?;
         if let Some(release_id) = result.release_id {
             eprintln!(
                 "{} Release uploaded: {}",

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -1695,44 +1695,6 @@ mod tests {
     }
 
     #[test]
-    fn release_check_preserves_kicad_drc_findings_and_exclusions() {
-        let violation = serde_json::json!({
-            "type": "copper_edge_clearance", "severity": "error",
-            "description": "Required 0.4 mm; actual 0.3 mm", "items": []
-        });
-        let mut violations = vec![violation.clone(); 7];
-        let mut excluded = violation;
-        excluded["excluded"] = true.into();
-        violations.push(excluded);
-        let report: pcb_kicad::drc::DrcReport = serde_json::from_value(serde_json::json!({
-            "coordinate_units": "mm", "date": "2026-09-09", "kicad_version": "9.0.0",
-            "source": "layout.kicad_pcb", "violations": violations
-        }))
-        .unwrap();
-        let mut diagnostics = Diagnostics::default();
-        report.add_to_diagnostics(&mut diagnostics, "layout.kicad_pcb");
-        let findings = release_findings(&diagnostics);
-        assert_eq!(
-            findings
-                .iter()
-                .filter(|finding| finding.blocking)
-                .map(|finding| finding.occurrences)
-                .sum::<usize>(),
-            7
-        );
-        assert!(
-            findings
-                .iter()
-                .all(|finding| finding.kind.as_deref() == Some("layout.drc.copper_edge_clearance"))
-        );
-        assert!(
-            findings
-                .iter()
-                .all(|finding| finding.message.contains("Required 0.4 mm; actual 0.3 mm"))
-        );
-    }
-
-    #[test]
     fn update_kicad_pro_release_variables_adds_missing_release_variables() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let kicad_pro_path = temp_dir.path().join("layout.kicad_pro");

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -213,9 +213,8 @@ fn execute_task<T>(
 
     spinner.finish();
     eprintln!(
-        "{}: {} ({}) {name}",
+        "{}: ({}) {name}",
         format_cumulative_time(cumulative_duration),
-        "✓".green(),
         format_task_duration(task_duration)
     );
     Ok(output)

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -1611,44 +1611,26 @@ mod tests {
     use super::*;
 
     #[test]
-    fn release_check_findings_match_publish_blockers() {
+    fn release_check_respects_suppression_and_outer_severity() {
         use pcb_zen_core::Diagnostic;
         use starlark::errors::EvalSeverity::{Error, Warning};
 
-        let warning =
-            Diagnostic::categorized("board.zen", "ordinary warning", "io.unused", Warning);
-        let schematic =
-            Diagnostic::categorized("board.zen", "schematic mismatch", "sch.mismatch", Warning);
-        let error = Diagnostic::categorized(
-            "layout.kicad_pcb",
-            "clearance",
-            "layout.drc.clearance",
-            Error,
-        );
+        let error = Diagnostic::new("clearance", Error, Path::new("layout.kicad_pcb"));
         let mut suppressed = error.clone();
         suppressed.suppressed = true;
         let wrapped = Diagnostic::new("downgraded", Warning, Path::new("board.zen"))
-            .with_child(Some(Box::new(error.clone())));
+            .with_child(Some(Box::new(error)));
         let diagnostics = Diagnostics {
-            diagnostics: vec![warning, schematic, error, suppressed, wrapped],
+            diagnostics: vec![suppressed, wrapped],
         };
-        assert_eq!(
-            diagnostics
-                .iter()
-                .map(|diagnostic| release_blocked(&Diagnostics {
-                    diagnostics: vec![diagnostic.clone()]
-                }))
-                .collect::<Vec<_>>(),
-            [false, true, true, false, false]
-        );
+        assert!(!release_blocked(&diagnostics));
         let findings =
             release_diagnostics(&diagnostics, Path::new("/repo"), Path::new("/tmp/release"));
         assert_eq!(
-            serde_json::to_value(&findings[4]).unwrap()["severity"],
+            serde_json::to_value(&findings[1]).unwrap()["severity"],
             "warning"
         );
-        assert!(findings[3].suppressed);
-        assert_eq!(findings[2].kind.as_deref(), Some("layout.drc.clearance"));
+        assert!(findings[0].suppressed);
     }
 
     #[test]

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -229,102 +229,34 @@ fn execute_tasks(info: &ReleaseInfo, tasks: &[(&str, TaskFn)], start_time: Insta
     Ok(())
 }
 
-#[derive(Debug, thiserror::Error)]
-#[error("{message}")]
-struct PreflightFailure {
-    message: String,
-    diagnostics: Diagnostics,
+fn release_blocked(diagnostics: &Diagnostics) -> bool {
+    diagnostics.error_count() > 0
+        || pcbc::kicad_schematic::has_unsuppressed_schematic_diagnostics(diagnostics)
 }
 
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct ReleaseChecks {
-    schema_version: u8,
-    status: &'static str,
-    layout_checked: bool,
-    message: Option<String>,
-    findings: Vec<ReleaseFinding>,
-}
-
-#[derive(serde::Serialize)]
-struct ReleaseFinding {
-    kind: Option<String>,
-    severity: starlark::errors::EvalSeverity,
-    message: String,
-    location: String,
-    occurrences: usize,
-    suppressed: bool,
-    blocking: bool,
-}
-
-fn release_findings(diagnostics: &Diagnostics) -> Vec<ReleaseFinding> {
+fn release_diagnostics(
+    diagnostics: &Diagnostics,
+    workspace_root: &Path,
+    staging: &Path,
+) -> Vec<pcb_zen_core::diagnostics::DiagnosticReport> {
+    let staged_src = staging.join("src").to_string_lossy().into_owned();
+    let workspace_root = workspace_root.to_string_lossy();
     diagnostics
         .iter()
         .map(|diagnostic| {
-            let report = pcb_zen_core::diagnostics::DiagnosticReport::from_diagnostic(diagnostic);
-            let schematic = report
-                .kind
-                .as_deref()
-                .is_some_and(|kind| kind == "sch" || kind.starts_with("sch."));
-            ReleaseFinding {
-                kind: report.kind,
-                // Release gating uses the outer severity, not the nested cause's.
-                severity: diagnostic.severity,
-                message: pcb_zen_core::diagnostics::diagnostic_headline(diagnostic),
-                location: report.location,
-                occurrences: report.occurrences,
-                suppressed: diagnostic.suppressed,
-                blocking: !diagnostic.suppressed && (diagnostic.is_error() || schematic),
+            let mut report =
+                pcb_zen_core::diagnostics::DiagnosticReport::from_diagnostic(diagnostic);
+            // Release gating uses the outer severity, not the nested cause's.
+            report.severity = diagnostic.severity;
+            report.location = report.location.replace(&staged_src, &workspace_root);
+            report.body = report.body.replace(&staged_src, &workspace_root);
+            for frame in &mut report.stack {
+                frame.location = frame.location.replace(&staged_src, &workspace_root);
+                frame.message = frame.message.replace(&staged_src, &workspace_root);
             }
+            report
         })
         .collect()
-}
-
-/// Serialize an already-completed preflight; this does not execute any checks.
-fn write_release_checks(
-    outcome: Result<(ReleaseInfo, Diagnostics)>,
-    workspace_root: &Path,
-    staging: &Path,
-    excluded: &[ArtifactType],
-) -> Result<()> {
-    let staged_src = staging.join("src").to_string_lossy().into_owned();
-    let workspace_root = workspace_root.to_string_lossy();
-    let (status, layout_checked, message, diagnostics) = match outcome {
-        Ok((info, diagnostics)) => (
-            "pass",
-            info.has_layout() && !excluded.contains(&ArtifactType::Drc),
-            None,
-            diagnostics,
-        ),
-        Err(error) => {
-            let message = Some(error.to_string());
-            match error.downcast::<PreflightFailure>() {
-                Ok(failure) => ("blocked", false, message, failure.diagnostics),
-                Err(_) => ("incomplete", false, message, Diagnostics::default()),
-            }
-        }
-    };
-    let mut findings = release_findings(&diagnostics);
-    for finding in &mut findings {
-        finding.location = finding.location.replace(&staged_src, &workspace_root);
-        finding.message = finding.message.replace(&staged_src, &workspace_root);
-    }
-    let report = ReleaseChecks {
-        schema_version: 1,
-        status,
-        layout_checked,
-        message: message.map(|message| message.replace(&staged_src, &workspace_root)),
-        findings,
-    };
-    pcb_ui::write_stdout(|stdout| {
-        serde_json::to_writer(&mut *stdout, &report)?;
-        writeln!(stdout)?;
-        Ok(())
-    })?;
-    if status != "pass" {
-        anyhow::bail!("Release checks {status}");
-    }
-    Ok(())
 }
 
 pub struct BoardReleaseOptions {
@@ -345,26 +277,48 @@ pub fn build_board_release(
 ) -> Result<Option<PathBuf>> {
     let start_time = Instant::now();
     let temporary = options.check.then(tempfile::tempdir).transpose()?;
+    let mut diagnostics = Diagnostics::default();
     let outcome = preflight_board_release(
-        zen_path,
+        zen_path.clone(),
         board_name,
-        options.suppress,
-        options.version,
-        &options.exclude,
-        options.geometry_resolution,
+        &options,
         temporary.as_ref().map(|dir| dir.path().join("release")),
+        &mut diagnostics,
     );
     // Check mode stops here, including on preflight failure, before any assets.
     if let Some(temporary) = temporary {
-        write_release_checks(
-            outcome,
-            workspace_root,
-            &temporary.path().join("release"),
-            &options.exclude,
-        )?;
+        if let Err(error) = &outcome {
+            diagnostics
+                .diagnostics
+                .push(pcb_zen_core::Diagnostic::categorized(
+                    &zen_path.to_string_lossy(),
+                    &format!("{error:#}"),
+                    "release.preflight",
+                    starlark::errors::EvalSeverity::Error,
+                ));
+        }
+        let layout_checked = !release_blocked(&diagnostics)
+            && !options.exclude.contains(&ArtifactType::Drc)
+            && outcome
+                .as_ref()
+                .ok()
+                .and_then(Option::as_ref)
+                .is_some_and(ReleaseInfo::has_layout);
+        let report = serde_json::json!({
+            "schemaVersion": 1,
+            "layoutChecked": layout_checked,
+            "diagnostics": release_diagnostics(&diagnostics, workspace_root, &temporary.path().join("release")),
+        });
+        pcb_ui::write_stdout(|stdout| {
+            serde_json::to_writer(&mut *stdout, &report)?;
+            writeln!(stdout)?;
+            Ok(())
+        })?;
+        outcome?.context("Evaluation failed")?;
+        anyhow::ensure!(!release_blocked(&diagnostics), "Release preflight failed");
         return Ok(None);
     }
-    let (release_info, mut diagnostics) = outcome?;
+    let release_info = outcome?.context("Evaluation failed")?;
     execute_task(
         &release_info,
         "Reviewing release preflight",
@@ -392,12 +346,10 @@ pub fn build_board_release(
 fn preflight_board_release(
     zen_path: PathBuf,
     board_name: String,
-    suppress: Vec<String>,
-    version: Option<String>,
-    excluded: &[ArtifactType],
-    geometry_resolution: Resolution,
+    options: &BoardReleaseOptions,
     staging_override: Option<PathBuf>,
-) -> Result<(ReleaseInfo, Diagnostics)> {
+    diagnostics: &mut Diagnostics,
+) -> Result<Option<ReleaseInfo>> {
     let start_time = Instant::now();
 
     let release_info = {
@@ -419,11 +371,11 @@ fn preflight_board_release(
                 diagnostics.apply_passes(&passes);
             });
             info_spinner.finish();
-            return Err(PreflightFailure {
-                message: "Evaluation failed".into(),
-                diagnostics: eval_result.diagnostics,
-            }
-            .into());
+            diagnostics
+                .diagnostics
+                .extend(eval_result.diagnostics.diagnostics);
+            anyhow::ensure!(diagnostics.has_errors(), "Evaluation produced no output");
+            return Ok(None);
         }
 
         info_spinner.finish();
@@ -436,7 +388,7 @@ fn preflight_board_release(
         let git_hash = git::rev_parse_head(workspace_root).unwrap_or_else(|| "unknown".to_string());
 
         // Use provided version, or fall back to short git hash
-        let version = version.unwrap_or_else(|| {
+        let version = options.version.clone().unwrap_or_else(|| {
             git::rev_parse_short_head(workspace_root).unwrap_or_else(|| "unknown".to_string())
         });
 
@@ -493,9 +445,9 @@ fn preflight_board_release(
             design_bom,
             output_dir,
             output_name,
-            suppress,
+            suppress: options.suppress.clone(),
             resolution,
-            geometry_resolution,
+            geometry_resolution: options.geometry_resolution,
             root_package_url: package_url,
         };
 
@@ -518,8 +470,8 @@ fn preflight_board_release(
         ensure_board_compatible_with_installed_kicad(&kicad_pcb_path)?;
     }
 
-    let diagnostics = run_release_preflight(&release_info, excluded, start_time)?;
-    Ok((release_info, diagnostics))
+    run_release_preflight(&release_info, &options.exclude, start_time, diagnostics)?;
+    Ok(Some(release_info))
 }
 
 /// Display release information summary
@@ -777,19 +729,23 @@ fn run_release_preflight(
     info: &ReleaseInfo,
     excluded: &[ArtifactType],
     start_time: Instant,
-) -> Result<Diagnostics> {
+    diagnostics: &mut Diagnostics,
+) -> Result<()> {
     execute_task(
         info,
         "Copying source files and dependencies",
         start_time,
         copy_sources,
     )?;
-    let mut diagnostics = execute_task(
+    execute_task(
         info,
         "Generating netlist from staged sources",
         start_time,
-        validate_build,
+        |info, spinner| validate_build(info, spinner, diagnostics),
     )?;
+    if release_blocked(diagnostics) {
+        return Ok(());
+    }
     execute_task(
         info,
         "Substituting version variables",
@@ -798,9 +754,15 @@ fn run_release_preflight(
     )?;
 
     if info.has_layout() && !excluded.contains(&ArtifactType::Drc) {
-        diagnostics.diagnostics.extend(
-            execute_task(info, "Running KiCad DRC checks", start_time, run_kicad_drc)?.diagnostics,
-        );
+        execute_task(
+            info,
+            "Running KiCad DRC checks",
+            start_time,
+            |info, _spinner| run_kicad_drc(info, diagnostics),
+        )?;
+        if release_blocked(diagnostics) {
+            return Ok(());
+        }
     }
     if !excluded.contains(&ArtifactType::Bom) {
         diagnostics.diagnostics.extend(
@@ -815,9 +777,9 @@ fn run_release_preflight(
     }
 
     // Process late-added BOM warnings before either JSON or interactive review.
-    pcb_zen_core::FilterHiddenPass.apply(&mut diagnostics);
-    pcb_zen_core::SuppressPass::new(info.suppress.clone()).apply(&mut diagnostics);
-    Ok(diagnostics)
+    pcb_zen_core::FilterHiddenPass.apply(diagnostics);
+    pcb_zen_core::SuppressPass::new(info.suppress.clone()).apply(diagnostics);
+    Ok(())
 }
 
 fn review_release_preflight(
@@ -826,6 +788,13 @@ fn review_release_preflight(
     diagnostics: &mut Diagnostics,
 ) -> Result<()> {
     spinner.suspend(|| crate::drc::render_diagnostics(diagnostics, &info.suppress, false));
+    if pcbc::kicad_schematic::has_unsuppressed_schematic_diagnostics(diagnostics) {
+        anyhow::bail!(
+            "Linked KiCad schematic is not equivalent. Run `pcb apply schematic {}` before publishing.",
+            info.zen_path.display()
+        );
+    }
+    anyhow::ensure!(diagnostics.error_count() == 0, "Release preflight failed");
     let warning_count = diagnostics.warning_count();
     if !confirm_continue_on_warnings(
         spinner,
@@ -858,7 +827,11 @@ impl DiagnosticsPass for RenderBuildErrorsPass {
 }
 
 /// Validate that the staged zen file can be built successfully.
-fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> {
+fn validate_build(
+    info: &ReleaseInfo,
+    spinner: &Spinner,
+    diagnostics: &mut Diagnostics,
+) -> Result<()> {
     // Calculate the zen file path in the staging directory
     let zen_file_rel = info
         .zen_path
@@ -900,21 +873,14 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> 
 
     let crate::build::BuildResult {
         schematic,
-        diagnostics,
+        diagnostics: build_diagnostics,
         ..
     } = build_result;
-    if pcbc::kicad_schematic::has_unsuppressed_schematic_diagnostics(&diagnostics) {
-        return Err(PreflightFailure {
-            message: format!("Linked KiCad schematic is not equivalent. Run `pcb apply schematic {}` before publishing.", info.zen_path.display()),
-            diagnostics,
-        }.into());
-    }
-    if diagnostics.error_count() > 0 {
-        return Err(PreflightFailure {
-            message: "Build failed".into(),
-            diagnostics,
-        }
-        .into());
+    diagnostics
+        .diagnostics
+        .extend(build_diagnostics.diagnostics);
+    if release_blocked(diagnostics) {
+        return Ok(());
     }
 
     // Write fp-lib-table with correct vendor/ paths to staged layout directory
@@ -933,7 +899,7 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> 
             .context("Failed to write netlist.json")?;
     }
 
-    Ok(diagnostics)
+    Ok(())
 }
 
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -1608,8 +1574,7 @@ fn generate_vrml_model(info: &ReleaseInfo, _spinner: &Spinner) -> Result<()> {
 }
 
 /// Run KiCad DRC checks on the layout file
-fn run_kicad_drc(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> {
-    let mut diagnostics = pcb_zen_core::Diagnostics::default();
+fn run_kicad_drc(info: &ReleaseInfo, diagnostics: &mut Diagnostics) -> Result<()> {
     let netlist_json_path = info.staging_dir.join("netlist.json");
     let netlist_json = fs::read_to_string(&netlist_json_path)
         .with_context(|| format!("Failed to read {}", netlist_json_path.display()))?;
@@ -1623,7 +1588,7 @@ fn run_kicad_drc(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> {
             check: true,
             ..Default::default()
         },
-        &mut diagnostics,
+        diagnostics,
     )?
     else {
         anyhow::bail!("No layout directory for DRC checks");
@@ -1635,21 +1600,10 @@ fn run_kicad_drc(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> {
     // Run DRC, writing raw KiCad JSON report to staging directory
     let drc_json_path = info.staging_dir.join("drc.json");
     let report = pcb_kicad::run_drc(&kicad_pcb_path, false, working_dir, &drc_json_path)?;
-    report.add_to_diagnostics(&mut diagnostics, &display_pcb_file.to_string_lossy());
+    report.add_to_diagnostics(diagnostics, &display_pcb_file.to_string_lossy());
 
-    pcb_zen_core::SuppressPass::new(info.suppress.clone()).apply(&mut diagnostics);
-    if diagnostics.error_count() > 0 {
-        spinner.suspend(|| {
-            crate::drc::render_diagnostics(&mut active_errors(&diagnostics), &[], false)
-        });
-        return Err(PreflightFailure {
-            message: "Layout checks failed".into(),
-            diagnostics,
-        }
-        .into());
-    }
-
-    Ok(diagnostics)
+    pcb_zen_core::SuppressPass::new(info.suppress.clone()).apply(diagnostics);
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1678,14 +1632,17 @@ mod tests {
         let diagnostics = Diagnostics {
             diagnostics: vec![warning, schematic, error, suppressed, wrapped],
         };
-        let findings = release_findings(&diagnostics);
         assert_eq!(
-            findings
+            diagnostics
                 .iter()
-                .map(|finding| finding.blocking)
+                .map(|diagnostic| release_blocked(&Diagnostics {
+                    diagnostics: vec![diagnostic.clone()]
+                }))
                 .collect::<Vec<_>>(),
             [false, true, true, false, false]
         );
+        let findings =
+            release_diagnostics(&diagnostics, Path::new("/repo"), Path::new("/tmp/release"));
         assert_eq!(
             serde_json::to_value(&findings[4]).unwrap()["severity"],
             "warning"

--- a/crates/pcbc/src/release.rs
+++ b/crates/pcbc/src/release.rs
@@ -8,7 +8,6 @@ use pcb_ui::{Colorize, Spinner, Style, StyledText};
 
 use crate::bom::generate_bom_with_fallback;
 use crate::bundle::{self, MetadataInput, SourceBundlePlan};
-use pcb_zen::WorkspaceInfo;
 use pcb_zen::workspace::WorkspaceInfoExt;
 use pcb_zen_core::resolution::ResolutionResult;
 use pcb_zen_core::{Diagnostics, DiagnosticsPass, EvalOutput};
@@ -230,28 +229,183 @@ fn execute_tasks(info: &ReleaseInfo, tasks: &[(&str, TaskFn)], start_time: Insta
     Ok(())
 }
 
-/// Build a release for a board file. Used by `pcb publish --board`.
-/// If version is provided (e.g. "v1.2.3"), uses that. Otherwise uses git commit hash.
-/// Takes pre-resolved workspace info to avoid duplicate resolution.
-/// Returns the path to the created release zip file.
+#[derive(Debug, thiserror::Error)]
+#[error("{message}")]
+struct PreflightFailure {
+    message: String,
+    diagnostics: Diagnostics,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ReleaseChecks {
+    schema_version: u8,
+    status: &'static str,
+    layout_checked: bool,
+    message: Option<String>,
+    findings: Vec<ReleaseFinding>,
+}
+
+#[derive(serde::Serialize)]
+struct ReleaseFinding {
+    kind: Option<String>,
+    severity: starlark::errors::EvalSeverity,
+    message: String,
+    location: String,
+    occurrences: usize,
+    suppressed: bool,
+    blocking: bool,
+}
+
+fn release_findings(diagnostics: &Diagnostics) -> Vec<ReleaseFinding> {
+    diagnostics
+        .iter()
+        .map(|diagnostic| {
+            let report = pcb_zen_core::diagnostics::DiagnosticReport::from_diagnostic(diagnostic);
+            let schematic = report
+                .kind
+                .as_deref()
+                .is_some_and(|kind| kind == "sch" || kind.starts_with("sch."));
+            ReleaseFinding {
+                kind: report.kind,
+                // Release gating uses the outer severity, not the nested cause's.
+                severity: diagnostic.severity,
+                message: pcb_zen_core::diagnostics::diagnostic_headline(diagnostic),
+                location: report.location,
+                occurrences: report.occurrences,
+                suppressed: diagnostic.suppressed,
+                blocking: !diagnostic.suppressed && (diagnostic.is_error() || schematic),
+            }
+        })
+        .collect()
+}
+
+/// Serialize an already-completed preflight; this does not execute any checks.
+fn write_release_checks(
+    outcome: Result<(ReleaseInfo, Diagnostics)>,
+    workspace_root: &Path,
+    staging: &Path,
+    excluded: &[ArtifactType],
+) -> Result<()> {
+    let staged_src = staging.join("src").to_string_lossy().into_owned();
+    let workspace_root = workspace_root.to_string_lossy();
+    let (status, layout_checked, message, diagnostics) = match outcome {
+        Ok((info, diagnostics)) => (
+            "pass",
+            info.has_layout() && !excluded.contains(&ArtifactType::Drc),
+            None,
+            diagnostics,
+        ),
+        Err(error) => {
+            let message = Some(error.to_string());
+            match error.downcast::<PreflightFailure>() {
+                Ok(failure) => ("blocked", false, message, failure.diagnostics),
+                Err(_) => ("incomplete", false, message, Diagnostics::default()),
+            }
+        }
+    };
+    let mut findings = release_findings(&diagnostics);
+    for finding in &mut findings {
+        finding.location = finding.location.replace(&staged_src, &workspace_root);
+        finding.message = finding.message.replace(&staged_src, &workspace_root);
+    }
+    let report = ReleaseChecks {
+        schema_version: 1,
+        status,
+        layout_checked,
+        message: message.map(|message| message.replace(&staged_src, &workspace_root)),
+        findings,
+    };
+    pcb_ui::write_stdout(|stdout| {
+        serde_json::to_writer(&mut *stdout, &report)?;
+        writeln!(stdout)?;
+        Ok(())
+    })?;
+    if status != "pass" {
+        anyhow::bail!("Release checks {status}");
+    }
+    Ok(())
+}
+
+pub struct BoardReleaseOptions {
+    pub version: Option<String>,
+    pub suppress: Vec<String>,
+    pub exclude: Vec<ArtifactType>,
+    pub geometry_resolution: Resolution,
+    pub check: bool,
+}
+
+/// Run release preflight, then generate assets and an archive unless `check` is set.
+/// Check mode returns no archive and leaves no persistent release staging.
 pub fn build_board_release(
-    workspace: WorkspaceInfo,
+    workspace_root: &Path,
+    zen_path: PathBuf,
+    board_name: String,
+    options: BoardReleaseOptions,
+) -> Result<Option<PathBuf>> {
+    let start_time = Instant::now();
+    let temporary = options.check.then(tempfile::tempdir).transpose()?;
+    let outcome = preflight_board_release(
+        zen_path,
+        board_name,
+        options.suppress,
+        options.version,
+        &options.exclude,
+        options.geometry_resolution,
+        temporary.as_ref().map(|dir| dir.path().join("release")),
+    );
+    // Check mode stops here, including on preflight failure, before any assets.
+    if let Some(temporary) = temporary {
+        write_release_checks(
+            outcome,
+            workspace_root,
+            &temporary.path().join("release"),
+            &options.exclude,
+        )?;
+        return Ok(None);
+    }
+    let (release_info, mut diagnostics) = outcome?;
+    execute_task(
+        &release_info,
+        "Reviewing release preflight",
+        start_time,
+        |info, spinner| review_release_preflight(info, spinner, &mut diagnostics),
+    )?;
+
+    let manufacturing_tasks = get_manufacturing_tasks(&options.exclude, release_info.has_layout());
+    execute_tasks(&release_info, &manufacturing_tasks, start_time)?;
+    execute_tasks(&release_info, FINALIZATION_TASKS, start_time)?;
+    let zip_path = archive_zip_path(&release_info);
+    eprintln!(
+        "{} {}",
+        "✓".green(),
+        format!("Release {} staged successfully", release_info.version).bold()
+    );
+    display_release_info(&release_info);
+    eprintln!(
+        "Archive: {}",
+        zip_path.display().to_string().with_style(Style::Cyan)
+    );
+    Ok(Some(zip_path))
+}
+
+fn preflight_board_release(
     zen_path: PathBuf,
     board_name: String,
     suppress: Vec<String>,
     version: Option<String>,
-    exclude: Vec<ArtifactType>,
+    excluded: &[ArtifactType],
     geometry_resolution: Resolution,
-) -> Result<PathBuf> {
+    staging_override: Option<PathBuf>,
+) -> Result<(ReleaseInfo, Diagnostics)> {
     let start_time = Instant::now();
 
     let release_info = {
         let info_spinner = Spinner::builder("Gathering release information").start();
 
-        let package_url = workspace.package_url_for_zen(&zen_path);
-
         info_spinner.set_message("Resolving dependencies");
         let resolution = crate::resolve::resolve(Some(&zen_path), false)?;
+        let package_url = resolution.workspace_info.package_url_for_zen(&zen_path);
         info_spinner.set_message("Evaluating zen file");
 
         // Evaluate the zen file for layout discovery and the authored design BOM.
@@ -265,7 +419,11 @@ pub fn build_board_release(
                 diagnostics.apply_passes(&passes);
             });
             info_spinner.finish();
-            anyhow::bail!("Evaluation failed");
+            return Err(PreflightFailure {
+                message: "Evaluation failed".into(),
+                diagnostics: eval_result.diagnostics,
+            }
+            .into());
         }
 
         info_spinner.finish();
@@ -283,9 +441,11 @@ pub fn build_board_release(
         });
 
         // Create release staging directory in workspace root with flat structure
-        let staging_dir = workspace_root
-            .join(".pcb/releases")
-            .join(format!("{}-{}", board_name, version));
+        let staging_dir = staging_override.unwrap_or_else(|| {
+            workspace_root
+                .join(".pcb/releases")
+                .join(format!("{}-{}", board_name, version))
+        });
 
         // Output directory and name use defaults
         let output_dir = workspace_root.join(".pcb/releases");
@@ -358,30 +518,8 @@ pub fn build_board_release(
         ensure_board_compatible_with_installed_kicad(&kicad_pcb_path)?;
     }
 
-    run_release_preflight(&release_info, &exclude, start_time)?;
-
-    let manufacturing_tasks = get_manufacturing_tasks(&exclude, release_info.has_layout());
-    execute_tasks(&release_info, &manufacturing_tasks, start_time)?;
-
-    // Execute finalization tasks
-    execute_tasks(&release_info, FINALIZATION_TASKS, start_time)?;
-
-    // Calculate archive path
-    let zip_path = archive_zip_path(&release_info);
-
-    eprintln!(
-        "{} {}",
-        "✓".green(),
-        format!("Release {} staged successfully", release_info.version).bold()
-    );
-    display_release_info(&release_info);
-
-    eprintln!(
-        "Archive: {}",
-        zip_path.display().to_string().with_style(Style::Cyan)
-    );
-
-    Ok(zip_path)
+    let diagnostics = run_release_preflight(&release_info, excluded, start_time)?;
+    Ok((release_info, diagnostics))
 }
 
 /// Display release information summary
@@ -639,7 +777,7 @@ fn run_release_preflight(
     info: &ReleaseInfo,
     excluded: &[ArtifactType],
     start_time: Instant,
-) -> Result<()> {
+) -> Result<Diagnostics> {
     execute_task(
         info,
         "Copying source files and dependencies",
@@ -676,12 +814,10 @@ fn run_release_preflight(
         );
     }
 
-    execute_task(
-        info,
-        "Reviewing release preflight",
-        start_time,
-        |info, spinner| review_release_preflight(info, spinner, &mut diagnostics),
-    )
+    // Process late-added BOM warnings before either JSON or interactive review.
+    pcb_zen_core::FilterHiddenPass.apply(&mut diagnostics);
+    pcb_zen_core::SuppressPass::new(info.suppress.clone()).apply(&mut diagnostics);
+    Ok(diagnostics)
 }
 
 fn review_release_preflight(
@@ -768,13 +904,17 @@ fn validate_build(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> 
         ..
     } = build_result;
     if pcbc::kicad_schematic::has_unsuppressed_schematic_diagnostics(&diagnostics) {
-        anyhow::bail!(
-            "Linked KiCad schematic is not equivalent. Run `pcb apply schematic {}` before publishing.",
-            info.zen_path.display()
-        );
+        return Err(PreflightFailure {
+            message: format!("Linked KiCad schematic is not equivalent. Run `pcb apply schematic {}` before publishing.", info.zen_path.display()),
+            diagnostics,
+        }.into());
     }
     if diagnostics.error_count() > 0 {
-        std::process::exit(1);
+        return Err(PreflightFailure {
+            message: "Build failed".into(),
+            diagnostics,
+        }
+        .into());
     }
 
     // Write fp-lib-table with correct vendor/ paths to staged layout directory
@@ -1502,7 +1642,11 @@ fn run_kicad_drc(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> {
         spinner.suspend(|| {
             crate::drc::render_diagnostics(&mut active_errors(&diagnostics), &[], false)
         });
-        std::process::exit(1);
+        return Err(PreflightFailure {
+            message: "Layout checks failed".into(),
+            diagnostics,
+        }
+        .into());
     }
 
     Ok(diagnostics)
@@ -1511,6 +1655,82 @@ fn run_kicad_drc(info: &ReleaseInfo, spinner: &Spinner) -> Result<Diagnostics> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn release_check_findings_match_publish_blockers() {
+        use pcb_zen_core::Diagnostic;
+        use starlark::errors::EvalSeverity::{Error, Warning};
+
+        let warning =
+            Diagnostic::categorized("board.zen", "ordinary warning", "io.unused", Warning);
+        let schematic =
+            Diagnostic::categorized("board.zen", "schematic mismatch", "sch.mismatch", Warning);
+        let error = Diagnostic::categorized(
+            "layout.kicad_pcb",
+            "clearance",
+            "layout.drc.clearance",
+            Error,
+        );
+        let mut suppressed = error.clone();
+        suppressed.suppressed = true;
+        let wrapped = Diagnostic::new("downgraded", Warning, Path::new("board.zen"))
+            .with_child(Some(Box::new(error.clone())));
+        let diagnostics = Diagnostics {
+            diagnostics: vec![warning, schematic, error, suppressed, wrapped],
+        };
+        let findings = release_findings(&diagnostics);
+        assert_eq!(
+            findings
+                .iter()
+                .map(|finding| finding.blocking)
+                .collect::<Vec<_>>(),
+            [false, true, true, false, false]
+        );
+        assert_eq!(
+            serde_json::to_value(&findings[4]).unwrap()["severity"],
+            "warning"
+        );
+        assert!(findings[3].suppressed);
+        assert_eq!(findings[2].kind.as_deref(), Some("layout.drc.clearance"));
+    }
+
+    #[test]
+    fn release_check_preserves_kicad_drc_findings_and_exclusions() {
+        let violation = serde_json::json!({
+            "type": "copper_edge_clearance", "severity": "error",
+            "description": "Required 0.4 mm; actual 0.3 mm", "items": []
+        });
+        let mut violations = vec![violation.clone(); 7];
+        let mut excluded = violation;
+        excluded["excluded"] = true.into();
+        violations.push(excluded);
+        let report: pcb_kicad::drc::DrcReport = serde_json::from_value(serde_json::json!({
+            "coordinate_units": "mm", "date": "2026-09-09", "kicad_version": "9.0.0",
+            "source": "layout.kicad_pcb", "violations": violations
+        }))
+        .unwrap();
+        let mut diagnostics = Diagnostics::default();
+        report.add_to_diagnostics(&mut diagnostics, "layout.kicad_pcb");
+        let findings = release_findings(&diagnostics);
+        assert_eq!(
+            findings
+                .iter()
+                .filter(|finding| finding.blocking)
+                .map(|finding| finding.occurrences)
+                .sum::<usize>(),
+            7
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|finding| finding.kind.as_deref() == Some("layout.drc.copper_edge_clearance"))
+        );
+        assert!(
+            findings
+                .iter()
+                .all(|finding| finding.message.contains("Required 0.4 mm; actual 0.3 mm"))
+        );
+    }
 
     #[test]
     fn update_kicad_pro_release_variables_adds_missing_release_variables() -> Result<()> {

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -188,12 +188,12 @@ fn test_release_check_does_not_publish_or_modify_authored_sources() {
     std::fs::create_dir(&temporary).unwrap();
     sb.env("TMPDIR", temporary.to_string_lossy());
     let head = sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap();
-    for (source, status) in [
-        ("# Unsaved to Git\n", "pass"),
-        ("fail(\"release-check diagnostic\")\n", "blocked"),
+    for (source, severity) in [
+        ("# Unsaved to Git\n", None),
+        ("fail(\"release-check diagnostic\")\n", Some("error")),
         (
             "warn(\"release-check diagnostic\", kind=\"sch.mismatch\")\n",
-            "blocked",
+            Some("warning"),
         ),
     ] {
         sb.write("boards/TestBoard.zen", source);
@@ -205,23 +205,18 @@ fn test_release_check_does_not_publish_or_modify_authored_sources() {
             .unchecked()
             .run()
             .unwrap();
-        assert_eq!(output.status.success(), status == "pass");
+        assert_eq!(output.status.success(), severity.is_none());
         let report: Value = serde_json::from_slice(&output.stdout).unwrap();
         assert_eq!(report["schemaVersion"], 1);
         assert_eq!(report["layoutChecked"], false);
-        if status == "blocked" {
+        if let Some(severity) = severity {
+            let diagnostic = &report["diagnostics"][0];
+            assert_eq!(diagnostic["severity"], severity);
             assert!(
-                report["diagnostics"]
-                    .as_array()
+                diagnostic["body"]
+                    .as_str()
                     .unwrap()
-                    .iter()
-                    .any(|finding| {
-                        (finding["severity"] == "error" || finding["kind"] == "sch.mismatch")
-                            && finding["body"]
-                                .as_str()
-                                .unwrap()
-                                .contains("release-check diagnostic")
-                    })
+                    .contains("release-check diagnostic")
             );
         }
         assert!(!sb.root_path().join("src/.pcb/releases").exists());
@@ -240,19 +235,6 @@ fn test_release_check_does_not_publish_or_modify_authored_sources() {
         .unwrap();
     assert!(!output.status.success());
     assert!(String::from_utf8_lossy(&output.stderr).contains("not equivalent"));
-}
-
-#[test]
-fn test_release_check_requires_board_target() {
-    let mut sb = Sandbox::new();
-    let output = sb
-        .run("pcbc", ["publish", "--check"])
-        .stderr_capture()
-        .unchecked()
-        .run()
-        .unwrap();
-    assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("explicit board .zen target"));
 }
 
 #[test]
@@ -288,7 +270,6 @@ fn test_release_check_operational_failure_is_a_diagnostic() {
     assert_eq!(diagnostic["kind"], "release.preflight");
     assert_eq!(diagnostic["severity"], "error");
     assert!(diagnostic["body"].as_str().unwrap().contains(".kicad_pro"));
-    assert!(!sb.root_path().join("src/.pcb/releases").exists());
     assert_eq!(std::fs::read_dir(&temporary).unwrap().count(), 0);
 }
 
@@ -327,7 +308,6 @@ fn test_release_check_drc_exclusion_does_not_claim_layout_checked() {
         .unwrap();
     let report: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(report["layoutChecked"], false);
-    assert!(!sb.root_path().join("src/.pcb/releases").exists());
     assert_eq!(sb.cmd("git", ["diff", "HEAD"]).read().unwrap(), before);
 }
 

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -191,6 +191,10 @@ fn test_release_check_does_not_publish_or_modify_authored_sources() {
     for (source, status) in [
         ("# Unsaved to Git\n", "pass"),
         ("fail(\"release-check diagnostic\")\n", "blocked"),
+        (
+            "warn(\"release-check diagnostic\", kind=\"sch.mismatch\")\n",
+            "blocked",
+        ),
     ] {
         sb.write("boards/TestBoard.zen", source);
         let before = sb.cmd("git", ["diff", "HEAD"]).read().unwrap();
@@ -204,17 +208,16 @@ fn test_release_check_does_not_publish_or_modify_authored_sources() {
         assert_eq!(output.status.success(), status == "pass");
         let report: Value = serde_json::from_slice(&output.stdout).unwrap();
         assert_eq!(report["schemaVersion"], 1);
-        assert_eq!(report["status"], status);
         assert_eq!(report["layoutChecked"], false);
         if status == "blocked" {
             assert!(
-                report["findings"]
+                report["diagnostics"]
                     .as_array()
                     .unwrap()
                     .iter()
                     .any(|finding| {
-                        finding["blocking"] == true
-                            && finding["message"]
+                        (finding["severity"] == "error" || finding["kind"] == "sch.mismatch")
+                            && finding["body"]
                                 .as_str()
                                 .unwrap()
                                 .contains("release-check diagnostic")
@@ -227,6 +230,16 @@ fn test_release_check_does_not_publish_or_modify_authored_sources() {
         assert_eq!(sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap(), head);
         assert!(sb.cmd("git", ["tag"]).read().unwrap().is_empty());
     }
+
+    // A schematic warning must also stop normal publishing, not just check mode.
+    let output = sb
+        .run("pcbc", ["publish", "boards/TestBoard.zen"])
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("not equivalent"));
 }
 
 #[test]
@@ -243,7 +256,7 @@ fn test_release_check_requires_board_target() {
 }
 
 #[test]
-fn test_release_check_operational_failure_is_incomplete() {
+fn test_release_check_operational_failure_is_a_diagnostic() {
     let mut sb = Sandbox::new();
     sb.cwd("src")
         .write("pcb.toml", PCB_TOML)
@@ -270,10 +283,11 @@ fn test_release_check_operational_failure_is_incomplete() {
         .unwrap();
     assert!(!output.status.success());
     let report: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(report["status"], "incomplete");
     assert_eq!(report["layoutChecked"], false);
-    assert_eq!(report["findings"], serde_json::json!([]));
-    assert!(report["message"].as_str().unwrap().contains(".kicad_pro"));
+    let diagnostic = &report["diagnostics"][0];
+    assert_eq!(diagnostic["kind"], "release.preflight");
+    assert_eq!(diagnostic["severity"], "error");
+    assert!(diagnostic["body"].as_str().unwrap().contains(".kicad_pro"));
     assert!(!sb.root_path().join("src/.pcb/releases").exists());
     assert_eq!(std::fs::read_dir(&temporary).unwrap().count(), 0);
 }
@@ -312,7 +326,6 @@ fn test_release_check_drc_exclusion_does_not_claim_layout_checked() {
         .run()
         .unwrap();
     let report: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(report["status"], "pass");
     assert_eq!(report["layoutChecked"], false);
     assert!(!sb.root_path().join("src/.pcb/releases").exists());
     assert_eq!(sb.cmd("git", ["diff", "HEAD"]).read().unwrap(), before);
@@ -356,8 +369,7 @@ fn test_release_check_respects_bom_suppression_and_exclusion() {
             .run()
             .unwrap();
         let report: Value = serde_json::from_slice(&output.stdout).unwrap();
-        assert_eq!(report["status"], "pass"); // Sourceability warnings are not release blockers.
-        let bom_findings = report["findings"]
+        let bom_findings = report["diagnostics"]
             .as_array()
             .unwrap()
             .iter()
@@ -367,7 +379,7 @@ fn test_release_check_respects_bom_suppression_and_exclusion() {
         assert_eq!(bom_findings.len(), if excluded { 0 } else { 2 });
         for finding in bom_findings {
             assert_eq!(finding["suppressed"], flags.contains(&"-S"));
-            assert_eq!(finding["blocking"], false);
+            assert_eq!(finding["severity"], "warning");
         }
     }
 }

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -175,6 +175,275 @@ fn find_staging_dir(sb: &Sandbox, board_name: &str) -> String {
 }
 
 #[test]
+fn test_release_check_does_not_publish_or_modify_authored_sources() {
+    let mut sb = Sandbox::new();
+    sb.cwd("src")
+        .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write("boards/TestBoard.zen", "# No components or layout\n")
+        .init_git()
+        .commit("Initial commit")
+        .sync();
+    let temporary = sb.root_path().join("check-tmp");
+    std::fs::create_dir(&temporary).unwrap();
+    sb.env("TMPDIR", temporary.to_string_lossy());
+    // An unstaged edit is legal in check mode and must remain untouched.
+    sb.write("boards/TestBoard.zen", "# Unsaved to Git\n");
+    let before = sb.cmd("git", ["diff", "HEAD"]).read().unwrap();
+    let head = sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap();
+    let output = sb
+        .run("pcbc", ["publish", "boards/TestBoard.zen", "--check"])
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["schemaVersion"], 1);
+    assert_eq!(report["status"], "pass");
+    assert_eq!(report["layoutChecked"], false);
+    assert!(!sb.root_path().join("src/.pcb/releases").exists());
+    assert_eq!(std::fs::read_dir(&temporary).unwrap().count(), 0);
+    assert_eq!(sb.cmd("git", ["diff", "HEAD"]).read().unwrap(), before);
+    assert_eq!(sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap(), head);
+    assert!(sb.cmd("git", ["tag"]).read().unwrap().is_empty());
+
+    sb.write(
+        "boards/TestBoard.zen",
+        "fail(\"release-check diagnostic\")\n",
+    );
+    let output = sb
+        .run("pcbc", ["publish", "boards/TestBoard.zen", "--check"])
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .unwrap();
+    assert!(!output.status.success());
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["status"], "blocked");
+    assert!(
+        report["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|finding| finding["blocking"] == true)
+    );
+    assert!(report.to_string().contains("release-check diagnostic"));
+    assert!(!sb.root_path().join("src/.pcb/releases").exists());
+    assert_eq!(std::fs::read_dir(&temporary).unwrap().count(), 0);
+    assert_eq!(sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap(), head);
+
+    // The ordinary release path uses the same preflight and rejects this input too.
+    let output = sb
+        .run("pcbc", ["publish", "boards/TestBoard.zen"])
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("release-check diagnostic"));
+    assert!(!sb.root_path().join("src/.pcb/releases").exists());
+
+    // Once preflight succeeds, only the ordinary path continues to an archive.
+    sb.write("boards/TestBoard.zen", "# No components or layout\n");
+    sb.run("pcbc", ["publish", "boards/TestBoard.zen"])
+        .stdout_capture()
+        .stderr_capture()
+        .run()
+        .expect("local release build failed");
+    assert!(
+        std::fs::read_dir(sb.root_path().join("src/.pcb/releases"))
+            .unwrap()
+            .any(|entry| entry
+                .unwrap()
+                .path()
+                .extension()
+                .is_some_and(|ext| ext == "zip"))
+    );
+    assert_eq!(sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap(), head);
+    assert!(sb.cmd("git", ["tag"]).read().unwrap().is_empty());
+}
+
+#[test]
+fn test_release_check_rejects_publication_options() {
+    let mut sb = Sandbox::new();
+    sb.cwd("src").write("pcb.toml", PCB_TOML).sync();
+    for option in ["--bump=patch", "--force", "--no-build", "--no-push"] {
+        let output = sb
+            .run("pcbc", ["publish", "board.zen", "--check", option])
+            .stdout_capture()
+            .stderr_capture()
+            .unchecked()
+            .run()
+            .unwrap();
+        assert!(!output.status.success(), "accepted {option}");
+        assert!(String::from_utf8_lossy(&output.stderr).contains("cannot be used with"));
+    }
+
+    let output = sb
+        .run("pcbc", ["publish", "--check"])
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("explicit board .zen target"));
+}
+
+#[test]
+fn test_release_check_operational_failure_is_incomplete() {
+    let mut sb = Sandbox::new();
+    sb.cwd("src")
+        .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write(
+            "boards/TestBoard.zen",
+            "Layout(name=\"TestBoard\", path=\"layout\")\n",
+        )
+        .write("boards/layout/one.kicad_pro", "{}")
+        .write("boards/layout/two.kicad_pro", "{}")
+        .init_git()
+        .commit("Initial commit")
+        .sync();
+    let before = sb.cmd("git", ["diff", "HEAD"]).read().unwrap();
+    let temporary = sb.root_path().join("check-tmp");
+    std::fs::create_dir(&temporary).unwrap();
+    sb.env("TMPDIR", temporary.to_string_lossy());
+
+    let output = sb
+        .run("pcbc", ["publish", "boards/TestBoard.zen", "--check"])
+        .stdout_capture()
+        .stderr_capture()
+        .unchecked()
+        .run()
+        .unwrap();
+    assert!(!output.status.success());
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["status"], "incomplete");
+    assert_eq!(report["layoutChecked"], false);
+    assert_eq!(report["findings"], serde_json::json!([]));
+    assert!(report["message"].as_str().unwrap().contains(".kicad_pro"));
+    assert!(!sb.root_path().join("src/.pcb/releases").exists());
+    assert_eq!(std::fs::read_dir(&temporary).unwrap().count(), 0);
+    assert_eq!(sb.cmd("git", ["diff", "HEAD"]).read().unwrap(), before);
+}
+
+#[test]
+fn test_release_check_drc_exclusion_does_not_claim_layout_checked() {
+    let mut sb = Sandbox::new();
+    sb.cwd("src")
+        .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write(
+            "boards/TestBoard.zen",
+            "Layout(name=\"TestBoard\", path=\"layout\")\n",
+        )
+        .write("boards/layout/layout.kicad_pro", "{}")
+        .write("boards/layout/layout.kicad_pcb", "(kicad_pcb)")
+        .init_git()
+        .commit("Initial commit")
+        .sync();
+    let before = sb.cmd("git", ["diff", "HEAD"]).read().unwrap();
+    let output = sb
+        .run(
+            "pcbc",
+            [
+                "publish",
+                "boards/TestBoard.zen",
+                "--check",
+                "--exclude",
+                "drc",
+                "--exclude",
+                "bom",
+            ],
+        )
+        .stdout_capture()
+        .stderr_capture()
+        .run()
+        .unwrap();
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["status"], "pass");
+    assert_eq!(report["layoutChecked"], false);
+    let log = String::from_utf8_lossy(&output.stderr);
+    assert!(!log.contains("Running KiCad DRC checks"));
+    assert!(!log.contains("Generating design BOM"));
+    assert!(!sb.root_path().join("src/.pcb/releases").exists());
+    assert_eq!(sb.cmd("git", ["diff", "HEAD"]).read().unwrap(), before);
+}
+
+#[test]
+fn test_release_check_respects_bom_suppression_and_exclusion() {
+    let server = MockServer::start();
+    let bom_match = server.mock(|when, then| {
+        when.method(POST)
+            .path("/api/boms/match")
+            .query_param("strict", "true");
+        then.status(200).json_body(serde_json::json!({
+            "results": (["GENERIC.R", "AUTHORED.R"].map(|path| serde_json::json!({
+                "designEntry": { "path": path },
+                "offerIds": [], "offerStockClasses": {},
+                "match": "MATCH_EXACT", "selectedOfferId": null
+            }))),
+            "offers": {}
+        }));
+    });
+    let mut sb = Sandbox::new();
+    sb.cwd("src")
+        .env("DIODE_API_URL", server.base_url())
+        .env("NO_PROXY", "127.0.0.1,localhost")
+        .env("no_proxy", "127.0.0.1,localhost")
+        .write("pcb.toml", PCB_TOML)
+        .write("boards/pcb.toml", BOARD_PCB_TOML)
+        .write("boards/TestBoard.zen", BOM_INTENT_BOARD_ZEN)
+        .init_git()
+        .commit("Initial commit")
+        .sync();
+
+    for flags in [vec![], vec!["-S", "bom"], vec!["--exclude", "bom"]] {
+        let mut args = vec!["publish", "boards/TestBoard.zen", "--check"];
+        args.extend(&flags);
+        let requests_before = bom_match.calls();
+        let output = sb
+            .run("pcbc", args)
+            .stdout_capture()
+            .stderr_capture()
+            .run()
+            .unwrap();
+        let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(report["status"], "pass"); // Sourceability warnings are not release blockers.
+        let bom_findings = report["findings"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|finding| finding["kind"] == "bom.sourceability.no_offers")
+            .collect::<Vec<_>>();
+        let excluded = flags.contains(&"--exclude");
+        assert_eq!(bom_findings.len(), if excluded { 0 } else { 2 });
+        for finding in bom_findings {
+            assert_eq!(finding["suppressed"], flags.contains(&"-S"));
+            assert_eq!(finding["blocking"], false);
+        }
+        assert_eq!(
+            String::from_utf8_lossy(&output.stderr).contains("Generating design BOM"),
+            !excluded
+        );
+        // Identical build hydration and sourcing inputs share the existing cache,
+        // including across subsequent checks with different reporting options.
+        assert_eq!(
+            bom_match.calls() - requests_before,
+            if flags.is_empty() { 1 } else { 0 }
+        );
+    }
+}
+
+#[test]
 fn test_publish_board_source_only() {
     let mut sb = Sandbox::new();
     sb.cwd("src")

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -187,106 +187,51 @@ fn test_release_check_does_not_publish_or_modify_authored_sources() {
     let temporary = sb.root_path().join("check-tmp");
     std::fs::create_dir(&temporary).unwrap();
     sb.env("TMPDIR", temporary.to_string_lossy());
-    // An unstaged edit is legal in check mode and must remain untouched.
-    sb.write("boards/TestBoard.zen", "# Unsaved to Git\n");
-    let before = sb.cmd("git", ["diff", "HEAD"]).read().unwrap();
     let head = sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap();
-    let output = sb
-        .run("pcbc", ["publish", "boards/TestBoard.zen", "--check"])
-        .stdout_capture()
-        .stderr_capture()
-        .unchecked()
-        .run()
-        .unwrap();
-    assert!(
-        output.status.success(),
-        "{}",
-        String::from_utf8_lossy(&output.stderr)
-    );
-    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(report["schemaVersion"], 1);
-    assert_eq!(report["status"], "pass");
-    assert_eq!(report["layoutChecked"], false);
-    assert!(!sb.root_path().join("src/.pcb/releases").exists());
-    assert_eq!(std::fs::read_dir(&temporary).unwrap().count(), 0);
-    assert_eq!(sb.cmd("git", ["diff", "HEAD"]).read().unwrap(), before);
-    assert_eq!(sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap(), head);
-    assert!(sb.cmd("git", ["tag"]).read().unwrap().is_empty());
-
-    sb.write(
-        "boards/TestBoard.zen",
-        "fail(\"release-check diagnostic\")\n",
-    );
-    let output = sb
-        .run("pcbc", ["publish", "boards/TestBoard.zen", "--check"])
-        .stdout_capture()
-        .stderr_capture()
-        .unchecked()
-        .run()
-        .unwrap();
-    assert!(!output.status.success());
-    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(report["status"], "blocked");
-    assert!(
-        report["findings"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|finding| finding["blocking"] == true)
-    );
-    assert!(report.to_string().contains("release-check diagnostic"));
-    assert!(!sb.root_path().join("src/.pcb/releases").exists());
-    assert_eq!(std::fs::read_dir(&temporary).unwrap().count(), 0);
-    assert_eq!(sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap(), head);
-
-    // The ordinary release path uses the same preflight and rejects this input too.
-    let output = sb
-        .run("pcbc", ["publish", "boards/TestBoard.zen"])
-        .stdout_capture()
-        .stderr_capture()
-        .unchecked()
-        .run()
-        .unwrap();
-    assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("release-check diagnostic"));
-    assert!(!sb.root_path().join("src/.pcb/releases").exists());
-
-    // Once preflight succeeds, only the ordinary path continues to an archive.
-    sb.write("boards/TestBoard.zen", "# No components or layout\n");
-    sb.run("pcbc", ["publish", "boards/TestBoard.zen"])
-        .stdout_capture()
-        .stderr_capture()
-        .run()
-        .expect("local release build failed");
-    assert!(
-        std::fs::read_dir(sb.root_path().join("src/.pcb/releases"))
-            .unwrap()
-            .any(|entry| entry
-                .unwrap()
-                .path()
-                .extension()
-                .is_some_and(|ext| ext == "zip"))
-    );
-    assert_eq!(sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap(), head);
-    assert!(sb.cmd("git", ["tag"]).read().unwrap().is_empty());
-}
-
-#[test]
-fn test_release_check_rejects_publication_options() {
-    let mut sb = Sandbox::new();
-    sb.cwd("src").write("pcb.toml", PCB_TOML).sync();
-    for option in ["--bump=patch", "--force", "--no-build", "--no-push"] {
+    for (source, status) in [
+        ("# Unsaved to Git\n", "pass"),
+        ("fail(\"release-check diagnostic\")\n", "blocked"),
+    ] {
+        sb.write("boards/TestBoard.zen", source);
+        let before = sb.cmd("git", ["diff", "HEAD"]).read().unwrap();
         let output = sb
-            .run("pcbc", ["publish", "board.zen", "--check", option])
+            .run("pcbc", ["publish", "boards/TestBoard.zen", "--check"])
             .stdout_capture()
             .stderr_capture()
             .unchecked()
             .run()
             .unwrap();
-        assert!(!output.status.success(), "accepted {option}");
-        assert!(String::from_utf8_lossy(&output.stderr).contains("cannot be used with"));
+        assert_eq!(output.status.success(), status == "pass");
+        let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+        assert_eq!(report["schemaVersion"], 1);
+        assert_eq!(report["status"], status);
+        assert_eq!(report["layoutChecked"], false);
+        if status == "blocked" {
+            assert!(
+                report["findings"]
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .any(|finding| {
+                        finding["blocking"] == true
+                            && finding["message"]
+                                .as_str()
+                                .unwrap()
+                                .contains("release-check diagnostic")
+                    })
+            );
+        }
+        assert!(!sb.root_path().join("src/.pcb/releases").exists());
+        assert_eq!(std::fs::read_dir(&temporary).unwrap().count(), 0);
+        assert_eq!(sb.cmd("git", ["diff", "HEAD"]).read().unwrap(), before);
+        assert_eq!(sb.cmd("git", ["rev-parse", "HEAD"]).read().unwrap(), head);
+        assert!(sb.cmd("git", ["tag"]).read().unwrap().is_empty());
     }
+}
 
+#[test]
+fn test_release_check_requires_board_target() {
+    let mut sb = Sandbox::new();
     let output = sb
         .run("pcbc", ["publish", "--check"])
         .stderr_capture()
@@ -312,7 +257,6 @@ fn test_release_check_operational_failure_is_incomplete() {
         .init_git()
         .commit("Initial commit")
         .sync();
-    let before = sb.cmd("git", ["diff", "HEAD"]).read().unwrap();
     let temporary = sb.root_path().join("check-tmp");
     std::fs::create_dir(&temporary).unwrap();
     sb.env("TMPDIR", temporary.to_string_lossy());
@@ -332,7 +276,6 @@ fn test_release_check_operational_failure_is_incomplete() {
     assert!(report["message"].as_str().unwrap().contains(".kicad_pro"));
     assert!(!sb.root_path().join("src/.pcb/releases").exists());
     assert_eq!(std::fs::read_dir(&temporary).unwrap().count(), 0);
-    assert_eq!(sb.cmd("git", ["diff", "HEAD"]).read().unwrap(), before);
 }
 
 #[test]
@@ -371,9 +314,6 @@ fn test_release_check_drc_exclusion_does_not_claim_layout_checked() {
     let report: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(report["status"], "pass");
     assert_eq!(report["layoutChecked"], false);
-    let log = String::from_utf8_lossy(&output.stderr);
-    assert!(!log.contains("Running KiCad DRC checks"));
-    assert!(!log.contains("Generating design BOM"));
     assert!(!sb.root_path().join("src/.pcb/releases").exists());
     assert_eq!(sb.cmd("git", ["diff", "HEAD"]).read().unwrap(), before);
 }
@@ -381,7 +321,7 @@ fn test_release_check_drc_exclusion_does_not_claim_layout_checked() {
 #[test]
 fn test_release_check_respects_bom_suppression_and_exclusion() {
     let server = MockServer::start();
-    let bom_match = server.mock(|when, then| {
+    let _bom_match = server.mock(|when, then| {
         when.method(POST)
             .path("/api/boms/match")
             .query_param("strict", "true");
@@ -409,7 +349,6 @@ fn test_release_check_respects_bom_suppression_and_exclusion() {
     for flags in [vec![], vec!["-S", "bom"], vec!["--exclude", "bom"]] {
         let mut args = vec!["publish", "boards/TestBoard.zen", "--check"];
         args.extend(&flags);
-        let requests_before = bom_match.calls();
         let output = sb
             .run("pcbc", args)
             .stdout_capture()
@@ -430,16 +369,6 @@ fn test_release_check_respects_bom_suppression_and_exclusion() {
             assert_eq!(finding["suppressed"], flags.contains(&"-S"));
             assert_eq!(finding["blocking"], false);
         }
-        assert_eq!(
-            String::from_utf8_lossy(&output.stderr).contains("Generating design BOM"),
-            !excluded
-        );
-        // Identical build hydration and sourcing inputs share the existing cache,
-        // including across subsequent checks with different reporting options.
-        assert_eq!(
-            bom_match.calls() - requests_before,
-            if flags.is_empty() { 1 } else { 0 }
-        );
     }
 }
 

--- a/crates/pcbc/tests/release.rs
+++ b/crates/pcbc/tests/release.rs
@@ -234,7 +234,16 @@ fn test_release_check_does_not_publish_or_modify_authored_sources() {
         .run()
         .unwrap();
     assert!(!output.status.success());
-    assert!(String::from_utf8_lossy(&output.stderr).contains("not equivalent"));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("not equivalent"));
+    let stage = stderr
+        .lines()
+        .find(|line| line.contains("Generating netlist from staged sources"))
+        .unwrap();
+    assert!(
+        !stage.contains('✓'),
+        "blocked stage claimed success: {stage}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Purpose
Expose the existing board-release preflight as `pcb publish path/to/board.zen --check`, so callers can check release blockers without generating manufacturing exports, creating an archive, uploading, or tagging.

## Design
- One release pipeline: gather/stage sources, run the existing build/schematic/layout/DRC/BOM preflight once, then stop in check mode. Normal publishing continues through warning review, exports and archive creation.
- Check mode uses temporary staging and returns structured diagnostics instead of terminating the process inside the build/DRC stages. Authored files, commits and tags are preserved.
- JSON contains existing PCB DiagnosticReport entries plus schemaVersion and layoutChecked. Exit status is authoritative; tool/preparation failures become release.preflight error diagnostics. There are no custom PreflightFailure, ReleaseChecks, or ReleaseFinding types. Invalid targets/workspaces and failures before preflight still use ordinary CLI errors.
- Supports existing `--exclude`, `--suppress`, and accuracy options. For example, `--check --exclude bom` skips the dedicated sourcing stage when a caller already owns BOM checks. Staged build hydration remains intact and reuses the existing BOM cache. Excluding DRC never claims `layoutChecked: true`.
- Publication-only options (`--bump`, `--force`, `--no-push`, `--no-build`) conflict with `--check`.

## Review corrections
Applied suppression/filtering before both JSON and interactive review so late-added BOM warnings follow the same rules. Verified outer diagnostic severity, linked-schematic warning blockers, suppressed/excluded DRC findings, temporary cleanup, and the boundary before asset generation. No parallel check implementation or new service/cache.

## Verification
After rebasing onto current origin/main:
- `cargo fmt --all -- --check` — passed.
- `cargo clippy -p pcbc --all-targets -- -D warnings` — passed.
- `cargo nextest run -p pcbc -E 'test(release_check) or test(release::tests) or test(publish::tests)'` — 36 passed.
- Existing version/local-tag preservation, authored-BOM intent and strict-BOM metadata integration tests — 3 passed.
- Focused tests cover success/failure diagnostics, tool failures as diagnostics, temporary cleanup and source preservation, BOM suppression/exclusion, skipped DRC, and release-specific severity/blocking. A schematic-warning regression checks both check mode and normal publishing. Existing normal-release, KiCad conversion and cache-policy tests retain ownership of those behaviors.
- Registry caller change validated separately with 26 focused tests and typecheck; Registry files are intentionally not part of this PR.

## Limits
Native KiCad is not installed in this orb, so full KiCad-backed DRC/export execution needs CI. An earlier source-only snapshot run differed only in unavailable KiCad version (`unknown`); no snapshots were accepted or changed.

This is a preflight result, not a guarantee of future release success: actual release reruns checks with its selected version and can still fail during exports, upload, or Git publication. Checks stop at the first blocking stage; ordinary sourcing warnings remain nonblocking, matching release behavior. CLI dependency/cache resolution is not an offline/no-network promise.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core board publish/release pipeline and changes how preflight failures are surfaced (diagnostics vs early exit), which affects both new check mode and normal publishes.
> 
> **Overview**
> Adds **`pcb publish path/to/board.zen --check`** so CI and tooling can run the same board-release preflight as a normal publish without creating `.pcb/releases` staging, building manufacturing exports, uploading, or tagging. **`--check`** conflicts with publish-only flags (`--bump`, `--force`, `--no-push`, `--no-build`) and is rejected unless the target is an explicit `.zen` board.
> 
> Release building is refactored around **`BoardReleaseOptions`** and a shared **`preflight_board_release`** path: check mode stages into a **temporary directory**, prints **JSON** (`schemaVersion`, `layoutChecked`, `DiagnosticReport` entries with workspace paths), and exits with a non-zero status when blocked. Preflight stages now **accumulate diagnostics** instead of exiting inside build/DRC; blocking includes errors and **unsuppressed schematic-equivalence warnings**, with suppression/`--exclude` applied before both JSON and interactive review. Normal publish continues through warning prompts and artifact generation; **`build_board_release`** returns **`Option<PathBuf>`** for the zip when not in check mode.
> 
> Integration tests cover no side effects on git/sources, operational failures as `release.preflight` diagnostics, DRC exclusion vs `layoutChecked`, and BOM suppress/exclude behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8ff7321a240502e89468c9f797830eba70748d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



