### PR TITLE
feat: prefer Board(path) with layout_path compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Prefer `Board(path=...)`, retaining `layout_path` as a compatibility alias, and enable persistent schematics in new board templates.
+- Prefer `Board(path=...)`, retaining `layout_path` as a compatibility alias and rejecting empty paths. New board templates enable persistent schematics while keeping `layout_path` for older compilers.
 - Speed up schematic connectivity analysis and repair planning with indexed terminal matching and verified batches of local wire cuts.
 
 ## [0.4.52] - 2026-09-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- Prefer `Board(path=...)`, retaining `layout_path` as a compatibility alias, and enable persistent schematics in new board templates.
 - Speed up schematic connectivity analysis and repair planning with indexed terminal matching and verified batches of local wire cuts.
 
 ## [0.4.52] - 2026-09-09

--- a/crates/pcb-zen-core/tests/board.rs
+++ b/crates/pcb-zen-core/tests/board.rs
@@ -64,9 +64,18 @@ fn board_path_and_legacy_calls_register_the_same_project() {
 }
 
 #[test]
-fn board_rejects_missing_or_ambiguous_paths() {
+fn board_rejects_empty_missing_or_ambiguous_paths() {
     for (args, message) in [
-        (r#"name="Test""#, "Board() requires path"),
+        (
+            r#"name="Test", path="""#,
+            "Board() requires a non-empty path",
+        ),
+        (
+            r#"name="Test", layout_path="""#,
+            "Board() requires a non-empty path",
+        ),
+        (r#""Test", """#, "Board() requires a non-empty path"),
+        (r#"name="Test""#, "Board() requires a non-empty path"),
         (
             r#"name="Test", path="new", layout_path="old""#,
             "Board() accepts either path or layout_path, not both",

--- a/crates/pcb-zen-core/tests/board.rs
+++ b/crates/pcb-zen-core/tests/board.rs
@@ -1,0 +1,91 @@
+use crate::common;
+
+#[test]
+fn board_path_and_legacy_calls_register_the_same_project() {
+    for args in [
+        r#"name="Test", path="hardware", layers=2"#,
+        r#"name="Test", layout_path="hardware", layers=2"#,
+        r#""Test", "hardware", None, 2"#,
+    ] {
+        for schematic in [false, true] {
+            let source = format!(
+                "load(\"@stdlib/board_config.zen\", \"Board\")\nBoard({args}, schematic={})",
+                if schematic { "True" } else { "False" }
+            );
+            let result = common::eval_zen(vec![("test.zen".into(), source)]);
+            assert!(result.is_success(), "{args}: {:?}", result.diagnostics);
+            let output = result.output.unwrap();
+            let tree = output.module_tree();
+            let root = tree
+                .values()
+                .find(|module| module.path().is_root())
+                .unwrap();
+            let properties = root.properties();
+            assert_eq!(
+                properties
+                    .get("layout_path")
+                    .unwrap()
+                    .to_value()
+                    .unpack_str(),
+                Some("package://test/hardware")
+            );
+            assert_eq!(
+                properties
+                    .get("layout_name")
+                    .unwrap()
+                    .to_value()
+                    .unpack_str(),
+                Some("Test")
+            );
+            assert!(properties.contains_key("board_config.Test"));
+            if schematic {
+                assert_eq!(
+                    properties
+                        .get("schematic_path")
+                        .unwrap()
+                        .to_value()
+                        .unpack_str(),
+                    Some("package://test/hardware")
+                );
+                assert_eq!(
+                    properties
+                        .get("schematic_name")
+                        .unwrap()
+                        .to_value()
+                        .unpack_str(),
+                    Some("Test")
+                );
+            } else {
+                assert!(!properties.contains_key("schematic_path"));
+                assert!(!properties.contains_key("schematic_name"));
+            }
+        }
+    }
+}
+
+#[test]
+fn board_rejects_missing_or_ambiguous_paths() {
+    for (args, message) in [
+        (r#"name="Test""#, "Board() requires path"),
+        (
+            r#"name="Test", path="new", layout_path="old""#,
+            "Board() accepts either path or layout_path, not both",
+        ),
+        (
+            r#""Test", "new", layout_path="old""#,
+            "Board() accepts either path or layout_path, not both",
+        ),
+    ] {
+        let source = format!("load(\"@stdlib/board_config.zen\", \"Board\")\nBoard({args})");
+        let result = common::eval_zen(vec![("test.zen".into(), source)]);
+        assert!(!result.is_success(), "{args} should fail");
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.to_string().contains(message)),
+            "{:?}",
+            result.diagnostics
+        );
+    }
+}

--- a/crates/pcb-zen-core/tests/integration.rs
+++ b/crates/pcb-zen-core/tests/integration.rs
@@ -3,6 +3,7 @@ mod common;
 
 mod assert;
 mod binding;
+mod board;
 mod component;
 mod component_footprint_inference;
 mod cross_package_load;

--- a/crates/pcbc/src/templates/board_zen.jinja
+++ b/crates/pcbc/src/templates/board_zen.jinja
@@ -4,7 +4,7 @@
 
 Board(
     name = "{{ board }}",
-    path = "layout",
+    layout_path = "layout",
     layers = 4,
     schematic = True,
 )

--- a/crates/pcbc/src/templates/board_zen.jinja
+++ b/crates/pcbc/src/templates/board_zen.jinja
@@ -4,6 +4,7 @@
 
 Board(
     name = "{{ board }}",
-    layout_path = "layout",
+    path = "layout",
     layers = 4,
+    schematic = True,
 )

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -566,24 +566,24 @@ gnd = Ground("GND")
 LedIndicator(name="LED1", VCC=vcc, GND=gnd, color="green")
 LedIndicator(name="LED2", VCC=vcc, GND=gnd, color="red")
 
-Board(name="MainBoard", layers=4, layout_path="layout/MainBoard")
+Board(name="MainBoard", layers=4, path="layout/MainBoard", schematic=True)
 ```
 
 ## Utilities
 
 ### Board and layout
 
-`Board()` configures PCB manufacturing parameters — stackup, design rules, and layout path. It is a prelude symbol.
+`Board()` configures PCB manufacturing parameters and a KiCad project. It is a prelude symbol. Use `schematic=True` to enable persistent schematics alongside layout; `Board()` already calls `Project()`, so do not combine them.
 
 ```python
-Board(name="my_board", layers=4, layout_path="layout/my_board")
+Board(name="my_board", layers=4, path="layout/my_board", schematic=True)
 ```
 
-Key parameters: `name`, `layout_path`, `layers` (2/4/6/8/10), `config` (explicit `BoardConfig`), `outer_copper_weight` (`"1oz"` or `"2oz"`), `copper_finish` (default `"ENIG"`). An explicit stackup must contain an even number of copper layers.
+Key parameters: `name`, `path`, `schematic` (default `False`), `layers` (2/4/6/8/10), `config` (explicit `BoardConfig`), `outer_copper_weight` (`"1oz"` or `"2oz"`), `copper_finish` (default `"ENIG"`). `path` is required; the old `layout_path` keyword remains an alias, but passing both is an error. Positional calls remain compatible. An explicit stackup must contain an even number of copper layers.
 
 When `layers` is provided, `Board()` selects an appropriate default stackup, netclasses, and design rules. An explicit `config` is merged on top. See `@stdlib/board_config.zen` for `BoardConfig`, `Stackup`, `DesignRules`, `NetClass`, and preset stackups.
 
-`Layout()` defines reusable layout blocks for modules. When writing a module, use `Layout(name, path)` to associate a PCB layout with the subcircuit. See `@stdlib/properties.zen`.
+For registry modules needing layout or schematics, prefer `Project(name="ModuleName", path="layout")`. It enables both by default; set `layout=False` or `schematic=False` to disable either. `Layout()` is the layout-only shorthand. Paths are relative to the declaring `.zen` file. See `@stdlib/properties.zen`.
 
 **`Simulation(name, setup=None, modifiers=None)`** — Attach inline simulation setup and component modifiers to the current module.
 

--- a/docs/pages/spec.mdx
+++ b/docs/pages/spec.mdx
@@ -579,7 +579,7 @@ Board(name="MainBoard", layers=4, path="layout/MainBoard", schematic=True)
 Board(name="my_board", layers=4, path="layout/my_board", schematic=True)
 ```
 
-Key parameters: `name`, `path`, `schematic` (default `False`), `layers` (2/4/6/8/10), `config` (explicit `BoardConfig`), `outer_copper_weight` (`"1oz"` or `"2oz"`), `copper_finish` (default `"ENIG"`). `path` is required; the old `layout_path` keyword remains an alias, but passing both is an error. Positional calls remain compatible. An explicit stackup must contain an even number of copper layers.
+Key parameters: `name`, `path`, `schematic` (default `False`), `layers` (2/4/6/8/10), `config` (explicit `BoardConfig`), `outer_copper_weight` (`"1oz"` or `"2oz"`), `copper_finish` (default `"ENIG"`). A non-empty `path` is required; the old `layout_path` keyword remains an alias, but passing both is an error. Positional calls remain compatible. An explicit stackup must contain an even number of copper layers.
 
 When `layers` is provided, `Board()` selects an appropriate default stackup, netclasses, and design rules. An explicit `config` is merged on top. See `@stdlib/board_config.zen` for `BoardConfig`, `Stackup`, `DesignRules`, `NetClass`, and preset stackups.
 

--- a/lib/std/board_config.zen
+++ b/lib/std/board_config.zen
@@ -434,8 +434,8 @@ def Board(
         fail("Board() accepts either path or layout_path, not both")
     if path == None:
         path = layout_path
-    if path == None:
-        fail("Board() requires path (or the legacy layout_path alias)")
+    if not path:
+        fail("Board() requires a non-empty path (or the legacy layout_path alias)")
 
     # Validate input units
     if isinstance(outer_copper_weight, str):

--- a/lib/std/board_config.zen
+++ b/lib/std/board_config.zen
@@ -381,7 +381,7 @@ def DefaultBoardConfig(
 
 def Board(
     name: str,
-    layout_path: str,
+    path: str | None = None,
     config: BoardConfig | None = None,
     layers: int | None = None,
     outer_copper_weight: str | CopperWeight = "1oz",
@@ -392,12 +392,15 @@ def Board(
     default: bool = False,
     modifiers: list | None = None,
     schematic: bool = False,
+    *,
+    layout_path: str | None = None,
 ):
     """Define a PCB board with an optional board configuration.
 
     Args:
         name: Board configuration name
-        layout_path: Path to the board layout file (e.g., PCB file)
+        path: Path to the KiCad project, shared by layout and schematic
+        layout_path: Backward-compatible alias for path; do not pass both
         config: Optional BoardConfig overrides to merge with a layers-derived default.
                 If layers is not provided, this is used directly.
         layers: Number of PCB layers (2, 4, 6, 8, or 10). Optional helper for deriving a default BoardConfig.
@@ -426,6 +429,13 @@ def Board(
         - Custom track_widths and via_dimensions are appended to base configuration
         - All lists are deduplicated and sorted before use
     """
+
+    if path != None and layout_path != None:
+        fail("Board() accepts either path or layout_path, not both")
+    if path == None:
+        path = layout_path
+    if path == None:
+        fail("Board() requires path (or the legacy layout_path alias)")
 
     # Validate input units
     if isinstance(outer_copper_weight, str):
@@ -461,7 +471,7 @@ def Board(
     # Add the KiCad project to the module
     Project(
         name=name,
-        path=layout_path,
+        path=path,
         modifiers=modifiers,
         schematic=schematic,
     )


### PR DESCRIPTION
## Changes
- Prefer `Board(path=...)` for the shared KiCad project directory, retaining `layout_path` as a keyword alias and preserving existing positional arguments.
- Reject missing paths and calls supplying both keywords rather than silently overriding either.
- Enable persistent schematics in the new-board template and document `Board` versus `Project` usage.

## Verification
- `INSTA_UPDATE=no cargo test -p pcb-zen-core --test integration`: 237 passed, including new alias, positional compatibility, schematic on/off, and argument-conflict regression cases.
- `cargo fmt --all --check` and `pcb fmt lib/std/board_config.zen` passed.
- The rendered new-board template created its schematic under `layout/`; a second apply reported `schematic unchanged`.
- `cargo test -p pcbc --test integration apply::`: schematic repair passed; combined schematic/layout test failed because this orb lacks the KiCad Python `pcbnew` module. Reproducing the fixture directly confirmed `ModuleNotFoundError: No module named pcbnew`.
- No snapshots changed.

## Rollout
The Diode app template remains on the compatible `layout_path` keyword until a compiler release supports `path`. This PR is for review, not automatic merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible API surface with stricter validation; new-board schematics are enabled by default in the template only.
> 
> **Overview**
> **`Board()`** now takes a required non-empty **`path`** for the shared KiCad project directory (layout + optional schematic), with **`layout_path`** kept as a keyword-only alias and positional calls unchanged. Evaluation **fails** if the path is missing/empty or if **`path`** and **`layout_path`** are both set.
> 
> The **new-board Jinja template** turns on **`schematic=True`** (still uses **`layout_path`** where older toolchains need it). **Spec/changelog** document **`path`**, schematic behavior, and **`Project`** vs **`Layout`**. **Integration tests** cover alias/positional parity and the new validation errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aee62025ddab6866520534fe595bcae429c2d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->