### PR TITLE
ENG-1607: Preserve BOM matches when one line needs retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Prefer `Board(path=...)`, retaining `layout_path` as a compatibility alias and rejecting empty paths. New board templates enable persistent schematics while keeping `layout_path` for older compilers.
 - Speed up schematic connectivity analysis and repair planning with indexed terminal matching and verified batches of local wire cuts.
 
+### Fixed
+
+- Preserve successful BOM matches when another line needs retrying.
+
 ## [0.4.52] - 2026-09-09
 
 ### Added

--- a/crates/pcb-diode-api/src/bom.rs
+++ b/crates/pcb-diode-api/src/bom.rs
@@ -430,10 +430,6 @@ fn prepare_bom_match(
             seen_paths.insert(path.to_string()),
             "BOM match response returned duplicate path: {path}"
         );
-        anyhow::ensure!(
-            bom_line.match_status != BomMatchStatus::NeedsRetry,
-            "BOM matching could not complete"
-        );
 
         let mut resolved_offers = Vec::with_capacity(bom_line.offer_ids.len());
         for offer_id in &bom_line.offer_ids {
@@ -766,7 +762,13 @@ fn prepare_bom_match_with_cache(
     )
     .and_then(|response| {
         let prepared = prepare_bom_match(bom, &response)?;
-        if let Some(cache) = cache {
+        // Serve partial results, but let the next request retry incomplete matches.
+        if let Some(cache) = cache
+            && !response
+                .results
+                .iter()
+                .any(|line| line.match_status == BomMatchStatus::NeedsRetry)
+        {
             let value = serialize_completed_bom_match(&response, &request.paths)?;
             if let Err(error) = cache.store(&request.cache_key, &value) {
                 log::warn!("Failed to update local BOM cache: {error:#}");
@@ -1874,7 +1876,7 @@ mod tests {
     }
 
     #[test]
-    fn incomplete_response_is_neither_served_nor_cached() {
+    fn incomplete_response_is_served_but_not_cached() {
         let server = MockServer::start();
         let tempdir = tempfile::tempdir().unwrap();
         let cache = cache_for(&tempdir);
@@ -1898,21 +1900,26 @@ mod tests {
             then.status(200).json_body(initial_response);
         });
 
-        assert!(
-            match_bom_with_cache(
-                &context,
-                None,
-                &mut bom,
-                true,
-                match_options(BomMatchMode::Online),
-                Some(&cache),
-                now,
-            )
-            .is_err()
+        match_bom_with_cache(
+            &context,
+            None,
+            &mut bom,
+            true,
+            match_options(BomMatchMode::Online),
+            Some(&cache),
+            now,
+        )
+        .unwrap();
+        assert_eq!(bom.entries["root.U1"].mpn.as_deref(), Some("API-MPN"));
+        assert_eq!(
+            bom.availability["root.U1"].match_status,
+            Some(BomMatchStatus::Compatible)
         );
-        assert!(bom.entries["root.U1"].mpn.is_none());
         assert!(bom.entries["root.U2"].mpn.is_none());
-        assert!(bom.availability.is_empty());
+        assert_eq!(
+            bom.availability["root.U2"].match_status,
+            Some(BomMatchStatus::NeedsRetry)
+        );
 
         let mut offline = test_bom_with_distinct_second_line();
         match_bom_with_cache(


### PR DESCRIPTION
## Problem
A single MATCH_NEEDS_RETRY result caused the CLI to reject an otherwise valid BOM matching response. Without a usable cache, successful lines lost their availability and resolved MPNs too.

## Change
Treat retry results as line-level outcomes and preserve successful matches. Keep MATCH_NEEDS_RETRY distinct from a definitive MATCH_FAILED. Do not cache incomplete responses, so the next request can retry. Update the existing mixed success/retry regression test and changelog.

This addresses the whole-BOM failure in ENG-1607. The separate JLC nominal-value compatibility issue is not included.

## Verification
- cargo test -p pcb-diode-api bom::tests --lib: 20 passed
- cargo fmt --all -- --check: passed
- git diff --check origin/main...HEAD: passed
- Before the fix, reproduced the failure with the installed 0.4.51 binary and a local HTTP 200 mock containing one successful line and one retry line.

Issue: https://linear.app/diodeinc/issue/ENG-1607

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes BOM match and cache behavior for mixed API responses; incorrect caching could delay retries, but scope is limited to `pcb-diode-api` BOM matching.
> 
> **Overview**
> **BOM matching no longer fails the whole response when one line returns `MATCH_NEEDS_RETRY`.** Successful lines keep resolved MPNs and availability; retry lines stay marked `NeedsRetry` instead of being treated like a hard match failure.
> 
> **Caching:** Partial responses (any `NeedsRetry` line) are returned to the caller but **not** written to the local BOM cache, so a follow-up online request can retry incomplete lines without serving a stale “complete” cache entry.
> 
> Changelog and the mixed success/retry regression test were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fb01f7e616094a243ac268bcee8837889c70511. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->