### PR TITLE
perf(quiche): accelerate schematic repair planning (ENG-1581)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Speed up schematic connectivity analysis and repair planning with indexed terminal matching and verified batches of local wire cuts.
 - Allow schematic and BOM consumers to omit the Starlark interpreter bindings.
 - Preserve sheet graphics and text annotations when updating KiCad schematics.
 - Add constrained region analysis meshes with boundary provenance, validated input accuracy, refinement diagnostics, and robust element-sided barycentric attachments to `pcb-ir`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Speed up schematic connectivity analysis and repair planning with indexed terminal matching and verified batches of local wire cuts.
+
 ## [0.4.52] - 2026-09-09
 
 ### Added
@@ -26,7 +30,6 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Speed up schematic connectivity analysis and repair planning with indexed terminal matching and verified batches of local wire cuts.
 - Allow schematic and BOM consumers to omit the Starlark interpreter bindings.
 - Preserve sheet graphics and text annotations when updating KiCad schematics.
 - Add constrained region analysis meshes with boundary provenance, validated input accuracy, refinement diagnostics, and robust element-sided barycentric attachments to `pcb-ir`.

--- a/crates/pcb-kicad-sch/src/analysis.rs
+++ b/crates/pcb-kicad-sch/src/analysis.rs
@@ -10,7 +10,7 @@ use crate::{
     connectivity::{
         ComponentIdentity, ComponentOrigin, ConnectionGroup, ConnectionOrigin, ConnectivityGraph,
         ConnectivityItemRef, IslandRef, PhysicalConnectivity, PhysicalIsland, PinVisibility,
-        SymbolLocation, Terminal, not_connected_terminals, reduce_with_provenance,
+        SymbolLocation, Terminal, TerminalIndex, not_connected_terminals, reduce_with_provenance,
     },
     symbol,
 };
@@ -634,13 +634,62 @@ pub fn analyze_connectivity(
     expected: &ConnectivityGraph,
     observed: &ConnectivityGraph,
 ) -> ConnectivityAnalysis {
+    let matches = GroupMatches::new(expected, observed);
     let components = analyze_components(expected, observed);
-    let nets = analyze_nets(expected, observed);
-    let issues = collect_issues(expected, observed, &components, &nets);
+    let nets = analyze_nets(expected, observed, &matches);
+    let issues = collect_issues(expected, observed, &components, &nets, &matches);
     ConnectivityAnalysis {
         components,
         nets,
         issues,
+    }
+}
+
+/// Compute the group relation once in both directions. Lists contain unique
+/// group indices in source order, independent of terminal/key lookup order.
+struct GroupMatches<'a> {
+    observed_by_expected: Vec<Vec<usize>>,
+    expected_by_observed: Vec<Vec<usize>>,
+    expected_terminals: TerminalIndex<'a>,
+    observed_terminals: TerminalIndex<'a>,
+}
+
+impl<'a> GroupMatches<'a> {
+    fn new(expected: &'a ConnectivityGraph, observed: &'a ConnectivityGraph) -> Self {
+        let mut matches = Self {
+            observed_by_expected: Vec::with_capacity(expected.groups.len()),
+            expected_by_observed: vec![Vec::new(); observed.groups.len()],
+            expected_terminals: TerminalIndex::new(),
+            observed_terminals: TerminalIndex::new(),
+        };
+        let mut observed_names = BTreeMap::<&str, Vec<usize>>::new();
+        for (index, group) in observed.groups.iter().enumerate() {
+            for name in &group.names {
+                observed_names.entry(name).or_default().push(index);
+            }
+            for terminal in &group.terminals {
+                matches.observed_terminals.insert(terminal, index);
+            }
+        }
+        for (expected_index, group) in expected.groups.iter().enumerate() {
+            let mut observed_indices = Vec::new();
+            for name in &group.names {
+                if let Some(indices) = observed_names.get(name.as_str()) {
+                    observed_indices.extend_from_slice(indices);
+                }
+            }
+            for terminal in &group.terminals {
+                matches.expected_terminals.insert(terminal, expected_index);
+                observed_indices.extend(matches.observed_terminals.matching(terminal));
+            }
+            observed_indices.sort_unstable();
+            observed_indices.dedup();
+            for &observed_index in &observed_indices {
+                matches.expected_by_observed[observed_index].push(expected_index);
+            }
+            matches.observed_by_expected.push(observed_indices);
+        }
+        matches
     }
 }
 
@@ -698,33 +747,33 @@ fn observed_component_locations(
 fn analyze_nets(
     expected: &ConnectivityGraph,
     observed: &ConnectivityGraph,
+    matches: &GroupMatches<'_>,
 ) -> BTreeMap<String, NetAnalysis> {
     expected
         .groups
         .iter()
-        .filter_map(|expected_group| {
+        .enumerate()
+        .filter_map(|(expected_index, expected_group)| {
             let name = logical_name(expected_group)?;
-            let matching_groups = observed
-                .groups
+            let matching_groups = matches.observed_by_expected[expected_index]
                 .iter()
-                .filter(|observed_group| groups_match(expected_group, observed_group))
-                .collect::<Vec<_>>();
+                .map(|&index| &observed.groups[index]);
             let missing_terminals = expected_group
                 .terminals
                 .iter()
                 .filter(|expected_terminal| {
-                    !matching_groups.iter().any(|observed_group| {
-                        observed_group
-                            .terminals
-                            .iter()
-                            .any(|observed_terminal| expected_terminal.matches(observed_terminal))
-                    })
+                    // A terminal match itself implies a group match, so no
+                    // restriction to matching_groups is necessary here.
+                    matches
+                        .observed_terminals
+                        .matching(expected_terminal)
+                        .next()
+                        .is_none()
                 })
                 .cloned()
                 .collect::<Vec<_>>();
             let connected_islands = matching_groups
-                .iter()
-                .map(|group| kicad_islands(group))
+                .map(kicad_islands)
                 .filter(|islands| !islands.is_empty())
                 .collect::<Vec<_>>();
             let islands = connected_islands.iter().flatten().cloned().collect();
@@ -742,25 +791,16 @@ fn analyze_nets(
         .collect()
 }
 
-fn groups_match(expected: &ConnectionGroup, observed: &ConnectionGroup) -> bool {
-    !expected.names.is_disjoint(&observed.names)
-        || expected.terminals.iter().any(|expected_terminal| {
-            observed
-                .terminals
-                .iter()
-                .any(|observed_terminal| expected_terminal.matches(observed_terminal))
-        })
-}
-
 fn collect_issues(
     expected: &ConnectivityGraph,
     observed: &ConnectivityGraph,
     components: &BTreeMap<SymbolSlotKey, ComponentAnalysis>,
     nets: &BTreeMap<String, NetAnalysis>,
+    matches: &GroupMatches<'_>,
 ) -> Vec<SchematicIssue> {
     let mut issues = Vec::new();
     collect_component_issues(expected, observed, components, &mut issues);
-    collect_connection_issues(expected, observed, nets, &mut issues);
+    collect_connection_issues(expected, observed, nets, matches, &mut issues);
     issues
 }
 
@@ -819,13 +859,13 @@ fn collect_connection_issues(
     expected: &ConnectivityGraph,
     observed: &ConnectivityGraph,
     nets: &BTreeMap<String, NetAnalysis>,
+    matches: &GroupMatches<'_>,
     issues: &mut Vec<SchematicIssue>,
 ) {
-    for observed_group in &observed.groups {
-        let matching_expected = expected
-            .groups
+    for (observed_index, observed_group) in observed.groups.iter().enumerate() {
+        let matching_expected = matches.expected_by_observed[observed_index]
             .iter()
-            .filter(|expected_group| groups_match(expected_group, observed_group))
+            .map(|&index| &expected.groups[index])
             .collect::<Vec<_>>();
         let matching_names = matching_expected
             .iter()
@@ -839,15 +879,10 @@ fn collect_connection_issues(
         }
 
         for name in &observed_group.names {
-            let accepted = matching_expected.iter().any(|group| {
-                group.names.contains(name)
-                    || group.terminals.iter().any(|terminal| {
-                        matches!(
-                            terminal,
-                            Terminal::InterfacePort { name: port_name } if port_name == name
-                        )
-                    })
-            });
+            let port = Terminal::InterfacePort { name: name.clone() };
+            let accepted = matching_expected
+                .iter()
+                .any(|group| group.names.contains(name) || group.terminals.contains(&port));
             if !accepted {
                 issues.push(SchematicIssue::UnexpectedNet {
                     net_name: name.clone(),
@@ -860,12 +895,12 @@ fn collect_connection_issues(
             .terminals
             .iter()
             .filter(|observed_terminal| {
-                !matching_expected.iter().any(|expected_group| {
-                    expected_group
-                        .terminals
-                        .iter()
-                        .any(|expected_terminal| expected_terminal.matches(observed_terminal))
-                })
+                // Any direct terminal match also matches its owning group.
+                matches
+                    .expected_terminals
+                    .matching(observed_terminal)
+                    .next()
+                    .is_none()
             })
             .cloned()
             .collect::<Vec<_>>();
@@ -944,6 +979,146 @@ mod tests {
         Label, LabelKind, LabelShape, Point, Rotation, SchItem, SchPage, Symbol, SymbolDefinition,
         SymbolField,
     };
+
+    #[test]
+    fn indexed_group_matching_preserves_analysis_and_source_order() {
+        let pin = |name: &str, number: &str| Terminal::ComponentPin {
+            component: ComponentIdentity::ManagedPath("U1".into()),
+            pin_name: name.into(),
+            pin_numbers: BTreeSet::from([number.into()]),
+        };
+        let a = pin("A", "1");
+        let bridge = pin("A", "2");
+        let c = pin("B", "2");
+        let missing = pin("D", "4");
+        let port = Terminal::InterfacePort { name: "P".into() };
+        let expected_group = |name: &str, terminals: BTreeSet<Terminal>| ConnectionGroup {
+            names: BTreeSet::from([name.into()]),
+            terminals,
+            origins: BTreeSet::from([ConnectionOrigin::ZenerNet { name: name.into() }]),
+        };
+        let island = |index| IslandRef {
+            page_id: "page".into(),
+            index,
+        };
+        let observed_group =
+            |index, names: &[&str], terminals: BTreeSet<Terminal>| ConnectionGroup {
+                names: names.iter().map(|name| (*name).into()).collect(),
+                terminals,
+                origins: BTreeSet::from([ConnectionOrigin::KiCadIsland(island(index))]),
+            };
+        let expected = ConnectivityGraph {
+            components: Vec::new(),
+            groups: vec![
+                expected_group("N", BTreeSet::from([a.clone(), port.clone()])),
+                expected_group("Z", BTreeSet::from([missing.clone()])),
+                ConnectionGroup::default(),
+            ],
+        };
+        let observed = ConnectivityGraph {
+            components: Vec::new(),
+            groups: vec![
+                observed_group(9, &["Z"], BTreeSet::new()),
+                // N matches by name, pin name, pin number and a second
+                // terminal. Z matches by name alone. Neither is duplicated.
+                observed_group(5, &["N", "Z"], BTreeSet::from([a, bridge, c.clone()])),
+                observed_group(2, &["P"], BTreeSet::from([port])),
+                // c matches bridge, but not a: no transitive group match.
+                observed_group(1, &["EXTRA"], BTreeSet::from([c.clone()])),
+                ConnectionGroup::default(),
+            ],
+        };
+        let matches = GroupMatches::new(&expected, &observed);
+        let brute_force = |left: &ConnectionGroup, right: &ConnectionGroup| {
+            !left.names.is_disjoint(&right.names)
+                || left
+                    .terminals
+                    .iter()
+                    .any(|a| right.terminals.iter().any(|b| a.matches(b)))
+        };
+        for (index, group) in expected.groups.iter().enumerate() {
+            assert_eq!(
+                matches.observed_by_expected[index],
+                observed
+                    .groups
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, other)| brute_force(group, other).then_some(index))
+                    .collect::<Vec<_>>()
+            );
+        }
+        for (index, group) in observed.groups.iter().enumerate() {
+            assert_eq!(
+                matches.expected_by_observed[index],
+                expected
+                    .groups
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(index, other)| brute_force(other, group).then_some(index))
+                    .collect::<Vec<_>>()
+            );
+        }
+
+        let analysis = analyze_connectivity(&expected, &observed);
+        let n_islands = vec![island(5), island(2)];
+        let z_islands = vec![island(9), island(5)];
+        assert_eq!(
+            analysis,
+            ConnectivityAnalysis {
+                components: BTreeMap::new(),
+                nets: BTreeMap::from([
+                    (
+                        "N".into(),
+                        NetAnalysis {
+                            name: "N".into(),
+                            expected_terminals: expected.groups[0]
+                                .terminals
+                                .iter()
+                                .cloned()
+                                .collect(),
+                            missing_terminals: Vec::new(),
+                            islands: n_islands.clone(),
+                            connected_islands: vec![vec![island(5)], vec![island(2)]],
+                        }
+                    ),
+                    (
+                        "Z".into(),
+                        NetAnalysis {
+                            name: "Z".into(),
+                            expected_terminals: vec![missing.clone()],
+                            missing_terminals: vec![missing.clone()],
+                            islands: z_islands.clone(),
+                            connected_islands: vec![vec![island(9)], vec![island(5)]],
+                        }
+                    ),
+                ]),
+                issues: vec![
+                    SchematicIssue::Shorted {
+                        islands: vec![island(5)],
+                        net_names: BTreeSet::from(["N".into(), "Z".into()]),
+                    },
+                    SchematicIssue::UnexpectedConnection {
+                        islands: vec![island(5)],
+                        terminals: vec![c],
+                    },
+                    SchematicIssue::UnexpectedNet {
+                        net_name: "EXTRA".into(),
+                        islands: vec![island(1)],
+                    },
+                    SchematicIssue::DisconnectedNet {
+                        net_name: "N".into(),
+                        islands: n_islands,
+                        missing_terminals: Vec::new(),
+                    },
+                    SchematicIssue::DisconnectedNet {
+                        net_name: "Z".into(),
+                        islands: z_islands,
+                        missing_terminals: vec![missing],
+                    },
+                ],
+            }
+        );
+    }
 
     #[test]
     fn reports_missing_component_slot() {

--- a/crates/pcb-kicad-sch/src/connectivity/mod.rs
+++ b/crates/pcb-kicad-sch/src/connectivity/mod.rs
@@ -10,6 +10,7 @@ mod zener;
 
 pub use kicad::{ConnectivityItemRef, PhysicalConnectivity, PhysicalIsland, PinVisibility};
 pub(crate) use kicad::{CutGraph, CutNode, PhysicalPinRef, cut_graph, reduce_with_provenance};
+pub(crate) use raw::TerminalIndex;
 pub(crate) use zener::{named_connected_nets, not_connected_terminals};
 
 pub use raw::{

--- a/crates/pcb-kicad-sch/src/connectivity/raw.rs
+++ b/crates/pcb-kicad-sch/src/connectivity/raw.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use crate::SymbolSlotKey;
 
@@ -90,6 +90,64 @@ impl Terminal {
     }
 }
 
+/// An index of direct terminal matches, not equivalence classes: matching by
+/// name or number is nontransitive, so aliases must never be unioned together.
+#[derive(Default)]
+pub(crate) struct TerminalIndex<'a> {
+    points: BTreeMap<ConnectionPoint<'a>, Vec<usize>>,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+enum ConnectionPoint<'a> {
+    PinName(&'a ComponentIdentity, &'a str),
+    PinNumber(&'a ComponentIdentity, &'a str),
+    InterfacePort(&'a str),
+}
+
+fn connection_points(terminal: &Terminal) -> impl Iterator<Item = ConnectionPoint<'_>> {
+    let (name, numbers) = match terminal {
+        Terminal::ComponentPin {
+            component,
+            pin_name,
+            pin_numbers,
+        } => (
+            (!pin_name.is_empty()).then_some(ConnectionPoint::PinName(component, pin_name)),
+            Some((component, pin_numbers)),
+        ),
+        Terminal::InterfacePort { name } => (Some(ConnectionPoint::InterfacePort(name)), None),
+    };
+    name.into_iter()
+        .chain(numbers.into_iter().flat_map(|(component, numbers)| {
+            numbers
+                .iter()
+                .map(move |number| ConnectionPoint::PinNumber(component, number))
+        }))
+}
+
+impl<'a> TerminalIndex<'a> {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert(&mut self, terminal: &'a Terminal, index: usize) {
+        for point in connection_points(terminal) {
+            self.points.entry(point).or_default().push(index);
+        }
+    }
+
+    /// Return payloads for direct matches. A payload may occur more than once
+    /// when terminals share multiple keys or multiple insertions use it.
+    pub(crate) fn matching<'b>(
+        &'b self,
+        terminal: &'b Terminal,
+    ) -> impl Iterator<Item = usize> + 'b {
+        connection_points(terminal)
+            .filter_map(|point| self.points.get(&point))
+            .flatten()
+            .copied()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ConnectionOrigin {
     ZenerNet { name: String },
@@ -100,4 +158,96 @@ pub enum ConnectionOrigin {
 pub struct IslandRef {
     pub page_id: String,
     pub index: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_index_matches_brute_force() {
+        let mut terminals = Vec::new();
+        for component in [
+            ComponentIdentity::ManagedPath("U1".into()),
+            ComponentIdentity::ManagedPath("U2".into()),
+            ComponentIdentity::KiCadSymbol(SymbolLocation {
+                page_id: "page-a".into(),
+                symbol_id: "U1".into(),
+            }),
+            ComponentIdentity::KiCadSymbol(SymbolLocation {
+                page_id: "page-b".into(),
+                symbol_id: "U1".into(),
+            }),
+            ComponentIdentity::KiCadSymbol(SymbolLocation {
+                page_id: "page-a".into(),
+                symbol_id: "U2".into(),
+            }),
+        ] {
+            for name in ["", "A", "B", "1"] {
+                for numbers in [vec![], vec![""], vec!["1"], vec!["2"], vec!["1", "2"]] {
+                    terminals.push(Terminal::ComponentPin {
+                        component: component.clone(),
+                        pin_name: name.into(),
+                        pin_numbers: numbers.into_iter().map(str::to_string).collect(),
+                    });
+                }
+            }
+        }
+        for name in ["", "A", "B", "1"] {
+            terminals.push(Terminal::InterfacePort { name: name.into() });
+        }
+        let mut index = TerminalIndex::default();
+        for (id, terminal) in terminals.iter().enumerate() {
+            index.insert(terminal, id);
+        }
+        for query in &terminals {
+            let brute_force = terminals
+                .iter()
+                .enumerate()
+                .filter_map(|(id, terminal)| terminal.matches(query).then_some(id))
+                .collect::<BTreeSet<_>>();
+            assert_eq!(
+                index.matching(query).collect::<BTreeSet<_>>(),
+                brute_force,
+                "query: {query:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn terminal_index_keeps_aliases_nontransitive_and_allows_duplicate_payloads() {
+        let pin = |name: &str, numbers: &[&str]| Terminal::ComponentPin {
+            component: ComponentIdentity::ManagedPath("U1".into()),
+            pin_name: name.into(),
+            pin_numbers: numbers.iter().map(|number| (*number).into()).collect(),
+        };
+        let terminals = [
+            pin("A", &["1"]),
+            pin("A", &["2", "3"]),
+            pin("B", &["2", "3"]),
+        ];
+        assert!(terminals[0].matches(&terminals[1]));
+        assert!(terminals[1].matches(&terminals[2]));
+        assert!(!terminals[0].matches(&terminals[2]));
+        let mut index = TerminalIndex::new();
+        for (id, terminal) in terminals.iter().enumerate() {
+            index.insert(terminal, id);
+        }
+        assert_eq!(
+            index.matching(&terminals[0]).collect::<BTreeSet<_>>(),
+            BTreeSet::from([0, 1])
+        );
+        // Name plus two overlapping numbers yields three hits, not one.
+        assert_eq!(
+            index.matching(&terminals[1]).filter(|&id| id == 1).count(),
+            3
+        );
+        index.insert(&terminals[2], 1);
+        assert_eq!(
+            index.matching(&terminals[1]).filter(|&id| id == 1).count(),
+            5
+        );
+        // Inserting another alias must not make the unrelated endpoint match.
+        assert!(!index.matching(&terminals[0]).any(|id| id == 2));
+    }
 }

--- a/crates/pcb-kicad-sch/src/cut.rs
+++ b/crates/pcb-kicad-sch/src/cut.rs
@@ -113,32 +113,60 @@ pub(crate) fn minimum_node_cut(
     sinks: &BTreeSet<usize>,
     cost: impl Fn(usize) -> Option<u64>,
 ) -> Option<Vec<usize>> {
+    minimum_node_cut_in_region(
+        graph,
+        sources,
+        sinks,
+        &(0..graph.nodes.len()).collect::<Vec<_>>(),
+        cost,
+    )
+}
+
+/// The caller supplies the live source-reachable region in original node
+/// order. Unrelated islands and deleted items cannot carry flow.
+pub(crate) fn minimum_node_cut_in_region(
+    graph: &CutGraph,
+    sources: &BTreeSet<usize>,
+    sinks: &BTreeSet<usize>,
+    original_nodes: &[usize],
+    cost: impl Fn(usize) -> Option<u64>,
+) -> Option<Vec<usize>> {
     if sources.is_empty() || sinks.is_empty() || !sources.is_disjoint(sinks) {
         return None;
     }
-    let nodes = graph.nodes.len();
+    let mut indices = vec![usize::MAX; graph.nodes.len()];
+    for (index, &node) in original_nodes.iter().enumerate() {
+        indices[node] = index;
+    }
+    let nodes = original_nodes.len();
     let entry = |node: usize| 2 * node;
     let exit = |node: usize| 2 * node + 1;
     let source = 2 * nodes;
     let sink = 2 * nodes + 1;
     let mut network = FlowNetwork::new(2 * nodes + 2);
     let mut costs = Vec::with_capacity(nodes);
-    for node in 0..nodes {
-        let node_cost = cost(node);
+    for (node, &original) in original_nodes.iter().enumerate() {
+        let node_cost = cost(original);
         costs.push(node_cost);
         network.add_arc(entry(node), exit(node), node_cost.unwrap_or(INFINITE));
     }
     // An undirected edge lets flow leave either node and enter the other, so
     // every path through a node still pays that node's entry-to-exit arc.
-    for (a, b) in &graph.edges {
-        network.add_arc(exit(*a), entry(*b), INFINITE);
-        network.add_arc(exit(*b), entry(*a), INFINITE);
+    for &(a, b) in &graph.edges {
+        if indices[a] != usize::MAX && indices[b] != usize::MAX {
+            network.add_arc(exit(indices[a]), entry(indices[b]), INFINITE);
+            network.add_arc(exit(indices[b]), entry(indices[a]), INFINITE);
+        }
     }
     for node in sources {
-        network.add_arc(source, entry(*node), INFINITE);
+        if indices[*node] != usize::MAX {
+            network.add_arc(source, entry(indices[*node]), INFINITE);
+        }
     }
     for node in sinks {
-        network.add_arc(exit(*node), sink, INFINITE);
+        if indices[*node] != usize::MAX {
+            network.add_arc(exit(indices[*node]), sink, INFINITE);
+        }
     }
     let flow = network.max_flow(source, sink, INFINITE);
     if flow >= INFINITE {
@@ -147,6 +175,7 @@ pub(crate) fn minimum_node_cut(
     let reachable = network.reachable(source);
     let cut = (0..nodes)
         .filter(|node| costs[*node].is_some() && reachable[entry(*node)] && !reachable[exit(*node)])
+        .map(|node| original_nodes[node])
         .collect::<Vec<_>>();
     (!cut.is_empty()).then_some(cut)
 }
@@ -198,6 +227,30 @@ mod tests {
             matches!(node, 1 | 2).then_some(1)
         });
         assert_eq!(cut, Some(vec![1, 2]));
+    }
+
+    #[test]
+    fn region_cut_keeps_original_costs_and_ignores_deleted_paths() {
+        let graph = graph(7, &[(0, 2), (2, 4), (4, 6), (0, 1), (1, 6)]);
+        let sources = BTreeSet::from([0]);
+        let sinks = BTreeSet::from([6]);
+        let cost = |node| match node {
+            1 | 4 => Some(1),
+            2 => Some(3),
+            _ => None,
+        };
+        assert_eq!(
+            minimum_node_cut(&graph, &sources, &sinks, cost),
+            Some(vec![1, 4])
+        );
+        assert_eq!(
+            minimum_node_cut_in_region(&graph, &sources, &sinks, &[0, 2, 4, 6], cost),
+            Some(vec![4])
+        );
+        assert_eq!(
+            minimum_node_cut_in_region(&graph, &sources, &sinks, &[0, 2], cost),
+            None
+        );
     }
 
     #[test]

--- a/crates/pcb-kicad-sch/src/repair.rs
+++ b/crates/pcb-kicad-sch/src/repair.rs
@@ -1,6 +1,9 @@
 //! Pure planning for KiCad connectivity repairs.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet},
+};
 
 use anyhow::{Result, bail};
 use pcb_sch::Schematic;
@@ -8,14 +11,14 @@ use pcb_sch::Schematic;
 use crate::{
     GEOMETRY_EPS_MM, Point, SchDocument, SchItem, SchPage, Symbol,
     analysis::{
-        ConnectivityInspection, SchematicIssue, SchematicIssueKey, analyze_connectivity,
-        ensure_issues_resolved, ensure_no_new_issues, inspect_schematic, issue_context,
-        logical_name, observed_reconcilable_connectivity,
+        ConnectivityAnalysis, ConnectivityInspection, SchematicIssue, SchematicIssueKey,
+        analyze_connectivity, ensure_issues_resolved, ensure_no_new_issues, inspect_schematic,
+        issue_context, logical_name, observed_reconcilable_connectivity,
     },
     compose,
     connectivity::{
-        ComponentIdentity, ConnectivityGraph, ConnectivityItemRef, CutNode, PhysicalIsland,
-        PinVisibility, SymbolLocation, Terminal, cut_graph,
+        ComponentIdentity, ConnectivityGraph, ConnectivityItemRef, CutNode, PhysicalConnectivity,
+        PhysicalIsland, PinVisibility, SymbolLocation, Terminal, TerminalIndex, cut_graph,
     },
     cut,
     net_symbols::NetSymbolSpec,
@@ -144,6 +147,7 @@ pub(crate) fn plan_connectivity_repair_core(
 ) -> Result<ConnectivityRepairIntent> {
     let expected = &inspection.expected;
     let observed = &inspection.physical;
+    let expected_nets = ExpectedNets::new(expected);
     let mut removals = BTreeSet::new();
     let mut relocate_symbols = BTreeSet::new();
     let selected = inspection
@@ -187,7 +191,7 @@ pub(crate) fn plan_connectivity_repair_core(
                                     .cloned(),
                             );
                         }
-                        reconnect_nets.extend(expected_names_for_island(expected, provenance));
+                        reconnect_nets.extend(expected_nets.for_island(provenance));
                     }
                 }
                 if drivers.is_empty() {
@@ -201,14 +205,14 @@ pub(crate) fn plan_connectivity_repair_core(
                 reconnect_nets.extend(net_names.iter().cloned());
                 for island in islands {
                     if let Some(provenance) = observed.islands.get(island) {
-                        reconnect_nets.extend(expected_names_for_island(expected, provenance));
+                        reconnect_nets.extend(expected_nets.for_island(provenance));
                     }
                 }
             }
             SchematicIssue::UnexpectedConnection { islands, .. } => {
                 for island in islands {
                     if let Some(provenance) = observed.islands.get(island) {
-                        reconnect_nets.extend(expected_names_for_island(expected, provenance));
+                        reconnect_nets.extend(expected_nets.for_island(provenance));
                     }
                 }
             }
@@ -244,7 +248,7 @@ pub(crate) fn plan_connectivity_repair_core(
             .values()
             .filter(|island| island.items.contains(item))
         {
-            reconnect_nets.extend(expected_names_for_island(expected, provenance));
+            reconnect_nets.extend(expected_nets.for_island(provenance));
         }
     }
 
@@ -252,25 +256,59 @@ pub(crate) fn plan_connectivity_repair_core(
     // also resolve a short without requiring a physical topology edit.
     let mut simulated = document.clone();
     remove_items(&mut simulated, &removals)?;
+    let mut current_observed = Cow::Borrowed(observed);
+    let mut current_analysis = Cow::Borrowed(&inspection.analysis);
+    if !removals.is_empty() {
+        current_observed = Cow::Owned(observed_reconcilable_connectivity(&simulated, netlist)?);
+        current_analysis = Cow::Owned(analyze_connectivity(expected, &current_observed.graph));
+    }
 
     loop {
-        let current_observed = observed_reconcilable_connectivity(&simulated, netlist)?;
-        let current_analysis = analyze_connectivity(expected, &current_observed.graph);
         let current_problems = repair_problem_counts(current_analysis.issues());
-        let Some(issue) = current_analysis.issues().iter().find(|issue| {
+        let participates = |issue: &SchematicIssue| {
             if !matches!(
                 issue,
                 SchematicIssue::Shorted { .. } | SchematicIssue::UnexpectedConnection { .. }
             ) {
                 return false;
             }
-            let context = issue_context((*issue).clone(), &current_observed.islands);
-            selected.iter().any(|selected| &selected.issue == *issue)
+            let context = issue_context(issue.clone(), &current_observed.islands);
+            selected.iter().any(|selected| &selected.issue == issue)
                 || !context.items.is_disjoint(&selected_items)
                 || !repair_problems(issue).is_disjoint(&selected_problems)
-        }) else {
+        };
+        let Some(issue) = current_analysis
+            .issues()
+            .iter()
+            .find(|issue| participates(issue))
+        else {
             break;
         };
+
+        if matches!(issue, SchematicIssue::UnexpectedConnection { .. }) {
+            let unexpected = current_analysis
+                .issues()
+                .iter()
+                .filter(|issue| {
+                    matches!(issue, SchematicIssue::UnexpectedConnection { .. })
+                        && participates(issue)
+                })
+                .collect::<Vec<_>>();
+            if let Some(batch) = verified_unexpected_connection_cuts(
+                &mut simulated,
+                netlist,
+                expected,
+                &current_observed.islands,
+                &current_problems,
+                &unexpected,
+            )? {
+                current_observed = Cow::Owned(batch.observed);
+                current_analysis = Cow::Owned(batch.analysis);
+                removals.extend(batch.removals);
+                reconnect_nets.extend(batch.reconnect_nets);
+                continue;
+            }
+        }
 
         // Whatever gets dismantled, its nets get rebuilt — including issues
         // repaired only because they overlap the selection.
@@ -282,22 +320,23 @@ pub(crate) fn plan_connectivity_repair_core(
         {
             for island in islands {
                 if let Some(provenance) = current_observed.islands.get(island) {
-                    reconnect_nets.extend(expected_names_for_island(expected, provenance));
+                    reconnect_nets.extend(expected_nets.for_island(provenance));
                 }
             }
         }
 
-        let candidates = repair_candidates(issue, expected, &current_observed.islands);
+        let candidates = repair_candidates(issue, &expected_nets, &current_observed.islands);
         if let Some(cut) = minimum_verified_cut(
-            &simulated,
+            &mut simulated,
             netlist,
             expected,
             &current_problems,
             issue,
             &candidates,
         )? {
-            remove_items(&mut simulated, &cut)?;
-            removals.extend(cut);
+            current_observed = Cow::Owned(cut.observed);
+            current_analysis = Cow::Owned(cut.analysis);
+            removals.extend(cut.removals);
             continue;
         }
 
@@ -317,7 +356,7 @@ pub(crate) fn plan_connectivity_repair_core(
                         .values()
                         .filter(|island| island.pins.iter().any(|pin| pin.is_on_symbol(&location)))
                     {
-                        reconnect_nets.extend(expected_names_for_island(expected, island));
+                        reconnect_nets.extend(expected_nets.for_island(island));
                     }
                     remove_items(
                         &mut simulated,
@@ -328,10 +367,12 @@ pub(crate) fn plan_connectivity_repair_core(
                     )?;
                 }
             }
-            continue;
+        } else {
+            remove_items(&mut simulated, &fallback)?;
+            removals.extend(fallback);
         }
-        remove_items(&mut simulated, &fallback)?;
-        removals.extend(fallback);
+        current_observed = Cow::Owned(observed_reconcilable_connectivity(&simulated, netlist)?);
+        current_analysis = Cow::Owned(analyze_connectivity(expected, &current_observed.graph));
     }
 
     removals.extend(orphaned_junctions(document, &simulated, &removals));
@@ -645,22 +686,18 @@ fn orphaned_junctions(
 /// finite cut (the sides meet only through labels or coincident pins) or the
 /// reducer does not confirm the cut, so the caller falls back to teardown.
 fn minimum_verified_cut(
-    document: &SchDocument,
+    document: &mut SchDocument,
     netlist: &Schematic,
     expected: &ConnectivityGraph,
     current_problems: &BTreeMap<RepairProblem, usize>,
     issue: &SchematicIssue,
     candidates: &BTreeSet<ConnectivityItemRef>,
-) -> Result<Option<BTreeSet<ConnectivityItemRef>>> {
+) -> Result<Option<VerifiedCuts>> {
     if candidates.is_empty() {
         return Ok(None);
     }
     let graph = cut_graph(document, PinVisibility::VisibleOnly)?;
-    let node_nets = graph
-        .nodes
-        .iter()
-        .map(|node| node_expected_nets(expected, node))
-        .collect::<Vec<_>>();
+    let node_nets = node_expected_nets(expected, &graph.nodes);
     let nodes_with = |predicate: &dyn Fn(usize, &CutNode) -> bool| {
         graph
             .nodes
@@ -745,36 +782,281 @@ fn minimum_verified_cut(
     if cut.is_empty() {
         return Ok(None);
     }
-    let mut next = document.clone();
-    remove_items(&mut next, &cut)?;
-    let observed = observed_reconcilable_connectivity(&next, netlist)?;
-    let analysis = analyze_connectivity(expected, &observed.graph);
-    let problems = repair_problem_counts(analysis.issues());
-    // The metric counts conflicts only. A cut may also split a net; the
-    // reconnect list rebuilds that, so "minimal" means the fewest removals,
-    // not the least rewiring.
-    Ok(strictly_reduces_problems(current_problems, &problems).then_some(cut))
+    Ok(
+        verify_cuts(document, netlist, expected, current_problems, &cut)?.map(
+            |(observed, analysis)| VerifiedCuts {
+                observed,
+                analysis,
+                removals: cut,
+                reconnect_nets: BTreeSet::new(),
+            },
+        ),
+    )
 }
 
 /// Expected nets a node belongs to, through its terminals or the names it
 /// drives.
-fn node_expected_nets(expected: &ConnectivityGraph, node: &CutNode) -> BTreeSet<String> {
-    let mut nets = BTreeSet::new();
-    for group in &expected.groups {
-        let Some(name) = logical_name(group) else {
-            continue;
-        };
-        if node.driver_names.iter().any(|driver| driver == name)
-            || group.terminals.iter().any(|expected_terminal| {
-                node.terminals
-                    .iter()
-                    .any(|observed| expected_terminal.matches(observed))
-            })
-        {
-            nets.insert(name.to_string());
+fn node_expected_nets(expected: &ConnectivityGraph, nodes: &[CutNode]) -> Vec<BTreeSet<String>> {
+    let mut terminals = TerminalIndex::new();
+    let names = expected
+        .groups
+        .iter()
+        .filter_map(logical_name)
+        .collect::<BTreeSet<_>>();
+    for (index, group) in expected.groups.iter().enumerate() {
+        for terminal in &group.terminals {
+            terminals.insert(terminal, index);
         }
     }
-    nets
+    nodes
+        .iter()
+        .map(|node| {
+            node.terminals
+                .iter()
+                .flat_map(|terminal| terminals.matching(terminal))
+                .filter_map(|index| logical_name(&expected.groups[index]))
+                .chain(
+                    node.driver_names
+                        .iter()
+                        .map(String::as_str)
+                        .filter(|name| names.contains(name)),
+                )
+                .map(str::to_string)
+                .collect()
+        })
+        .collect()
+}
+
+struct VerifiedCuts {
+    observed: PhysicalConnectivity,
+    analysis: ConnectivityAnalysis,
+    removals: BTreeSet<ConnectivityItemRef>,
+    reconnect_nets: BTreeSet<String>,
+}
+
+/// Isolate unexpected pins on a deletion-only graph, then verify the entire
+/// batch through the real reducer. Wires/junctions cannot merge islands, so
+/// other independent conflicts do not need to be reanalyzed after every cut.
+/// The cut graph approximates legacy power semantics: if verification rejects
+/// the batch, the caller retains the individually verified repair path.
+fn verified_unexpected_connection_cuts(
+    document: &mut SchDocument,
+    netlist: &Schematic,
+    expected: &ConnectivityGraph,
+    islands: &BTreeMap<crate::connectivity::IslandRef, PhysicalIsland>,
+    current_problems: &BTreeMap<RepairProblem, usize>,
+    issues: &[&SchematicIssue],
+) -> Result<Option<VerifiedCuts>> {
+    let expected_nets = ExpectedNets::new(expected);
+    let issues = issues
+        .iter()
+        .filter_map(|issue| {
+            let candidates = repair_candidates(issue, &expected_nets, islands);
+            (!candidates.is_empty()).then_some((*issue, candidates))
+        })
+        .collect::<Vec<_>>();
+    if issues.is_empty() {
+        return Ok(None);
+    }
+    let graph = cut_graph(document, PinVisibility::VisibleOnly)?;
+    let node_nets = node_expected_nets(expected, &graph.nodes);
+    let expected_names = expected
+        .groups
+        .iter()
+        .flat_map(|group| &group.names)
+        .collect::<BTreeSet<_>>();
+    let mut expected_terminals = TerminalIndex::new();
+    for group in &expected.groups {
+        for terminal in &group.terminals {
+            expected_terminals.insert(terminal, 0);
+        }
+    }
+    let matches_expected = graph
+        .nodes
+        .iter()
+        .map(|node| {
+            node.driver_names
+                .iter()
+                .any(|name| expected_names.contains(name))
+                || node
+                    .terminals
+                    .iter()
+                    .any(|terminal| expected_terminals.matching(terminal).next().is_some())
+        })
+        .collect::<Vec<_>>();
+    let mut terminals = TerminalIndex::new();
+    let mut item_nodes = BTreeMap::<&ConnectivityItemRef, Vec<usize>>::new();
+    let mut adjacency = vec![Vec::new(); graph.nodes.len()];
+    for (index, node) in graph.nodes.iter().enumerate() {
+        if let Some(item) = &node.item {
+            item_nodes.entry(item).or_default().push(index);
+        }
+        for terminal in &node.terminals {
+            terminals.insert(terminal, index);
+        }
+    }
+    for &(a, b) in &graph.edges {
+        adjacency[a].push(b);
+        adjacency[b].push(a);
+    }
+    let mut active = vec![true; graph.nodes.len()];
+    let mut removals = BTreeSet::new();
+    let mut reconnect_nets = BTreeSet::new();
+    for (issue, candidates) in issues {
+        let SchematicIssue::UnexpectedConnection {
+            terminals: unexpected,
+            islands: issue_islands,
+        } = issue
+        else {
+            continue;
+        };
+        let unexpected_nodes = unexpected
+            .iter()
+            .flat_map(|terminal| terminals.matching(terminal))
+            .collect::<BTreeSet<_>>();
+        let mut changed = false;
+        for terminal in unexpected {
+            let sources = terminals
+                .matching(terminal)
+                .filter(|&index| active[index])
+                .collect::<BTreeSet<_>>();
+            let mut reachable = vec![false; graph.nodes.len()];
+            let mut pending = sources.iter().copied().collect::<Vec<_>>();
+            let mut region = Vec::new();
+            let mut connected_terminals = BTreeSet::new();
+            let mut connected_to_expected = false;
+            while let Some(node) = pending.pop() {
+                if reachable[node] || !active[node] {
+                    continue;
+                }
+                reachable[node] = true;
+                region.push(node);
+                connected_terminals.extend(graph.nodes[node].terminals.iter());
+                connected_to_expected |= matches_expected[node];
+                pending.extend(adjacency[node].iter().copied());
+            }
+            if connected_terminals.len() < 2 && !connected_to_expected {
+                continue;
+            }
+            region.sort_unstable();
+            let adjacent = sources
+                .iter()
+                .flat_map(|&node| adjacency[node].iter().copied())
+                .collect::<BTreeSet<_>>();
+            let source_nets = sources
+                .iter()
+                .flat_map(|&index| node_nets[index].iter().cloned())
+                .collect::<BTreeSet<_>>();
+            let sinks = region
+                .iter()
+                .copied()
+                .filter(|index| {
+                    let node = &graph.nodes[*index];
+                    !sources.contains(index)
+                        && !adjacent.contains(index)
+                        && node_nets[*index].is_disjoint(&source_nets)
+                        && !node
+                            .driver_names
+                            .iter()
+                            .any(|name| source_nets.contains(name))
+                        && (node.item.is_none()
+                            || !node_nets[*index].is_empty()
+                            || !node.driver_names.is_empty()
+                            || unexpected_nodes.contains(index))
+                })
+                .collect::<BTreeSet<_>>();
+            let Some(cut) =
+                cut::minimum_node_cut_in_region(&graph, &sources, &sinks, &region, |index| {
+                    graph.nodes[index]
+                        .item
+                        .as_ref()
+                        .filter(|item| candidates.contains(item))
+                        .map(connectivity_item_cut_cost)
+                })
+            else {
+                continue;
+            };
+            let cut = cut
+                .into_iter()
+                .filter_map(|index| graph.nodes[index].item.clone())
+                .collect::<BTreeSet<_>>();
+            // One physical item can occur in several instances of a sheet.
+            for item in &cut {
+                for &index in &item_nodes[item] {
+                    active[index] = false;
+                }
+            }
+            removals.extend(cut);
+            changed = true;
+        }
+        if changed {
+            for island in issue_islands {
+                if let Some(island) = islands.get(island) {
+                    reconnect_nets.extend(expected_nets.for_island(island));
+                }
+            }
+        }
+    }
+    if removals.is_empty() {
+        return Ok(None);
+    }
+    let Some((observed, analysis)) =
+        verify_cuts(document, netlist, expected, current_problems, &removals)?
+    else {
+        return Ok(None);
+    };
+    Ok(Some(VerifiedCuts {
+        observed,
+        analysis,
+        removals,
+        reconnect_nets,
+    }))
+}
+
+/// Speculate on the working document, retaining only the removed items for
+/// rollback rather than cloning all page libraries. Cuts never edit sheet
+/// pins or other retained items. Restore exact order on rejection or error.
+fn verify_cuts(
+    document: &mut SchDocument,
+    netlist: &Schematic,
+    expected: &ConnectivityGraph,
+    current_problems: &BTreeMap<RepairProblem, usize>,
+    removals: &BTreeSet<ConnectivityItemRef>,
+) -> Result<Option<(PhysicalConnectivity, ConnectivityAnalysis)>> {
+    let by_page = index_removals(removals);
+    let mut saved = Vec::new();
+    for (page_index, page) in document.pages.iter().enumerate() {
+        let Some(by_id) = by_page.get(page.id.as_str()) else {
+            continue;
+        };
+        for (item_index, item) in page.items.iter().enumerate() {
+            if item
+                .id()
+                .and_then(|id| by_id.get(id))
+                .is_some_and(|candidates| {
+                    candidates
+                        .iter()
+                        .any(|removal| item_matches(&page.id, item, removal))
+                })
+            {
+                saved.push((page_index, item_index, item.clone()));
+            }
+        }
+    }
+    remove_items(document, removals)?;
+    let result = observed_reconcilable_connectivity(document, netlist).map(|observed| {
+        let analysis = analyze_connectivity(expected, &observed.graph);
+        // Disconnected nets are rebuilt by the realizer. Only conflicts must
+        // decrease, and no existing conflict may get worse.
+        strictly_reduces_problems(current_problems, &repair_problem_counts(analysis.issues()))
+            .then_some((observed, analysis))
+    });
+    if !matches!(&result, Ok(Some(_))) {
+        for (page, index, item) in saved {
+            document.pages[page].items.insert(index, item);
+        }
+    }
+    result
 }
 
 fn relocation_candidates(
@@ -925,7 +1207,7 @@ fn connectivity_item_cut_cost(item: &ConnectivityItemRef) -> u64 {
 
 fn repair_candidates(
     issue: &SchematicIssue,
-    expected: &ConnectivityGraph,
+    expected: &ExpectedNets<'_>,
     islands: &std::collections::BTreeMap<crate::connectivity::IslandRef, PhysicalIsland>,
 ) -> BTreeSet<ConnectivityItemRef> {
     let issue_islands = match issue {
@@ -972,11 +1254,12 @@ pub(crate) fn point_on_segment(point: Point, a: Point, b: Point) -> bool {
 
 fn repair_island(
     issue: &SchematicIssue,
-    expected: &ConnectivityGraph,
+    expected: &ExpectedNets<'_>,
     island: &PhysicalIsland,
 ) -> bool {
     match issue {
-        SchematicIssue::Shorted { net_names, .. } => expected_names_for_island(expected, island)
+        SchematicIssue::Shorted { net_names, .. } => expected
+            .for_island(island)
             .intersection(net_names)
             .nth(1)
             .is_some(),
@@ -1057,44 +1340,115 @@ fn describe_terminal(document: &SchDocument, terminal: &Terminal) -> String {
     }
 }
 
-fn expected_names_for_island(
-    expected: &ConnectivityGraph,
-    island: &PhysicalIsland,
-) -> BTreeSet<String> {
-    expected
-        .groups
-        .iter()
-        .filter(|group| {
-            !group.names.is_disjoint(&island.names)
-                || group.terminals.iter().any(|expected_terminal| {
-                    island
-                        .terminals
-                        .iter()
-                        .any(|observed_terminal| expected_terminal.matches(observed_terminal))
-                })
-        })
-        .filter_map(logical_name)
-        .map(str::to_string)
-        .collect()
+struct ExpectedNets<'a> {
+    graph: &'a ConnectivityGraph,
+    terminals: TerminalIndex<'a>,
+    names: BTreeMap<&'a str, Vec<usize>>,
+}
+
+impl<'a> ExpectedNets<'a> {
+    fn new(graph: &'a ConnectivityGraph) -> Self {
+        let mut terminals = TerminalIndex::new();
+        let mut names = BTreeMap::<&str, Vec<usize>>::new();
+        for (index, group) in graph.groups.iter().enumerate() {
+            for terminal in &group.terminals {
+                terminals.insert(terminal, index);
+            }
+            for name in &group.names {
+                names.entry(name).or_default().push(index);
+            }
+        }
+        Self {
+            graph,
+            terminals,
+            names,
+        }
+    }
+
+    fn for_island(&self, island: &PhysicalIsland) -> BTreeSet<String> {
+        island
+            .terminals
+            .iter()
+            .flat_map(|terminal| self.terminals.matching(terminal))
+            .chain(
+                island
+                    .names
+                    .iter()
+                    .filter_map(|name| self.names.get(name.as_str()))
+                    .flatten()
+                    .copied(),
+            )
+            .filter_map(|index| logical_name(&self.graph.groups[index]))
+            .map(str::to_string)
+            .collect()
+    }
+}
+
+type RemovalIndex<'a> = BTreeMap<&'a str, BTreeMap<&'a str, Vec<&'a ConnectivityItemRef>>>;
+
+fn index_removals(removals: &BTreeSet<ConnectivityItemRef>) -> RemovalIndex<'_> {
+    let mut by_page = RemovalIndex::new();
+    for removal in removals {
+        let (page, id) = removal.page_and_item_id();
+        by_page
+            .entry(page)
+            .or_default()
+            .entry(id)
+            .or_default()
+            .push(removal);
+    }
+    by_page
 }
 
 pub(crate) fn remove_items(
     document: &mut SchDocument,
     removals: &BTreeSet<ConnectivityItemRef>,
 ) -> Result<()> {
+    if removals.is_empty() {
+        return Ok(());
+    }
+    let by_page = index_removals(removals);
+    let mut counts = removals
+        .iter()
+        .map(|removal| (removal, 0usize))
+        .collect::<BTreeMap<_, _>>();
+    // Validate every address before changing anything, including duplicate
+    // IDs and item-kind mismatches. Indexing limits comparisons to that ID.
+    for page in &document.pages {
+        let Some(by_id) = by_page.get(page.id.as_str()) else {
+            continue;
+        };
+        for item in &page.items {
+            let Some(candidates) = item.id().and_then(|id| by_id.get(id)) else {
+                continue;
+            };
+            for &removal in candidates {
+                let count = if let ConnectivityItemRef::SheetPin { pin_id, .. } = removal
+                    && let SchItem::Sheet(sheet) = item
+                {
+                    sheet.pins.iter().filter(|pin| &pin.id == pin_id).count()
+                } else {
+                    usize::from(item_matches(&page.id, item, removal))
+                };
+                *counts.get_mut(removal).expect("indexed removal") += count;
+            }
+        }
+    }
     for removal in removals {
-        let count = document
-            .pages
-            .iter()
-            .map(|page| matching_item_count(page, removal))
-            .sum::<usize>();
+        let count = counts[removal];
         if count != 1 {
             bail!("connectivity item {removal:?} matched {count} loaded schematic items");
         }
     }
     for page in &mut document.pages {
+        let Some(by_id) = by_page.get(page.id.as_str()) else {
+            continue;
+        };
         page.items.retain_mut(|item| {
-            for removal in removals {
+            let Some(candidates) = item.id().and_then(|id| by_id.get(id)) else {
+                return true;
+            };
+            for &removal in candidates {
                 if let ConnectivityItemRef::SheetPin {
                     page_id,
                     sheet_id,
@@ -1117,33 +1471,6 @@ pub(crate) fn remove_items(
     Ok(())
 }
 
-fn matching_item_count(page: &SchPage, item_ref: &ConnectivityItemRef) -> usize {
-    if let ConnectivityItemRef::SheetPin {
-        page_id,
-        sheet_id,
-        pin_id,
-    } = item_ref
-    {
-        if page_id != &page.id {
-            return 0;
-        }
-        return page
-            .items
-            .iter()
-            .filter_map(|item| match item {
-                SchItem::Sheet(sheet) if &sheet.id == sheet_id => Some(sheet),
-                _ => None,
-            })
-            .flat_map(|sheet| &sheet.pins)
-            .filter(|pin| &pin.id == pin_id)
-            .count();
-    }
-    page.items
-        .iter()
-        .filter(|item| item_matches(&page.id, item, item_ref))
-        .count()
-}
-
 pub(crate) fn item_matches(page_id: &str, item: &SchItem, item_ref: &ConnectivityItemRef) -> bool {
     match (item, item_ref) {
         (SchItem::Symbol(_), ConnectivityItemRef::Symbol { page_id: page, id })
@@ -1158,6 +1485,19 @@ pub(crate) fn item_matches(page_id: &str, item: &SchItem, item_ref: &Connectivit
 }
 
 impl ConnectivityItemRef {
+    fn page_and_item_id(&self) -> (&str, &str) {
+        match self {
+            Self::Symbol { page_id, id }
+            | Self::Wire { page_id, id }
+            | Self::Junction { page_id, id }
+            | Self::NoConnect { page_id, id }
+            | Self::Label { page_id, id } => (page_id, id),
+            Self::SheetPin {
+                page_id, sheet_id, ..
+            } => (page_id, sheet_id),
+        }
+    }
+
     fn is_removable_name_driver(&self) -> bool {
         matches!(self, Self::Label { .. } | Self::Symbol { .. })
     }
@@ -1236,6 +1576,230 @@ mod tests {
             )]),
             pins: Vec::new(),
             unsupported: Vec::new(),
+        }
+    }
+
+    fn unmanaged_chains(chains: usize, pins: usize) -> SchDocument {
+        let definition = SymbolDefinition::from_kicad_symbol_sexpr(
+            r#"(symbol "Test:Part" (symbol "Part_1_1"
+              (pin passive line (at 0 0 0) (length 2.54) (name "1") (number "1"))))"#,
+        )
+        .unwrap();
+        let mut page = SchPage::new("chains");
+        page.library
+            .definitions
+            .insert(definition.lib_id.clone(), definition);
+        for chain in 0..chains {
+            for pin in 0..pins {
+                let at = Point::new(pin as f64 * 9.0, chain as f64 * 10.0);
+                let mut symbol = part(at, at);
+                symbol.id = format!("part-{chain}-{pin}");
+                page.items.push(SchItem::Symbol(symbol));
+                if pin > 0 {
+                    for segment in 0..3 {
+                        page.items.push(SchItem::Wire(Wire {
+                            id: format!("wire-{chain}-{pin}-{segment}"),
+                            a: Point::new(at.x - 9.0 + segment as f64 * 3.0, at.y),
+                            b: Point::new(at.x - 6.0 + segment as f64 * 3.0, at.y),
+                            unsupported: Vec::new(),
+                        }));
+                    }
+                }
+            }
+        }
+        document(vec![page])
+    }
+
+    #[test]
+    fn batches_only_selected_conflicts_and_preserves_wire_stubs() {
+        let document = unmanaged_chains(32, 2);
+        let original = document.clone();
+        let netlist = Schematic::new();
+        let inspection = inspect_schematic(&document, &netlist).unwrap();
+        let conflicts = inspection
+            .issues
+            .iter()
+            .filter(|issue| matches!(issue.issue, SchematicIssue::UnexpectedConnection { .. }))
+            .collect::<Vec<_>>();
+        assert_eq!(conflicts.len(), 32);
+        let selected = conflicts
+            .iter()
+            .step_by(2)
+            .map(|issue| issue.key.clone())
+            .collect();
+        let intent = plan_connectivity_repair(
+            &document,
+            &netlist,
+            &inspection,
+            &selected,
+            &BTreeSet::new(),
+        )
+        .unwrap();
+        assert_eq!(
+            intent.removals.len(),
+            16,
+            "one cut per selected three-segment path"
+        );
+        assert!(intent.relocated_symbols.is_empty());
+        assert!(intent.reconnect_nets.is_empty());
+        let after = intent.apply_edits(&document).unwrap();
+        let verified =
+            verify_connectivity_repair(&document, &inspection, &netlist, &intent, &after).unwrap();
+        for issue in conflicts.iter().skip(1).step_by(2) {
+            assert!(
+                verified
+                    .issues
+                    .iter()
+                    .any(|remaining| remaining.key == issue.key),
+                "unselected conflict changed"
+            );
+        }
+        assert_eq!(document, original, "planning is pure");
+        assert_eq!(
+            intent,
+            plan_connectivity_repair(
+                &document,
+                &netlist,
+                &inspection,
+                &selected,
+                &BTreeSet::new()
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn batch_verification_rejects_an_unverified_cut() {
+        let mut document = unmanaged_chains(2, 2);
+        let original = document.clone();
+        let netlist = Schematic::new();
+        let inspection = inspect_schematic(&document, &netlist).unwrap();
+        let issues = inspection
+            .issues
+            .iter()
+            .map(|issue| &issue.issue)
+            .filter(|issue| matches!(issue, SchematicIssue::UnexpectedConnection { .. }))
+            .collect::<Vec<_>>();
+        // A stale/overly optimistic conflict count cannot authorize edits.
+        // The real reducer must reject the batch even though graph cuts exist.
+        assert!(
+            verified_unexpected_connection_cuts(
+                &mut document,
+                &netlist,
+                &inspection.expected,
+                &inspection.physical.islands,
+                &BTreeMap::new(),
+                &issues
+            )
+            .unwrap()
+            .is_none()
+        );
+        assert_eq!(document, original);
+    }
+
+    #[test]
+    fn failed_cut_inspection_restores_exact_item_order() {
+        let mut document = unmanaged_chains(2, 2);
+        document.pages[0].library.definitions.clear();
+        let original = document.clone();
+        let cuts = BTreeSet::from([
+            ConnectivityItemRef::Wire {
+                page_id: "chains".into(),
+                id: "wire-0-1-0".into(),
+            },
+            ConnectivityItemRef::Wire {
+                page_id: "chains".into(),
+                id: "wire-1-1-2".into(),
+            },
+        ]);
+        assert!(
+            verify_cuts(
+                &mut document,
+                &Schematic::new(),
+                &ConnectivityGraph::default(),
+                &BTreeMap::new(),
+                &cuts
+            )
+            .is_err()
+        );
+        assert_eq!(document, original);
+    }
+
+    #[test]
+    fn indexed_removals_validate_kind_page_and_duplicates_before_mutation() {
+        let mut document = unmanaged_chains(1, 2);
+        let wire = document.pages[0]
+            .items
+            .iter()
+            .find(|item| matches!(item, SchItem::Wire(_)))
+            .unwrap()
+            .clone();
+        let id = wire.id().unwrap().to_string();
+        document.pages.push(page_with("other", vec![wire.clone()]));
+        let original = document.clone();
+        let selected = ConnectivityItemRef::Wire {
+            page_id: "chains".into(),
+            id: id.clone(),
+        };
+        let wrong_kind = ConnectivityItemRef::Symbol {
+            page_id: "chains".into(),
+            id: id.clone(),
+        };
+        assert!(
+            remove_items(
+                &mut document,
+                &BTreeSet::from([selected.clone(), wrong_kind])
+            )
+            .is_err()
+        );
+        assert_eq!(document, original);
+        document.pages[0].items.push(wire.clone());
+        let duplicated = document.clone();
+        assert!(remove_items(&mut document, &BTreeSet::from([selected.clone()])).is_err());
+        assert_eq!(document, duplicated);
+        document.pages[0].items.pop();
+        remove_items(&mut document, &BTreeSet::from([selected])).unwrap();
+        assert_eq!(document.pages[1].items, vec![wire]);
+        assert!(
+            !document.pages[0]
+                .items
+                .iter()
+                .any(|item| item.id() == Some(id.as_str()))
+        );
+    }
+
+    #[test]
+    #[ignore = "release-mode synthetic performance benchmark; run explicitly"]
+    fn benchmark_unexpected_connection_repairs() {
+        for (chains, pins) in [(64, 2), (256, 2), (1024, 2), (1, 256)] {
+            let document = unmanaged_chains(chains, pins);
+            let netlist = Schematic::new();
+            let inspection = inspect_schematic(&document, &netlist).unwrap();
+            let selected = inspection
+                .issues
+                .iter()
+                .filter(|issue| matches!(issue.issue, SchematicIssue::UnexpectedConnection { .. }))
+                .map(|issue| issue.key.clone())
+                .collect();
+            let start = std::time::Instant::now();
+            let intent = plan_connectivity_repair(
+                &document,
+                &netlist,
+                &inspection,
+                &selected,
+                &BTreeSet::new(),
+            )
+            .unwrap();
+            eprintln!(
+                "chains={chains} pins={pins} planning={:?} removals={}",
+                start.elapsed(),
+                intent.removals.len()
+            );
+            if pins == 2 {
+                assert_eq!(intent.removals.len(), chains);
+            }
+            let after = intent.apply_edits(&document).unwrap();
+            verify_connectivity_repair(&document, &inspection, &netlist, &intent, &after).unwrap();
         }
     }
 
@@ -1439,7 +2003,7 @@ mod tests {
         };
 
         assert_eq!(
-            repair_candidates(&issue, &expected, &islands),
+            repair_candidates(&issue, &ExpectedNets::new(&expected), &islands),
             BTreeSet::from([wire("bridge")])
         );
     }
@@ -1461,7 +2025,11 @@ mod tests {
         };
 
         assert_eq!(
-            repair_candidates(&issue, &ConnectivityGraph::default(), &islands),
+            repair_candidates(
+                &issue,
+                &ExpectedNets::new(&ConnectivityGraph::default()),
+                &islands
+            ),
             BTreeSet::from([wire("unexpected-connection")])
         );
     }

--- a/crates/pcb-kicad-sch/tests/repair_planning.rs
+++ b/crates/pcb-kicad-sch/tests/repair_planning.rs
@@ -12,6 +12,48 @@ use pcb_kicad_sch::{
 };
 
 #[test]
+fn batch_cut_removes_a_shared_wire_from_every_sheet_instance() {
+    use common::kicad_builder::{KicadBuilder, TestPin};
+
+    let mut builder = KicadBuilder::new();
+    builder
+        .sheet("shared.kicad_sch", &[])
+        .sheet("shared.kicad_sch", &[])
+        .add_page("shared", "shared.kicad_sch")
+        .define_symbol("Test:OnePin", &[TestPin::passive("1", (0.0, 0.0))])
+        .component("Test:OnePin", None, (0.0, 0.0))
+        .component("Test:OnePin", None, (9.0, 0.0))
+        .global_label("SHARED", (0.0, 0.0))
+        .wire((0.0, 0.0), (3.0, 0.0))
+        .wire((3.0, 0.0), (6.0, 0.0))
+        .wire((6.0, 0.0), (9.0, 0.0));
+    let document = builder.build();
+    let netlist = pcb_sch::Schematic::new();
+    let inspection = inspect_schematic(&document, &netlist).unwrap();
+    let selected = inspection
+        .issues
+        .iter()
+        .filter(|issue| matches!(issue.issue, SchematicIssue::UnexpectedConnection { .. }))
+        .map(|issue| issue.key.clone())
+        .collect();
+    let intent = plan_connectivity_repair(
+        &document,
+        &netlist,
+        &inspection,
+        &selected,
+        &BTreeSet::new(),
+    )
+    .unwrap();
+    assert_eq!(
+        intent.removals().len(),
+        1,
+        "the same file item occurs in both instances"
+    );
+    let after = intent.apply_edits(&document).unwrap();
+    verify_connectivity_repair(&document, &inspection, &netlist, &intent, &after).unwrap();
+}
+
+#[test]
 fn chooses_one_deterministic_wire_when_single_item_repairs_are_ambiguous() {
     let netlist = common::compile_fixture("analysis", "simple.zen");
     let mut document = plan_reconciliation(None, &netlist, "simple.kicad_sch")


### PR DESCRIPTION
## Motivation
Loading the reported 12-sheet QSBC schematic blocks the viewer in synchronous PCB WASM repair planning. Native planning originally took 432.315 seconds for 473 unexpected connections.

Closes https://linear.app/diodeinc/issue/ENG-1581/speed-up-schematic-connectivity-repair-planning-to-prevent-viewer

## Approach
- Index direct terminal matches and reuse expected/observed group relations without introducing transitive alias matching.
- Batch unexpected-connection cuts on a deletion-only graph, restrict min-cut networks to live source-reachable regions, verify with the authoritative connectivity reducer, and retain serial fallback.
- Reuse inspection and verified analysis, index removal addresses, and roll back speculative removals instead of cloning symbol libraries for every attempt. The public planner remains pure.

## Performance
Measured on the motivating board in the orb before rebasing (planner time, not total page load):
- Native: 432.315 s original → 574.713 ms current.
- WASM under Node WASI: 1.243 s first optimization → 736.548 ms current.
- The later optimizations preserve the first optimized plan exactly, including native/WASM agreement.

Post-rebase release benchmark: 64 independent pairs 3.59 ms; 256 pairs 15.11 ms; 1,024 pairs 82.99 ms; 256-pin chain 36.96 ms. Synthetic repairs pass verification.

## Behavior and limitations
Batching is an algorithm change, not solely a transparent optimization: it can choose different removals than serial planning. The motivating board produces 1,603 removals versus the original 2,111, with the same single relocation and zero reconnect nets.

That board still fails final application verification on the same preexisting U34 stacked VDD pins 1/10 and GND pins 4/5 in both old and new planners. These are not VDD-to-GND shorts. Missing imported Path identity and relocation that cannot separate coincident pins within one symbol remain outside this performance change. This PR does not claim a passing end-to-end repair of that board or update the production Diode dependency pin.

Requested oracle review found no blockers. Remaining review follow-ups: aggregate batch acceptance can mask a per-key increase in one cut with a decrease in another; repeated batch rejection can redo work before serial fallback; add a passing real-board regression after isolating the existing U34 issue.

## Validation
After rebasing onto origin/main without conflicts:
- `cargo nextest run -p pcb-kicad-sch --status-level fail --final-status-level fail`: 205 passed, 1 ignored benchmark.
- `cargo nextest run --release -p pcb-kicad-sch --lib -E "test(benchmark_unexpected_connection_repairs)" --run-ignored only --no-capture`: passed.
- `cargo clippy -p pcb-kicad-sch --all-targets -- -D warnings`: passed.
- `cargo fmt --all -- --check`: passed.
- `cargo test --doc -p pcb-kicad-sch`: passed (0 doctests).
- `git diff --check`: passed. No snapshots changed.

[Investigation, implementation, and oracle review](https://ampcode.com/threads/T-01a087db-3e88-73e2-a1f1-2704bda4421c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core schematic connectivity analysis and repair algorithms (including batched cuts and different removal choices), though cuts remain gated by the authoritative reducer and extensive new tests.
> 
> **Overview**
> This PR **speeds up schematic connectivity comparison and repair planning** by replacing repeated brute-force net/group matching with precomputed **`GroupMatches`** and a **`TerminalIndex`** for direct (non-transitive) pin/port lookups.
> 
> **Repair planning** now batches **unexpected-connection** fixes: it plans local wire/junction cuts on a deletion-only graph using **`minimum_node_cut_in_region`**, applies them together, and **verifies once** through the real connectivity reducer—with rollback via **`verify_cuts`** instead of cloning whole documents each attempt. Removals are **indexed by page/id** before mutation, and expected-net resolution goes through an **`ExpectedNets`** helper reused across cut selection and reconnect planning.
> 
> The public **`plan_connectivity_repair`** path stays pure on input documents; behavior can differ from serial one-issue cuts when batching accepts a verified set (fewer removals on large boards). Changelog notes the performance change; tests cover index equivalence, batch selection, shared sheet instances, and failed-cut restoration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 753db417dbaa9312a3202236d9658346e351c385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->