### PR TITLE
Add mouse-bite tab placement analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add `--mouse-bite-placement` to `board-array create` to report where breakaway tabs would go on a board.
+
 ### Changed
 
 - Prefer `Board(path=...)`, retaining `layout_path` as a compatibility alias and rejecting empty paths. New board templates enable persistent schematics while keeping `layout_path` for older compilers.

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/eligibility.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/eligibility.rs
@@ -7,7 +7,7 @@ use ipc2581::{
 use pcb_ir::{
     dialects::ipc::{ArtworkScope, LayoutStepKind, ProfileSet, profile_occurrences_for},
     geom::{
-        ContourBuf, ContourSet, FillRule, PathCmd, PathOp, Resolution, Segment,
+        BBox, ContourBuf, ContourSet, FillRule, PathCmd, PathOp, Resolution, Segment,
         attachment::{
             QueryTolerance,
             outline::{OutlineFootprint, OutlineObstacle, eligible_outline},
@@ -18,9 +18,16 @@ use pcb_ir::{
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 
-struct Evidence {
-    id: String,
-    region: Option<ContourSet>,
+pub(super) struct Evidence {
+    pub id: String,
+    pub region: Option<ContourSet>,
+}
+
+pub(super) struct Prepared {
+    pub report: Value,
+    pub substrate: ContourSet,
+    pub evidence: Vec<Evidence>,
+    pub intervals: Vec<pcb_ir::geom::attachment::outline::OutlineInterval>,
 }
 
 struct CourtyardGroup {
@@ -41,6 +48,16 @@ pub fn analyze(
     exclusions: &[OutlineObstacle<'_>],
     resolution: Resolution,
 ) -> Result<Value> {
+    Ok(prepare(xml, footprint, clearance_mm, exclusions, resolution)?.report)
+}
+
+pub(super) fn prepare(
+    xml: &str,
+    footprint: OutlineFootprint,
+    clearance_mm: f64,
+    exclusions: &[OutlineObstacle<'_>],
+    resolution: Resolution,
+) -> Result<Prepared> {
     if !clearance_mm.is_finite() || clearance_mm < 0.0 {
         bail!("clearance must be finite and nonnegative");
     }
@@ -84,7 +101,7 @@ pub fn analyze(
         }
         substrate = substrate.union(&region)?;
     }
-    let mut evidence = courtyard_evidence(&imported, resolution)?;
+    let (mut evidence, ignored_footprints) = courtyard_evidence(&imported, resolution)?;
     evidence.extend(exclusions.iter().map(|exclusion| Evidence {
         id: format!("explicit:{}", exclusion.id),
         region: exclusion.region.cloned(),
@@ -106,13 +123,15 @@ pub fn analyze(
         numerical_mm: pcb_ir::geom::tol::EPSILON_MM,
     };
     let intervals = eligible_outline(&substrate, &obstacles, footprint, tolerance)?;
-    Ok(json!({
+    let report = json!({
         "phase": "outline-eligibility-only",
         "manufacturing_ready": false,
         "scope": "canonical-board",
         "source_xml_sha256": hex::encode(Sha256::digest(xml.as_bytes())),
         "units": "mm",
+        "ignored_footprints": ignored_footprints,
         "policy": {
+            "missing_courtyard": "ignore-footprint",
             "width_mm": footprint.width_mm, "inward_mm": footprint.inward_mm,
             "outward_mm": footprint.outward_mm, "clearance_mm": clearance_mm,
             "accuracy_mm": resolution.accuracy.max_error_mm(),
@@ -122,7 +141,7 @@ pub fn analyze(
         "limitations": [
             "Eligible means clear only of supplied courtyard/exclusion evidence on the prepared polygon model; interval endpoints carry no guarantee.",
             "Closed courtyard contours are filled conservatively, regardless of outline ink styling. Both board sides are included without additional mirroring.",
-            "Missing applicable component courtyard evidence is Unknown. No body-free classifications or fallback envelopes are inferred.",
+            "Footprints without courtyard evidence contribute no obstruction and are listed in ignored_footprints. Clearance is conditional on supplied courtyards being complete; ignored physical components may overhang. Present but unusable courtyards are errors.",
             "General keep-out export coverage is not established. No copper, pad, drill, stackup or 3D collision checks are performed.",
             "No tabs, perforations, frame connections, router access, mechanics or panel export are generated."
         ],
@@ -136,10 +155,19 @@ pub fn analyze(
             "obstacles": i.obstacles.iter().map(|&index| &evidence[index].id).collect::<Vec<_>>(),
             "uncertainty_mm": i.uncertainty_mm,
         })).collect::<Vec<_>>(),
-    }))
+    });
+    Ok(Prepared {
+        report,
+        substrate,
+        evidence,
+        intervals,
+    })
 }
 
-fn courtyard_evidence(imported: &ImportedDesign, resolution: Resolution) -> Result<Vec<Evidence>> {
+fn courtyard_evidence(
+    imported: &ImportedDesign,
+    resolution: Resolution,
+) -> Result<(Vec<Evidence>, Vec<String>)> {
     let mut evidence = Vec::new();
     let mut covered = Vec::new();
     for (index, layer) in imported
@@ -195,9 +223,18 @@ fn courtyard_evidence(imported: &ImportedDesign, resolution: Resolution) -> Resu
             } else {
                 None
             };
-            if region.as_ref().is_some_and(|r| !r.is_empty()) {
-                covered.push((group.component, layer.side));
+            if !region.as_ref().is_some_and(|r| !r.is_empty()) {
+                bail!(
+                    "unusable courtyard on {} for {} ({})",
+                    imported.resolve(layer.name),
+                    group
+                        .component
+                        .map(|c| imported.resolve(c))
+                        .unwrap_or("unassociated"),
+                    group.sources.join(",")
+                );
             }
+            covered.push(group.component);
             evidence.push(Evidence {
                 id: format!(
                     "courtyard:{}:{}:{}",
@@ -212,34 +249,24 @@ fn courtyard_evidence(imported: &ImportedDesign, resolution: Resolution) -> Resu
             });
         }
     }
+    let mut ignored = Vec::new();
     for occurrence in imported.component_occurrences(ArtworkScope::Board)? {
         let component = imported
             .component_definition(occurrence.id.component)
             .unwrap();
-        let side = imported
-            .layer_definitions
-            .iter()
-            .find(|l| l.name == component.source.layer_ref)
-            .and_then(|l| l.side);
-        if component.source.ref_des.is_none()
-            || side.is_none()
-            || !covered.contains(&(component.source.ref_des, side))
-        {
-            evidence.push(Evidence {
-                id: format!(
-                    "missing-courtyard:{}:component-{}",
-                    component
-                        .source
-                        .ref_des
-                        .map(|r| imported.resolve(r))
-                        .unwrap_or("unnamed"),
-                    occurrence.id.component.0
-                ),
-                region: None,
-            });
+        if component.source.ref_des.is_none() || !covered.contains(&component.source.ref_des) {
+            ignored.push(format!(
+                "{}:component-{}",
+                component
+                    .source
+                    .ref_des
+                    .map(|r| imported.resolve(r))
+                    .unwrap_or("unnamed"),
+                occurrence.id.component.0
+            ));
         }
     }
-    Ok(evidence)
+    Ok((evidence, ignored))
 }
 
 // Import is intentionally permissive and may discard unresolved references,
@@ -359,71 +386,92 @@ fn courtyard_region(contours: &[ContourBuf], resolution: Resolution) -> Result<O
             segments.extend(contour.segments());
         }
     }
-    // A degree other than two means a gap, branch or duplicated segment.
-    if segments.iter().any(|s| {
-        [s.start(), s.end()].iter().any(|p| {
-            segments
-                .iter()
-                .map(|s| usize::from(s.start() == *p) + usize::from(s.end() == *p))
-                .sum::<usize>()
-                != 2
-        })
-    }) {
-        return Ok(None);
-    }
+    let mut open_components = Vec::new();
     while let Some(first) = segments.pop() {
-        let start = first.start();
-        let mut end = first.end();
-        let mut cmds = vec![PathCmd::move_to(start), segment_command(first, false)];
-        while end != start {
-            let Some(index) = segments
-                .iter()
-                .position(|s| s.start() == end || s.end() == end)
-            else {
-                return Ok(None);
-            };
-            let segment = segments.remove(index);
-            let reverse = segment.end() == end;
-            end = if reverse {
-                segment.start()
-            } else {
-                segment.end()
-            };
-            cmds.push(segment_command(segment, reverse));
+        let mut component = vec![first];
+        let mut index = 0;
+        while index < component.len() {
+            let endpoints = [component[index].start(), component[index].end()];
+            let mut candidate = 0;
+            while candidate < segments.len() {
+                if endpoints.contains(&segments[candidate].start())
+                    || endpoints.contains(&segments[candidate].end())
+                {
+                    component.push(segments.remove(candidate));
+                } else {
+                    candidate += 1;
+                }
+            }
+            index += 1;
         }
-        cmds.push(PathCmd::close());
-        loops.push(ContourBuf::new(cmds).with_uncertainty(uncertainty));
+        let closed = component.iter().all(|segment| {
+            [segment.start(), segment.end()].iter().all(|point| {
+                component
+                    .iter()
+                    .map(|other| {
+                        usize::from(other.start() == *point) + usize::from(other.end() == *point)
+                    })
+                    .sum::<usize>()
+                    == 2
+            })
+        });
+        if closed {
+            loops.push(closed_component(component, uncertainty)?);
+        } else {
+            open_components.push(component);
+        }
     }
     if loops.is_empty() {
         return Ok(None);
     }
-    Ok(Some(ContourSet::from_filled_contours(&loops, resolution)?))
-}
-
-fn segment_command(segment: Segment, reverse: bool) -> PathCmd {
-    let end = if reverse {
-        segment.start()
-    } else {
-        segment.end()
-    };
-    match segment {
-        Segment::Line { .. } => PathCmd::line_to(end),
-        Segment::Arc(arc) => PathCmd::arc_to(end, arc.center, arc.clockwise ^ reverse),
-        Segment::Ellipse(arc) => PathCmd::ellipse_to(
-            end,
-            arc.center,
-            arc.x_axis,
-            arc.y_axis,
-            arc.clockwise ^ reverse,
-        ),
-        Segment::Cubic { c1, c2, .. } => {
-            if reverse {
-                PathCmd::cubic_to(c2, c1, end)
-            } else {
-                PathCmd::cubic_to(c1, c2, end)
-            }
+    let region = ContourSet::from_filled_contours(&loops, resolution)?;
+    // An open component is harmless only when its entire conservative bounds
+    // fit strictly inside the enclosure. Segment bboxes include curve extrema
+    // (cubic control bounds are conservative); source and prepared-boundary
+    // uncertainty plus the requested preparation error expand the proof
+    // rectangle. This is not gap snapping: expansion can only reject evidence,
+    // makes boundary contact fail, and gives axial lines a nonzero area that
+    // survives the region representation.
+    for component in open_components {
+        let guard = uncertainty + region.uncertainty_mm + resolution.accuracy.max_error_mm();
+        let bbox = component
+            .iter()
+            .fold(BBox::empty(), |bbox, segment| bbox.union(segment.bbox()))
+            .expand(guard);
+        if !bbox.is_valid()
+            || bbox.width() <= 0.0
+            || bbox.height() <= 0.0
+            || !ContourSet::rectangle(bbox, resolution)
+                .difference(&region)?
+                .is_empty()
+        {
+            return Ok(None);
         }
     }
+    Ok(Some(region))
+}
+
+fn closed_component(mut segments: Vec<Segment>, uncertainty: f64) -> Result<ContourBuf> {
+    let first = segments.pop().context("empty closed courtyard component")?;
+    let start = first.start();
+    let mut end = first.end();
+    let mut cmds = vec![PathCmd::move_to(start), first.to_path_cmd(false)];
+    while end != start {
+        let index = segments
+            .iter()
+            .position(|segment| segment.start() == end || segment.end() == end)
+            .context("disconnected closed courtyard component")?;
+        let segment = segments.remove(index);
+        let reverse = segment.end() == end;
+        end = if reverse {
+            segment.start()
+        } else {
+            segment.end()
+        };
+        cmds.push(segment.to_path_cmd(reverse));
+    }
+    cmds.push(PathCmd::close());
+    Ok(ContourBuf::new(cmds).with_uncertainty(uncertainty))
 }
 
 #[cfg(feature = "cli")]
@@ -558,7 +606,7 @@ mod tests {
     }
 
     #[test]
-    fn fragmented_courtyard_joins_by_component_but_gaps_remain_unknown() {
+    fn fragmented_courtyard_joins_by_component_but_gaps_are_errors() {
         let xml = fixture();
         let start = xml.find("<LayerFeature layerRef=\"F.Courtyard\">").unwrap();
         let end = start + xml[start..].find("</LayerFeature>").unwrap();
@@ -575,24 +623,107 @@ mod tests {
             );
             let imported =
                 import_design(&Ipc2581::parse(&xml).unwrap(), Resolution::default()).unwrap();
-            let evidence = courtyard_evidence(&imported, Resolution::default()).unwrap();
-            let top = &evidence[0];
-            if count == 4 {
+            let result = courtyard_evidence(&imported, Resolution::default());
+            if count == 3 {
                 assert!(
-                    top.region
-                        .as_ref()
+                    result
+                        .err()
                         .unwrap()
-                        .prepare_query()
-                        .signed_distance(Point::new(7.0, 3.0))
-                        .unwrap()
-                        .mm
-                        < -0.9
+                        .to_string()
+                        .contains("unusable courtyard")
                 );
-                assert_eq!(top.id.matches("feature-").count(), 4);
-            } else {
-                assert!(top.region.is_none());
+                continue;
             }
+            let (evidence, _) = result.unwrap();
+            let top = &evidence[0];
+            assert!(
+                top.region
+                    .as_ref()
+                    .unwrap()
+                    .prepare_query()
+                    .signed_distance(Point::new(7.0, 3.0))
+                    .unwrap()
+                    .mm
+                    < -0.9
+            );
+            assert_eq!(top.id.matches("feature-").count(), 4);
         }
+    }
+
+    fn fragmented_rectangle_with(extra: Vec<ContourBuf>) -> Vec<ContourBuf> {
+        let point = |x, y| Point::new(x, y);
+        let mut contours = [
+            (point(0.0, 0.0), point(10.0, 0.0)),
+            (point(10.0, 0.0), point(10.0, 6.0)),
+            (point(10.0, 6.0), point(0.0, 6.0)),
+            (point(0.0, 6.0), point(0.0, 0.0)),
+        ]
+        .into_iter()
+        .map(|(start, end)| ContourBuf::new(vec![PathCmd::move_to(start), PathCmd::line_to(end)]))
+        .collect::<Vec<_>>();
+        contours.extend(extra);
+        contours
+    }
+
+    fn open_line(start: Point, end: Point) -> ContourBuf {
+        ContourBuf::new(vec![PathCmd::move_to(start), PathCmd::line_to(end)])
+    }
+
+    #[test]
+    fn fragmented_enclosure_allows_only_fully_enclosed_open_components() {
+        let center_marks = vec![
+            open_line(Point::new(4.0, 2.0), Point::new(6.0, 2.0)),
+            open_line(Point::new(5.0, 1.0), Point::new(5.0, 3.0)),
+        ];
+        let expected = courtyard_region(
+            &fragmented_rectangle_with(Vec::new()),
+            Resolution::default(),
+        )
+        .unwrap()
+        .unwrap();
+        let accepted = courtyard_region(
+            &fragmented_rectangle_with(center_marks),
+            Resolution::default(),
+        )
+        .unwrap()
+        .unwrap();
+        assert!(accepted.difference(&expected).unwrap().is_empty());
+        assert!(expected.difference(&accepted).unwrap().is_empty());
+
+        for y in [6.0, 7.0] {
+            let outside = open_line(Point::new(4.0, y), Point::new(6.0, y));
+            assert!(
+                courtyard_region(
+                    &fragmented_rectangle_with(vec![outside]),
+                    Resolution::default()
+                )
+                .unwrap()
+                .is_none()
+            );
+        }
+    }
+
+    #[test]
+    fn open_only_and_curves_bulging_outside_are_rejected() {
+        assert!(
+            courtyard_region(
+                &[open_line(Point::new(1.0, 1.0), Point::new(2.0, 1.0))],
+                Resolution::default()
+            )
+            .unwrap()
+            .is_none()
+        );
+
+        // Both endpoints are inside, but the upper semicircle reaches y=7.
+        let arc = ContourBuf::new(vec![
+            PathCmd::move_to(Point::new(1.0, 3.0)),
+            PathCmd::arc_to(Point::new(9.0, 3.0), Point::new(5.0, 3.0), false),
+        ]);
+        assert!(
+            courtyard_region(&fragmented_rectangle_with(vec![arc]), Resolution::default())
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -633,7 +764,8 @@ mod tests {
     fn courtyard_occurrences_fill_hollow_envelopes_on_both_sides() {
         let ipc = Ipc2581::parse(&fixture()).unwrap();
         let imported = import_design(&ipc, Resolution::default()).unwrap();
-        let evidence = courtyard_evidence(&imported, Resolution::default()).unwrap();
+        let (evidence, ignored) = courtyard_evidence(&imported, Resolution::default()).unwrap();
+        assert!(ignored.is_empty());
         assert_eq!(
             evidence.len(),
             2,
@@ -722,22 +854,33 @@ mod tests {
     }
 
     #[test]
-    fn missing_applicable_courtyard_is_unknown_even_with_opposite_side_evidence() {
+    fn absent_courtyard_is_disclosed_without_poisoning_supplied_evidence() {
         let xml = fixture().replace(
-            "layerRef=\"BOTTOM\" mountType",
-            "layerRef=\"TOP\" mountType",
+            "<Component refDes=\"U2\"",
+            "<Component refDes=\"NO_COURTYARD\"",
         );
         let report = analyze(&xml, footprint(), 0.0, &[], Resolution::default()).unwrap();
-        let intervals = report["intervals"].as_array().unwrap();
-        assert!(intervals.iter().any(|i| i["state"] == "Unknown"));
-        assert!(!intervals.iter().any(|i| i["state"] == "Eligible"));
-        assert!(report["evidence"].as_array().unwrap().iter().any(|e| {
-            e["id"]
-                .as_str()
+        let original = analyze(&fixture(), footprint(), 0.0, &[], Resolution::default()).unwrap();
+        assert_eq!(report["intervals"], original["intervals"]);
+        assert_eq!(
+            report["ignored_footprints"],
+            json!(["NO_COURTYARD:component-1"])
+        );
+        assert_eq!(report["policy"]["missing_courtyard"], "ignore-footprint");
+        assert!(
+            report["intervals"]
+                .as_array()
                 .unwrap()
-                .starts_with("missing-courtyard:U2")
-                && e["available"] == false
-        }));
+                .iter()
+                .any(|i| i["state"] == "Eligible")
+        );
+        assert!(
+            report["intervals"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|i| i["state"] == "Blocked")
+        );
     }
 
     #[test]

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/eligibility.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/eligibility.rs
@@ -25,6 +25,8 @@ pub(super) struct Evidence {
 
 pub(super) struct Prepared {
     pub report: Value,
+    /// Overall stackup thickness, when the source states one.
+    pub thickness_mm: Option<f64>,
     pub substrate: ContourSet,
     pub evidence: Vec<Evidence>,
     pub intervals: Vec<pcb_ir::geom::attachment::outline::OutlineInterval>,
@@ -63,6 +65,10 @@ pub(super) fn prepare(
     }
     let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
     validate_courtyard_references(&ipc)?;
+    let thickness_mm = crate::accessors::IpcAccessor::new(&ipc)
+        .stackup_details()
+        .and_then(|stackup| stackup.overall_thickness_mm)
+        .filter(|t| t.is_finite() && *t > 0.0);
     // Keep small substrate cutouts and courtyard regions; accuracy remains the
     // caller's existing geometry budget (--accuracy-um in the CLI).
     let resolution = resolution.strict();
@@ -158,6 +164,7 @@ pub(super) fn prepare(
     });
     Ok(Prepared {
         report,
+        thickness_mm,
         substrate,
         evidence,
         intervals,

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 pub mod eligibility;
+pub mod placement;
 
 use super::board_array_auto::{
     AutoBoardArrayPlan, AutoSheetSize, TargetSizeMm, auto_board_array_plan,

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
@@ -1,0 +1,414 @@
+//! Where mouse-bite tabs go on one canonical board: candidate sites along the
+//! Eligible outline, then the fewest tabs that hold the board rigidly.
+//! Analysis only: no tab geometry, routing, frame, or panel export.
+//!
+//! The panel is assumed to route a slot of `routing_gap_mm` that follows the
+//! board outline, with frame material beyond it. A candidate is a straight
+//! strip of the tab width from the outline across the slot into that frame.
+
+pub mod select;
+
+use anyhow::Result;
+use pcb_ir::geom::{
+    ContourSet, FillRule, Point, Resolution,
+    attachment::{
+        BoundaryId, BoundaryQuery, QueryTolerance,
+        outline::{OutlineFootprint, OutlineState},
+    },
+    region::{ring_edges, ring_signed_area},
+};
+use serde_json::{Value, json};
+
+use super::eligibility::{self, Prepared};
+use pcb_ir::geom::mouse_bite::SparkFunShallow;
+use select::{Laminate, Model, Process, Rail, Site, TabBeam};
+
+/// Opinionated placement preset, in millimeters and newtons. Not user knobs.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct Preset {
+    /// Tab width along the outline, neck plus router shoulders.
+    pub tab_width_mm: f64,
+    /// How far the perforations reach into the board.
+    pub inward_mm: f64,
+    /// Growth applied to courtyards before they count as obstacles.
+    pub courtyard_clearance_mm: f64,
+    /// Routed slot between the board outline and the frame.
+    pub routing_gap_mm: f64,
+    /// Frame material a tab must reach beyond the slot.
+    pub frame_landing_mm: f64,
+    /// Candidate spacing along usable outline runs.
+    pub candidate_pitch_mm: f64,
+    /// Outline may turn at most this much within the tab's own width.
+    pub tab_bend_degrees: f64,
+    /// Outline may turn at most this much within the tab plus the keep-out on
+    /// either side, which keeps tabs clear of corners without excluding round
+    /// boards.
+    pub corner_bend_degrees: f64,
+    pub corner_keepout_mm: f64,
+    /// Closest two tabs may sit.
+    pub min_separation_mm: f64,
+    /// Spacing of the outline points the load may act at.
+    pub load_point_spacing_mm: f64,
+    /// Assumed when the source states no stackup thickness.
+    pub default_thickness_mm: f64,
+    pub laminate: Laminate,
+    pub tab: TabBeam,
+    pub rail: Rail,
+    pub process: Process,
+}
+
+pub const PRESET: Preset = Preset {
+    tab_width_mm: SparkFunShallow::NECK_WIDTH_MM + 2.0 * SparkFunShallow::CUTTER_RADIUS_MM,
+    inward_mm: 0.2,
+    courtyard_clearance_mm: 0.0,
+    routing_gap_mm: 2.0,
+    frame_landing_mm: 1.0,
+    candidate_pitch_mm: 2.5,
+    tab_bend_degrees: 15.0,
+    corner_bend_degrees: 60.0,
+    corner_keepout_mm: 5.0,
+    min_separation_mm: 10.0,
+    load_point_spacing_mm: 2.0,
+    default_thickness_mm: 1.6,
+    // Typical rigid FR-4, in-plane; the laminate is treated as isotropic.
+    laminate: Laminate {
+        youngs_modulus: 22_000.0,
+        shear_modulus: 4_500.0,
+        poisson_ratio: 0.13,
+    },
+    // The neck spans the routing gap; perforation halves its section.
+    tab: TabBeam {
+        width_mm: SparkFunShallow::NECK_WIDTH_MM,
+        length_mm: 2.0,
+        perforation_factor: 0.5,
+    },
+    // Two default 5 mm board margins minus a slot on each side.
+    rail: Rail { width_mm: 6.0 },
+    // A finger or placement nozzle anywhere on the board, and the sag that
+    // still leaves the surface flat enough for placement.
+    process: Process {
+        load_n: 5.0,
+        deflection_limit_mm: 0.25,
+    },
+};
+
+impl Preset {
+    /// The band checked for obstacles: the tab from its perforations to its
+    /// frame landing.
+    pub fn footprint(&self) -> OutlineFootprint {
+        OutlineFootprint {
+            width_mm: self.tab_width_mm,
+            inward_mm: self.inward_mm,
+            outward_mm: self.routing_gap_mm + self.frame_landing_mm,
+        }
+    }
+
+    /// Cross rails sit one board span apart, so the rail a tab lands on is
+    /// held that far apart at worst.
+    pub fn model(&self, thickness_mm: f64, board_span_mm: f64) -> Model {
+        Model::new(
+            thickness_mm,
+            board_span_mm,
+            self.laminate,
+            self.tab,
+            self.rail,
+            self.process,
+            self.min_separation_mm,
+        )
+    }
+}
+
+/// Analyze one canonical board: eligibility plus tab placement.
+pub fn analyze(xml: &str, preset: &Preset, resolution: Resolution) -> Result<Value> {
+    let prepared = eligibility::prepare(
+        xml,
+        preset.footprint(),
+        preset.courtyard_clearance_mm,
+        &[],
+        resolution,
+    )?;
+    let mut report = prepared.report.clone();
+    report["phase"] = json!("tab-placement-only");
+    report["placement"] = place(&prepared, preset, resolution.strict())?;
+    Ok(report)
+}
+
+struct Candidate {
+    ring: usize,
+    station_mm: f64,
+    site: Site,
+}
+
+fn place(prepared: &Prepared, preset: &Preset, resolution: Resolution) -> Result<Value> {
+    let substrate = &prepared.substrate;
+    let tolerance = QueryTolerance {
+        boundary_mm: 0.0,
+        numerical_mm: pcb_ir::geom::tol::EPSILON_MM,
+    };
+    let boundary = BoundaryQuery::new(substrate, tolerance)?;
+    let reach = preset.routing_gap_mm + preset.frame_landing_mm;
+    // Frame material beyond an outline-following slot, locally to this board.
+    let frame = ContourSet::rectangle(substrate.bbox().expand(reach + 1.0), resolution)
+        .difference(&substrate.disk_dilate(preset.routing_gap_mm)?)?;
+
+    let mut candidates = Vec::new();
+    let mut rejected = Vec::new();
+    for id in boundary.boundaries() {
+        let ring = &substrate.rings[id.ring];
+        if ring_signed_area(ring) <= 0.0 {
+            continue; // holes cannot reach the frame
+        }
+        let perimeter = boundary.perimeter(id)?;
+        let turns = turning_angles(ring);
+        let half = preset.tab_width_mm / 2.0;
+        for (lo, hi) in eligible_runs(&prepared.intervals, id, perimeter) {
+            let length = hi - lo;
+            let bins = (length / preset.candidate_pitch_mm).ceil().max(1.0) as usize;
+            for k in 0..bins {
+                let station_mm = (lo + length * (k as f64 + 0.5) / bins as f64) % perimeter;
+                let site = boundary.site(id, station_mm)?;
+                let tab_bend = bend_within(&turns, perimeter, station_mm, half);
+                let corner_bend = bend_within(
+                    &turns,
+                    perimeter,
+                    station_mm,
+                    half + preset.corner_keepout_mm,
+                );
+                if tab_bend > preset.tab_bend_degrees || corner_bend > preset.corner_bend_degrees {
+                    let p = site.point;
+                    rejected.push(json!({
+                        "ring": id.ring, "station_mm": station_mm, "point": [p.x, p.y],
+                        "reason": if tab_bend > preset.tab_bend_degrees {
+                            format!("outline turns {tab_bend:.0}° within the tab")
+                        } else {
+                            format!("outline turns {corner_bend:.0}° within the corner keep-out")
+                        },
+                    }));
+                    continue;
+                }
+                let (p, t, n) = (site.point, site.tangent, site.outward_normal);
+                let width = preset.tab_width_mm;
+                let across = strip(p, t, n, width, 0.0, preset.routing_gap_mm, resolution)?;
+                let landing = strip(p, t, n, width, preset.routing_gap_mm, reach, resolution)?;
+                let reason = if across.intersection(substrate)?.area() > 0.0 {
+                    Some("tab crosses back into the board")
+                } else if !landing.difference(&frame)?.is_empty() {
+                    Some("no frame material beyond the slot")
+                } else {
+                    None
+                };
+                match reason {
+                    Some(reason) => rejected.push(json!({
+                        "ring": id.ring, "station_mm": station_mm, "point": [p.x, p.y], "reason": reason,
+                    })),
+                    None => candidates.push(Candidate {
+                        ring: id.ring,
+                        station_mm,
+                        site: Site {
+                            point: p,
+                            outward_normal: n,
+                        },
+                    }),
+                }
+            }
+        }
+    }
+
+    let loads = outline_samples(substrate, preset.load_point_spacing_mm);
+    let bbox = substrate.bbox();
+    let thickness_mm = prepared.thickness_mm.unwrap_or(preset.default_thickness_mm);
+    let model = preset.model(thickness_mm, bbox.width().max(bbox.height()));
+    let sites: Vec<_> = candidates.iter().map(|c| c.site).collect();
+    let selection = select::select(&sites, &loads, &model);
+    let rings = |region: &ContourSet| {
+        region
+            .rings
+            .iter()
+            .map(|ring| ring.iter().map(|p| json!([p[0], p[1]])).collect::<Vec<_>>())
+            .collect::<Vec<_>>()
+    };
+    Ok(json!({
+        "preset": preset,
+        "model": model,
+        "thickness_source": if prepared.thickness_mm.is_some() { "stackup" } else { "default" },
+        "board": {"bbox": [bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y]},
+        "substrate": rings(substrate),
+        "frame": rings(&frame),
+        "obstacles": prepared.evidence.iter().filter_map(|e| {
+            e.region.as_ref().map(|r| json!({"id": e.id, "rings": rings(r)}))
+        }).collect::<Vec<_>>(),
+        "candidates": candidates.iter().enumerate().map(|(i, c)| json!({
+            "id": i, "ring": c.ring, "station_mm": c.station_mm,
+            "point": [c.site.point.x, c.site.point.y],
+            "normal": [c.site.outward_normal.x, c.site.outward_normal.y],
+        })).collect::<Vec<_>>(),
+        "rejected": rejected,
+        "selected": selection.chosen,
+        "tab_count": selection.chosen.len(),
+        "deflection_mm": selection.deflection_mm.is_finite().then_some(selection.deflection_mm),
+        "worst_point": selection.worst_point.map(|j| [loads[j].x, loads[j].y]),
+        "satisfied": selection.satisfied(),
+        "violations": selection.violations.iter().map(ToString::to_string).collect::<Vec<_>>(),
+    }))
+}
+
+/// Contiguous Eligible arclength runs on one ring, joined across the seam.
+/// A run through the seam is returned with `hi` beyond the perimeter.
+fn eligible_runs(
+    intervals: &[pcb_ir::geom::attachment::outline::OutlineInterval],
+    id: BoundaryId,
+    perimeter: f64,
+) -> Vec<(f64, f64)> {
+    let mut runs: Vec<(f64, f64)> = Vec::new();
+    for interval in intervals
+        .iter()
+        .filter(|i| i.boundary == id && i.state == OutlineState::Eligible)
+    {
+        match runs.last_mut() {
+            Some(last) if last.1 == interval.start_mm => last.1 = interval.end_mm,
+            _ => runs.push((interval.start_mm, interval.end_mm)),
+        }
+    }
+    if runs.len() > 1 && runs[0].0 == 0.0 && runs.last().unwrap().1 == perimeter {
+        let first = runs.remove(0);
+        runs.last_mut().unwrap().1 = perimeter + first.1;
+    }
+    runs
+}
+
+/// Unsigned turning angle at each vertex, in degrees, with the vertex's
+/// station. Flattened arcs turn a little at many vertices; corners a lot at one.
+fn turning_angles(ring: &Vec<[f64; 2]>) -> Vec<(f64, f64)> {
+    let edges: Vec<(Point, Point)> = ring_edges(ring).collect();
+    let mut station = 0.0;
+    let mut turns = Vec::with_capacity(edges.len());
+    for (i, (a, b)) in edges.iter().enumerate() {
+        let (prev_a, prev_b) = edges[(i + edges.len() - 1) % edges.len()];
+        let incoming = prev_b - prev_a;
+        let outgoing = *b - *a;
+        let angle = (incoming.x * outgoing.y - incoming.y * outgoing.x)
+            .atan2(incoming.x * outgoing.x + incoming.y * outgoing.y)
+            .abs()
+            .to_degrees();
+        turns.push((station, angle));
+        station += a.distance_to(*b);
+    }
+    turns
+}
+
+/// Total turning strictly within `half` of `station` along the cyclic ring.
+fn bend_within(turns: &[(f64, f64)], perimeter: f64, station: f64, half: f64) -> f64 {
+    turns
+        .iter()
+        .filter(|(s, _)| {
+            let d = (s - station).rem_euclid(perimeter);
+            d.min(perimeter - d) < half
+        })
+        .map(|(_, angle)| angle)
+        .sum()
+}
+
+/// Rectangle of `width` across the tangent, spanning `lo..hi` along the normal.
+fn strip(
+    p: Point,
+    tangent: Point,
+    normal: Point,
+    width: f64,
+    lo: f64,
+    hi: f64,
+    resolution: Resolution,
+) -> Result<ContourSet> {
+    let corners = [
+        p - tangent * (width / 2.0) + normal * lo,
+        p + tangent * (width / 2.0) + normal * lo,
+        p + tangent * (width / 2.0) + normal * hi,
+        p - tangent * (width / 2.0) + normal * hi,
+    ];
+    Ok(ContourSet::from_rings(
+        vec![corners.map(|c| [c.x, c.y]).to_vec()],
+        FillRule::EvenOdd,
+        resolution,
+    )?)
+}
+
+/// Points every `spacing` of arclength along the outer rings. Loads act
+/// here; the rigid response is convex, so the outline is the worst case.
+fn outline_samples(region: &ContourSet, spacing: f64) -> Vec<Point> {
+    let mut samples = Vec::new();
+    for ring in region.rings.iter().filter(|r| ring_signed_area(r) > 0.0) {
+        let mut next = 0.0;
+        let mut station = 0.0;
+        for (a, b) in ring_edges(ring) {
+            let length = a.distance_to(b);
+            while next < station + length {
+                samples.push(a + (b - a) * ((next - station) / length));
+                next += spacing;
+            }
+            station += length;
+        }
+    }
+    samples
+}
+
+#[cfg(feature = "cli")]
+pub fn execute(
+    input: &std::path::Path,
+    output: &std::path::Path,
+    resolution: Resolution,
+) -> Result<()> {
+    let xml = crate::utils::file::load_ipc_file(input)?;
+    let report = analyze(&xml, &PRESET, resolution)?;
+    let mut json = serde_json::to_vec_pretty(&report)?;
+    json.push(b'\n');
+    if output.as_os_str() == "-" {
+        pcb_ui::write_stdout(|stdout| stdout.write_all(&json))?;
+    } else {
+        std::fs::write(output, json)?;
+    }
+    anstream::eprintln!("Tab placement analysis only; no mouse-bite panel generated.");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bends_distinguish_corners_from_gentle_arcs() {
+        // A 40 x 10 rectangle whose top-right corner is a 12-vertex arc of
+        // radius 4, plus a collinear split on the bottom edge.
+        let mut ring = vec![[0.0, 0.0], [15.0, 0.0], [40.0, 0.0], [40.0, 6.0]];
+        for k in 1..12 {
+            let a = std::f64::consts::FRAC_PI_2 * k as f64 / 12.0;
+            ring.push([36.0 + 4.0 * a.cos(), 6.0 + 4.0 * a.sin()]);
+        }
+        ring.extend([[36.0, 10.0], [0.0, 10.0]]);
+        let turns = turning_angles(&ring);
+        let perimeter: f64 = ring_edges(&ring).map(|(a, b)| a.distance_to(b)).sum();
+        // Mid bottom edge: the collinear vertex adds no turning.
+        assert!(bend_within(&turns, perimeter, 20.0, 6.5) < 1e-9);
+        // Sharp bottom-right corner at station 40: 90° inside any window.
+        assert!((bend_within(&turns, perimeter, 39.0, 1.5) - 90.0).abs() < 1e-9);
+        assert!((bend_within(&turns, perimeter, 34.0, 6.5) - 90.0).abs() < 1e-9);
+        // A 4 mm radius turns about 43° within a 3 mm tab and most of the
+        // quarter turn within the keep-out window: too tight for a tab.
+        let mid_arc = 40.0 + 6.0 + std::f64::consts::FRAC_PI_2 * 4.0 / 2.0;
+        let within_tab = bend_within(&turns, perimeter, mid_arc, 1.5);
+        assert!(within_tab > 15.0 && within_tab < 90.0, "{within_tab}");
+        assert!(bend_within(&turns, perimeter, mid_arc, 6.5) > 60.0);
+        // Across the seam: the top-left corner sits at station 0.
+        assert!((bend_within(&turns, perimeter, perimeter - 1.0, 2.0) - 90.0).abs() < 1e-9);
+        // A 40 mm radius flattened at the same angle per vertex turns about
+        // 4° within a tab and 19° within the keep-out window: usable.
+        let big: Vec<[f64; 2]> = (0..48)
+            .map(|k| {
+                let a = std::f64::consts::TAU * k as f64 / 48.0;
+                [40.0 * a.cos(), 40.0 * a.sin()]
+            })
+            .collect();
+        let turns = turning_angles(&big);
+        let perimeter: f64 = ring_edges(&big).map(|(a, b)| a.distance_to(b)).sum();
+        assert!(bend_within(&turns, perimeter, 10.0, 1.5) < 15.0);
+        assert!(bend_within(&turns, perimeter, 10.0, 6.5) < 60.0);
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
@@ -1,60 +1,51 @@
-//! Where mouse-bite tabs go on one canonical board: candidate sites along the
-//! Eligible outline, then the fewest tabs that hold the board rigidly.
-//! Analysis only: no tab geometry, routing, frame, or panel export.
+//! Where mouse-bite tabs go on one canonical board. Analysis only: no tab
+//! geometry, routing, frame, or panel export.
 //!
-//! The panel is assumed to route a slot of `routing_gap_mm` that follows the
-//! board outline, with frame material beyond it. A candidate is a straight
-//! strip of the tab width from the outline across the slot into that frame.
+//! [`candidates`] finds where a tab could sit on the eligible outline and
+//! [`select`] chooses the fewest of them that hold the board under a process
+//! load. The panel is assumed to route a slot of `routing_gap_mm` that
+//! follows the outline, with frame material beyond it.
 
+pub mod candidates;
 pub mod select;
 
-use anyhow::Result;
+use anyhow::{Result, ensure};
 use pcb_ir::geom::{
-    ContourSet, FillRule, Point, Resolution,
-    attachment::{
-        BoundaryId, BoundaryQuery, QueryTolerance,
-        outline::{OutlineFootprint, OutlineState},
-    },
-    region::{ring_edges, ring_signed_area},
+    ContourSet, Resolution, attachment::outline::OutlineFootprint, mouse_bite::SparkFunShallow,
 };
 use serde_json::{Value, json};
 
-use super::eligibility::{self, Prepared};
-use pcb_ir::geom::mouse_bite::SparkFunShallow;
-use select::{Laminate, Model, Process, Rail, Site, TabBeam};
+use super::eligibility;
+use select::{Model, Physics};
 
 /// Opinionated placement preset, in millimeters and newtons. Not user knobs.
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct Preset {
-    /// Tab width along the outline, neck plus router shoulders.
+    /// Tab width along the outline: neck plus router shoulders.
     pub tab_width_mm: f64,
     /// How far the perforations reach into the board.
     pub inward_mm: f64,
     /// Growth applied to courtyards before they count as obstacles.
     pub courtyard_clearance_mm: f64,
-    /// Routed slot between the board outline and the frame.
+    /// Routed slot between the board outline and the frame; the neck spans it.
     pub routing_gap_mm: f64,
     /// Frame material a tab must reach beyond the slot.
     pub frame_landing_mm: f64,
-    /// Candidate spacing along usable outline runs.
+    /// Candidate spacing along eligible outline runs.
     pub candidate_pitch_mm: f64,
     /// Outline may turn at most this much within the tab's own width.
     pub tab_bend_degrees: f64,
     /// Outline may turn at most this much within the tab plus the keep-out on
-    /// either side, which keeps tabs clear of corners without excluding round
-    /// boards.
+    /// either side: clear of corners without excluding round boards.
     pub corner_bend_degrees: f64,
     pub corner_keepout_mm: f64,
     /// Closest two tabs may sit.
     pub min_separation_mm: f64,
-    /// Spacing of the outline points the load may act at.
+    /// Spacing of the outline points a load may act at.
     pub load_point_spacing_mm: f64,
     /// Assumed when the source states no stackup thickness.
     pub default_thickness_mm: f64,
-    pub laminate: Laminate,
-    pub tab: TabBeam,
-    pub rail: Rail,
-    pub process: Process,
+    pub physics: Physics,
 }
 
 pub const PRESET: Preset = Preset {
@@ -70,23 +61,18 @@ pub const PRESET: Preset = Preset {
     min_separation_mm: 10.0,
     load_point_spacing_mm: 2.0,
     default_thickness_mm: 1.6,
-    // Typical rigid FR-4, in-plane; the laminate is treated as isotropic.
-    laminate: Laminate {
-        youngs_modulus: 22_000.0,
-        shear_modulus: 4_500.0,
+    physics: Physics {
+        // Typical rigid FR-4, in-plane, treated as isotropic.
+        youngs_modulus_mpa: 22_000.0,
+        shear_modulus_mpa: 4_500.0,
         poisson_ratio: 0.13,
-    },
-    // The neck spans the routing gap; perforation halves its section.
-    tab: TabBeam {
-        width_mm: SparkFunShallow::NECK_WIDTH_MM,
-        length_mm: 2.0,
-        perforation_factor: 0.5,
-    },
-    // Two default 5 mm board margins minus a slot on each side.
-    rail: Rail { width_mm: 6.0 },
-    // A finger or placement nozzle anywhere on the board, and the sag that
-    // still leaves the surface flat enough for placement.
-    process: Process {
+        // Perforation halves the neck's section.
+        neck_width_mm: SparkFunShallow::NECK_WIDTH_MM,
+        neck_perforation_factor: 0.5,
+        // Two default 5 mm board margins minus a slot on each side.
+        rail_width_mm: 6.0,
+        // A finger or placement nozzle anywhere on the board, and the sag that
+        // still leaves the surface flat enough for placement.
         load_n: 5.0,
         deflection_limit_mm: 0.25,
     },
@@ -102,20 +88,6 @@ impl Preset {
             outward_mm: self.routing_gap_mm + self.frame_landing_mm,
         }
     }
-
-    /// Cross rails sit one board span apart, so the rail a tab lands on is
-    /// held that far apart at worst.
-    pub fn model(&self, thickness_mm: f64, board_span_mm: f64) -> Model {
-        Model::new(
-            thickness_mm,
-            board_span_mm,
-            self.laminate,
-            self.tab,
-            self.rail,
-            self.process,
-            self.min_separation_mm,
-        )
-    }
 }
 
 /// Analyze one canonical board: eligibility plus tab placement.
@@ -127,99 +99,30 @@ pub fn analyze(xml: &str, preset: &Preset, resolution: Resolution) -> Result<Val
         &[],
         resolution,
     )?;
-    let mut report = prepared.report.clone();
-    report["phase"] = json!("tab-placement-only");
-    report["placement"] = place(&prepared, preset, resolution.strict())?;
-    Ok(report)
-}
-
-struct Candidate {
-    ring: usize,
-    station_mm: f64,
-    site: Site,
-}
-
-fn place(prepared: &Prepared, preset: &Preset, resolution: Resolution) -> Result<Value> {
     let substrate = &prepared.substrate;
-    let tolerance = QueryTolerance {
-        boundary_mm: 0.0,
-        numerical_mm: pcb_ir::geom::tol::EPSILON_MM,
-    };
-    let boundary = BoundaryQuery::new(substrate, tolerance)?;
-    let reach = preset.routing_gap_mm + preset.frame_landing_mm;
-    // Frame material beyond an outline-following slot, locally to this board.
-    let frame = ContourSet::rectangle(substrate.bbox().expand(reach + 1.0), resolution)
-        .difference(&substrate.disk_dilate(preset.routing_gap_mm)?)?;
-
-    let mut candidates = Vec::new();
-    let mut rejected = Vec::new();
-    for id in boundary.boundaries() {
-        let ring = &substrate.rings[id.ring];
-        if ring_signed_area(ring) <= 0.0 {
-            continue; // holes cannot reach the frame
-        }
-        let perimeter = boundary.perimeter(id)?;
-        let turns = turning_angles(ring);
-        let half = preset.tab_width_mm / 2.0;
-        for (lo, hi) in eligible_runs(&prepared.intervals, id, perimeter) {
-            let length = hi - lo;
-            let bins = (length / preset.candidate_pitch_mm).ceil().max(1.0) as usize;
-            for k in 0..bins {
-                let station_mm = (lo + length * (k as f64 + 0.5) / bins as f64) % perimeter;
-                let site = boundary.site(id, station_mm)?;
-                let tab_bend = bend_within(&turns, perimeter, station_mm, half);
-                let corner_bend = bend_within(
-                    &turns,
-                    perimeter,
-                    station_mm,
-                    half + preset.corner_keepout_mm,
-                );
-                if tab_bend > preset.tab_bend_degrees || corner_bend > preset.corner_bend_degrees {
-                    let p = site.point;
-                    rejected.push(json!({
-                        "ring": id.ring, "station_mm": station_mm, "point": [p.x, p.y],
-                        "reason": if tab_bend > preset.tab_bend_degrees {
-                            format!("outline turns {tab_bend:.0}° within the tab")
-                        } else {
-                            format!("outline turns {corner_bend:.0}° within the corner keep-out")
-                        },
-                    }));
-                    continue;
-                }
-                let (p, t, n) = (site.point, site.tangent, site.outward_normal);
-                let width = preset.tab_width_mm;
-                let across = strip(p, t, n, width, 0.0, preset.routing_gap_mm, resolution)?;
-                let landing = strip(p, t, n, width, preset.routing_gap_mm, reach, resolution)?;
-                let reason = if across.intersection(substrate)?.area() > 0.0 {
-                    Some("tab crosses back into the board")
-                } else if !landing.difference(&frame)?.is_empty() {
-                    Some("no frame material beyond the slot")
-                } else {
-                    None
-                };
-                match reason {
-                    Some(reason) => rejected.push(json!({
-                        "ring": id.ring, "station_mm": station_mm, "point": [p.x, p.y], "reason": reason,
-                    })),
-                    None => candidates.push(Candidate {
-                        ring: id.ring,
-                        station_mm,
-                        site: Site {
-                            point: p,
-                            outward_normal: n,
-                        },
-                    }),
-                }
-            }
-        }
-    }
-
-    let loads = outline_samples(substrate, preset.load_point_spacing_mm);
+    let islands = substrate.connected_components().len();
+    ensure!(
+        islands == 1,
+        "placement models one connected board; this substrate has {islands} separate islands"
+    );
+    let sites = candidates::find(substrate, &prepared.intervals, preset, resolution.strict())?;
+    let loads = candidates::load_points(substrate, preset.load_point_spacing_mm);
     let bbox = substrate.bbox();
-    let thickness_mm = prepared.thickness_mm.unwrap_or(preset.default_thickness_mm);
-    let model = preset.model(thickness_mm, bbox.width().max(bbox.height()));
-    let sites: Vec<_> = candidates.iter().map(|c| c.site).collect();
-    let selection = select::select(&sites, &loads, &model);
+    // Cross rails sit one board span apart, so the rail a tab lands on is
+    // held that far apart at worst.
+    let model = Model::new(
+        prepared.thickness_mm.unwrap_or(preset.default_thickness_mm),
+        bbox.width().max(bbox.height()),
+        preset.routing_gap_mm,
+        preset.physics,
+        preset.min_separation_mm,
+    );
+    let selection = select::select(
+        &sites.candidates.iter().map(|c| c.site).collect::<Vec<_>>(),
+        &loads,
+        &model,
+    );
+
     let rings = |region: &ContourSet| {
         region
             .rings
@@ -227,127 +130,35 @@ fn place(prepared: &Prepared, preset: &Preset, resolution: Resolution) -> Result
             .map(|ring| ring.iter().map(|p| json!([p[0], p[1]])).collect::<Vec<_>>())
             .collect::<Vec<_>>()
     };
-    Ok(json!({
+    let mut report = prepared.report.clone();
+    report["phase"] = json!("tab-placement-only");
+    report["placement"] = json!({
         "preset": preset,
         "model": model,
         "thickness_source": if prepared.thickness_mm.is_some() { "stackup" } else { "default" },
         "board": {"bbox": [bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y]},
         "substrate": rings(substrate),
-        "frame": rings(&frame),
+        "frame": rings(&sites.frame),
         "obstacles": prepared.evidence.iter().filter_map(|e| {
             e.region.as_ref().map(|r| json!({"id": e.id, "rings": rings(r)}))
         }).collect::<Vec<_>>(),
-        "candidates": candidates.iter().enumerate().map(|(i, c)| json!({
+        "candidates": sites.candidates.iter().enumerate().map(|(i, c)| json!({
             "id": i, "ring": c.ring, "station_mm": c.station_mm,
             "point": [c.site.point.x, c.site.point.y],
             "normal": [c.site.outward_normal.x, c.site.outward_normal.y],
         })).collect::<Vec<_>>(),
-        "rejected": rejected,
+        "rejected": sites.rejected.iter().map(|r| json!({
+            "ring": r.ring, "station_mm": r.station_mm, "point": [r.point.x, r.point.y], "reason": r.reason,
+        })).collect::<Vec<_>>(),
         "selected": selection.chosen,
         "tab_count": selection.chosen.len(),
+        "proven_minimal": selection.proven,
         "deflection_mm": selection.deflection_mm.is_finite().then_some(selection.deflection_mm),
         "worst_point": selection.worst_point.map(|j| [loads[j].x, loads[j].y]),
         "satisfied": selection.satisfied(),
         "violations": selection.violations.iter().map(ToString::to_string).collect::<Vec<_>>(),
-    }))
-}
-
-/// Contiguous Eligible arclength runs on one ring, joined across the seam.
-/// A run through the seam is returned with `hi` beyond the perimeter.
-fn eligible_runs(
-    intervals: &[pcb_ir::geom::attachment::outline::OutlineInterval],
-    id: BoundaryId,
-    perimeter: f64,
-) -> Vec<(f64, f64)> {
-    let mut runs: Vec<(f64, f64)> = Vec::new();
-    for interval in intervals
-        .iter()
-        .filter(|i| i.boundary == id && i.state == OutlineState::Eligible)
-    {
-        match runs.last_mut() {
-            Some(last) if last.1 == interval.start_mm => last.1 = interval.end_mm,
-            _ => runs.push((interval.start_mm, interval.end_mm)),
-        }
-    }
-    if runs.len() > 1 && runs[0].0 == 0.0 && runs.last().unwrap().1 == perimeter {
-        let first = runs.remove(0);
-        runs.last_mut().unwrap().1 = perimeter + first.1;
-    }
-    runs
-}
-
-/// Unsigned turning angle at each vertex, in degrees, with the vertex's
-/// station. Flattened arcs turn a little at many vertices; corners a lot at one.
-fn turning_angles(ring: &Vec<[f64; 2]>) -> Vec<(f64, f64)> {
-    let edges: Vec<(Point, Point)> = ring_edges(ring).collect();
-    let mut station = 0.0;
-    let mut turns = Vec::with_capacity(edges.len());
-    for (i, (a, b)) in edges.iter().enumerate() {
-        let (prev_a, prev_b) = edges[(i + edges.len() - 1) % edges.len()];
-        let incoming = prev_b - prev_a;
-        let outgoing = *b - *a;
-        let angle = (incoming.x * outgoing.y - incoming.y * outgoing.x)
-            .atan2(incoming.x * outgoing.x + incoming.y * outgoing.y)
-            .abs()
-            .to_degrees();
-        turns.push((station, angle));
-        station += a.distance_to(*b);
-    }
-    turns
-}
-
-/// Total turning strictly within `half` of `station` along the cyclic ring.
-fn bend_within(turns: &[(f64, f64)], perimeter: f64, station: f64, half: f64) -> f64 {
-    turns
-        .iter()
-        .filter(|(s, _)| {
-            let d = (s - station).rem_euclid(perimeter);
-            d.min(perimeter - d) < half
-        })
-        .map(|(_, angle)| angle)
-        .sum()
-}
-
-/// Rectangle of `width` across the tangent, spanning `lo..hi` along the normal.
-fn strip(
-    p: Point,
-    tangent: Point,
-    normal: Point,
-    width: f64,
-    lo: f64,
-    hi: f64,
-    resolution: Resolution,
-) -> Result<ContourSet> {
-    let corners = [
-        p - tangent * (width / 2.0) + normal * lo,
-        p + tangent * (width / 2.0) + normal * lo,
-        p + tangent * (width / 2.0) + normal * hi,
-        p - tangent * (width / 2.0) + normal * hi,
-    ];
-    Ok(ContourSet::from_rings(
-        vec![corners.map(|c| [c.x, c.y]).to_vec()],
-        FillRule::EvenOdd,
-        resolution,
-    )?)
-}
-
-/// Points every `spacing` of arclength along the outer rings. Loads act
-/// here; the rigid response is convex, so the outline is the worst case.
-fn outline_samples(region: &ContourSet, spacing: f64) -> Vec<Point> {
-    let mut samples = Vec::new();
-    for ring in region.rings.iter().filter(|r| ring_signed_area(r) > 0.0) {
-        let mut next = 0.0;
-        let mut station = 0.0;
-        for (a, b) in ring_edges(ring) {
-            let length = a.distance_to(b);
-            while next < station + length {
-                samples.push(a + (b - a) * ((next - station) / length));
-                next += spacing;
-            }
-            station += length;
-        }
-    }
-    samples
+    });
+    Ok(report)
 }
 
 #[cfg(feature = "cli")]
@@ -367,48 +178,4 @@ pub fn execute(
     }
     anstream::eprintln!("Tab placement analysis only; no mouse-bite panel generated.");
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn bends_distinguish_corners_from_gentle_arcs() {
-        // A 40 x 10 rectangle whose top-right corner is a 12-vertex arc of
-        // radius 4, plus a collinear split on the bottom edge.
-        let mut ring = vec![[0.0, 0.0], [15.0, 0.0], [40.0, 0.0], [40.0, 6.0]];
-        for k in 1..12 {
-            let a = std::f64::consts::FRAC_PI_2 * k as f64 / 12.0;
-            ring.push([36.0 + 4.0 * a.cos(), 6.0 + 4.0 * a.sin()]);
-        }
-        ring.extend([[36.0, 10.0], [0.0, 10.0]]);
-        let turns = turning_angles(&ring);
-        let perimeter: f64 = ring_edges(&ring).map(|(a, b)| a.distance_to(b)).sum();
-        // Mid bottom edge: the collinear vertex adds no turning.
-        assert!(bend_within(&turns, perimeter, 20.0, 6.5) < 1e-9);
-        // Sharp bottom-right corner at station 40: 90° inside any window.
-        assert!((bend_within(&turns, perimeter, 39.0, 1.5) - 90.0).abs() < 1e-9);
-        assert!((bend_within(&turns, perimeter, 34.0, 6.5) - 90.0).abs() < 1e-9);
-        // A 4 mm radius turns about 43° within a 3 mm tab and most of the
-        // quarter turn within the keep-out window: too tight for a tab.
-        let mid_arc = 40.0 + 6.0 + std::f64::consts::FRAC_PI_2 * 4.0 / 2.0;
-        let within_tab = bend_within(&turns, perimeter, mid_arc, 1.5);
-        assert!(within_tab > 15.0 && within_tab < 90.0, "{within_tab}");
-        assert!(bend_within(&turns, perimeter, mid_arc, 6.5) > 60.0);
-        // Across the seam: the top-left corner sits at station 0.
-        assert!((bend_within(&turns, perimeter, perimeter - 1.0, 2.0) - 90.0).abs() < 1e-9);
-        // A 40 mm radius flattened at the same angle per vertex turns about
-        // 4° within a tab and 19° within the keep-out window: usable.
-        let big: Vec<[f64; 2]> = (0..48)
-            .map(|k| {
-                let a = std::f64::consts::TAU * k as f64 / 48.0;
-                [40.0 * a.cos(), 40.0 * a.sin()]
-            })
-            .collect();
-        let turns = turning_angles(&big);
-        let perimeter: f64 = ring_edges(&big).map(|(a, b)| a.distance_to(b)).sum();
-        assert!(bend_within(&turns, perimeter, 10.0, 1.5) < 15.0);
-        assert!(bend_within(&turns, perimeter, 10.0, 6.5) < 60.0);
-    }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement/candidates.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement/candidates.rs
@@ -1,0 +1,332 @@
+//! Where a tab could sit: eligible outline runs sampled at a pitch. A site is
+//! kept where the outline is straight enough for the tab and its keep-out,
+//! the strip across the slot stays out of the board, and frame material lies
+//! beyond the slot. Holes cannot reach the frame and are skipped.
+
+use anyhow::Result;
+use pcb_ir::geom::{
+    ContourSet, FillRule, Point, Resolution,
+    attachment::{
+        BoundaryId, BoundaryQuery, BoundarySite, QueryTolerance,
+        outline::{OutlineInterval, OutlineState},
+    },
+    region::{ring_edges, ring_signed_area},
+};
+
+use super::{Preset, select::Site};
+
+pub struct Candidate {
+    pub ring: usize,
+    pub station_mm: f64,
+    pub site: Site,
+}
+
+pub struct Rejection {
+    pub ring: usize,
+    pub station_mm: f64,
+    pub point: Point,
+    pub reason: String,
+}
+
+pub struct Sites {
+    pub candidates: Vec<Candidate>,
+    pub rejected: Vec<Rejection>,
+    /// Frame material beyond an outline-following slot, local to this board.
+    pub frame: ContourSet,
+}
+
+pub fn find(
+    substrate: &ContourSet,
+    intervals: &[OutlineInterval],
+    preset: &Preset,
+    resolution: Resolution,
+) -> Result<Sites> {
+    let boundary = BoundaryQuery::new(
+        substrate,
+        QueryTolerance {
+            boundary_mm: 0.0,
+            numerical_mm: pcb_ir::geom::tol::EPSILON_MM,
+        },
+    )?;
+    let reach = preset.routing_gap_mm + preset.frame_landing_mm;
+    let frame = ContourSet::rectangle(substrate.bbox().expand(reach + 1.0), resolution)
+        .difference(&substrate.disk_dilate(preset.routing_gap_mm)?)?;
+    let checker = Checker {
+        substrate,
+        frame: &frame,
+        preset,
+        resolution,
+    };
+    let mut sites = Sites {
+        candidates: Vec::new(),
+        rejected: Vec::new(),
+        frame: ContourSet::empty(resolution),
+    };
+    for id in boundary
+        .boundaries()
+        .filter(|id| ring_signed_area(&substrate.rings[id.ring]) > 0.0)
+    {
+        let perimeter = boundary.perimeter(id)?;
+        let turns = turning_angles(&substrate.rings[id.ring]);
+        for (lo, hi) in eligible_runs(intervals, id, perimeter) {
+            let bins = ((hi - lo) / preset.candidate_pitch_mm).ceil().max(1.0) as usize;
+            for k in 0..bins {
+                let station_mm = (lo + (hi - lo) * (k as f64 + 0.5) / bins as f64) % perimeter;
+                let site = boundary.site(id, station_mm)?;
+                match checker.rejection(&site, &turns, perimeter)? {
+                    Some(reason) => sites.rejected.push(Rejection {
+                        ring: id.ring,
+                        station_mm,
+                        point: site.point,
+                        reason,
+                    }),
+                    None => sites.candidates.push(Candidate {
+                        ring: id.ring,
+                        station_mm,
+                        site: Site {
+                            point: site.point,
+                            outward_normal: site.outward_normal,
+                        },
+                    }),
+                }
+            }
+        }
+    }
+    sites.frame = frame;
+    Ok(sites)
+}
+
+struct Checker<'a> {
+    substrate: &'a ContourSet,
+    frame: &'a ContourSet,
+    preset: &'a Preset,
+    resolution: Resolution,
+}
+
+impl Checker<'_> {
+    /// Why a tab cannot sit at `site`, if it cannot.
+    fn rejection(
+        &self,
+        site: &BoundarySite,
+        turns: &[(f64, f64)],
+        perimeter: f64,
+    ) -> Result<Option<String>> {
+        let p = self.preset;
+        let half = p.tab_width_mm / 2.0;
+        let tab_bend = bend_within(turns, perimeter, site.station_mm, half);
+        if tab_bend > p.tab_bend_degrees {
+            return Ok(Some(format!("outline turns {tab_bend:.0}° within the tab")));
+        }
+        let corner_bend = bend_within(
+            turns,
+            perimeter,
+            site.station_mm,
+            half + p.corner_keepout_mm,
+        );
+        if corner_bend > p.corner_bend_degrees {
+            return Ok(Some(format!(
+                "outline turns {corner_bend:.0}° within the corner keep-out"
+            )));
+        }
+        let across = self.strip(site, 0.0, p.routing_gap_mm)?;
+        if across.intersection(self.substrate)?.area() > 0.0 {
+            return Ok(Some("tab crosses back into the board".into()));
+        }
+        let landing = self.strip(
+            site,
+            p.routing_gap_mm,
+            p.routing_gap_mm + p.frame_landing_mm,
+        )?;
+        if !landing.difference(self.frame)?.is_empty() {
+            return Ok(Some("no frame material beyond the slot".into()));
+        }
+        Ok(None)
+    }
+
+    /// Rectangle of the tab width across the tangent, spanning `lo..hi`
+    /// outward along the normal.
+    fn strip(&self, site: &BoundarySite, lo: f64, hi: f64) -> Result<ContourSet> {
+        let (p, t, n) = (site.point, site.tangent, site.outward_normal);
+        let half = t * (self.preset.tab_width_mm / 2.0);
+        let corners = [
+            p - half + n * lo,
+            p + half + n * lo,
+            p + half + n * hi,
+            p - half + n * hi,
+        ];
+        Ok(ContourSet::from_rings(
+            vec![corners.map(|c| [c.x, c.y]).to_vec()],
+            FillRule::EvenOdd,
+            self.resolution,
+        )?)
+    }
+}
+
+/// Contiguous Eligible arclength runs on one ring, joined across the seam.
+/// A run through the seam is returned with `hi` beyond the perimeter.
+fn eligible_runs(intervals: &[OutlineInterval], id: BoundaryId, perimeter: f64) -> Vec<(f64, f64)> {
+    let touching = |a: f64, b: f64| (a - b).abs() < 1e-9;
+    let mut runs: Vec<(f64, f64)> = Vec::new();
+    for interval in intervals
+        .iter()
+        .filter(|i| i.boundary == id && i.state == OutlineState::Eligible)
+    {
+        match runs.last_mut() {
+            Some(last) if touching(last.1, interval.start_mm) => last.1 = interval.end_mm,
+            _ => runs.push((interval.start_mm, interval.end_mm)),
+        }
+    }
+    if let [first, .., last] = runs.as_mut_slice()
+        && touching(first.0, 0.0)
+        && touching(last.1, perimeter)
+    {
+        last.1 = perimeter + first.1;
+        runs.remove(0);
+    }
+    runs
+}
+
+/// Unsigned turning angle at each vertex, in degrees, with the vertex's
+/// station. Flattened arcs turn a little at many vertices; corners a lot at one.
+fn turning_angles(ring: &Vec<[f64; 2]>) -> Vec<(f64, f64)> {
+    let edges: Vec<(Point, Point)> = ring_edges(ring).collect();
+    let mut station = 0.0;
+    let mut turns = Vec::with_capacity(edges.len());
+    for (i, (a, b)) in edges.iter().enumerate() {
+        let (prev_a, prev_b) = edges[(i + edges.len() - 1) % edges.len()];
+        let incoming = prev_b - prev_a;
+        let outgoing = *b - *a;
+        let angle = (incoming.x * outgoing.y - incoming.y * outgoing.x)
+            .atan2(incoming.x * outgoing.x + incoming.y * outgoing.y)
+            .abs()
+            .to_degrees();
+        turns.push((station, angle));
+        station += a.distance_to(*b);
+    }
+    turns
+}
+
+/// Total turning strictly within `half` of `station` along the cyclic ring.
+fn bend_within(turns: &[(f64, f64)], perimeter: f64, station: f64, half: f64) -> f64 {
+    turns
+        .iter()
+        .filter(|(s, _)| {
+            let d = (s - station).rem_euclid(perimeter);
+            d.min(perimeter - d) < half
+        })
+        .map(|(_, angle)| angle)
+        .sum()
+}
+
+/// Points a load may act at: every `spacing` of arclength along the outer
+/// rings. The rigid response is a convex function of position, so it peaks
+/// on the outline. The local bending term is a cantilever from the nearest
+/// tab, which is the right picture along a free edge; a point inside the
+/// board is farther from the tabs but surrounded by supported material, and
+/// the plate between supports is stiffer than any edge cantilever, so the
+/// outline governs there too.
+pub fn load_points(region: &ContourSet, spacing: f64) -> Vec<Point> {
+    let mut points = Vec::new();
+    for ring in region.rings.iter().filter(|r| ring_signed_area(r) > 0.0) {
+        let (mut next, mut station) = (0.0, 0.0);
+        for (a, b) in ring_edges(ring) {
+            let length = a.distance_to(b);
+            while next < station + length {
+                points.push(a + (b - a) * ((next - station) / length));
+                next += spacing;
+            }
+            station += length;
+        }
+    }
+    points
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bends_distinguish_corners_from_gentle_arcs() {
+        // A 40 x 10 rectangle whose top-right corner is a 12-vertex arc of
+        // radius 4, plus a collinear split on the bottom edge.
+        let mut ring = vec![[0.0, 0.0], [15.0, 0.0], [40.0, 0.0], [40.0, 6.0]];
+        for k in 1..12 {
+            let a = std::f64::consts::FRAC_PI_2 * k as f64 / 12.0;
+            ring.push([36.0 + 4.0 * a.cos(), 6.0 + 4.0 * a.sin()]);
+        }
+        ring.extend([[36.0, 10.0], [0.0, 10.0]]);
+        let turns = turning_angles(&ring);
+        let perimeter: f64 = ring_edges(&ring).map(|(a, b)| a.distance_to(b)).sum();
+        // Mid bottom edge: the collinear vertex adds no turning.
+        assert!(bend_within(&turns, perimeter, 20.0, 6.5) < 1e-9);
+        // Sharp bottom-right corner at station 40: 90° inside any window.
+        assert!((bend_within(&turns, perimeter, 39.0, 1.5) - 90.0).abs() < 1e-9);
+        assert!((bend_within(&turns, perimeter, 34.0, 6.5) - 90.0).abs() < 1e-9);
+        // A 4 mm radius turns about 43° within a 3 mm tab and most of the
+        // quarter turn within the keep-out window: too tight for a tab.
+        let mid_arc = 40.0 + 6.0 + std::f64::consts::FRAC_PI_2 * 4.0 / 2.0;
+        let within_tab = bend_within(&turns, perimeter, mid_arc, 1.5);
+        assert!(within_tab > 15.0 && within_tab < 90.0, "{within_tab}");
+        assert!(bend_within(&turns, perimeter, mid_arc, 6.5) > 60.0);
+        // Across the seam: the top-left corner sits at station 0.
+        assert!((bend_within(&turns, perimeter, perimeter - 1.0, 2.0) - 90.0).abs() < 1e-9);
+        // A 40 mm radius flattened at the same angle per vertex turns about
+        // 4° within a tab and 19° within the keep-out window: usable.
+        let big: Vec<[f64; 2]> = (0..48)
+            .map(|k| {
+                let a = std::f64::consts::TAU * k as f64 / 48.0;
+                [40.0 * a.cos(), 40.0 * a.sin()]
+            })
+            .collect();
+        let turns = turning_angles(&big);
+        let perimeter: f64 = ring_edges(&big).map(|(a, b)| a.distance_to(b)).sum();
+        assert!(bend_within(&turns, perimeter, 10.0, 1.5) < 15.0);
+        assert!(bend_within(&turns, perimeter, 10.0, 6.5) < 60.0);
+    }
+
+    #[test]
+    fn eligible_runs_merge_neighbors_and_join_across_the_seam() {
+        let id = BoundaryId {
+            component: 0,
+            ring: 0,
+        };
+        let interval = |start_mm: f64, end_mm: f64, state: OutlineState| OutlineInterval {
+            boundary: id,
+            edge: 0,
+            start_mm,
+            end_mm,
+            start: Point::ZERO,
+            end: Point::ZERO,
+            state,
+            landing: OutlineState::Eligible,
+            obstacles: Vec::new(),
+            uncertainty_mm: 0.0,
+        };
+        let intervals = [
+            interval(0.0, 10.0, OutlineState::Eligible),
+            interval(10.0, 30.0, OutlineState::Eligible),
+            interval(30.0, 50.0, OutlineState::Blocked),
+            interval(50.0, 100.0, OutlineState::Eligible),
+        ];
+        assert_eq!(eligible_runs(&intervals, id, 100.0), vec![(50.0, 130.0)]);
+    }
+
+    #[test]
+    fn load_points_follow_the_outline_at_the_spacing() {
+        let region = ContourSet::rectangle(
+            pcb_ir::geom::BBox::new(Point::ZERO, Point::new(20.0, 10.0)),
+            Resolution::default(),
+        );
+        let points = load_points(&region, 2.0);
+        assert_eq!(points.len(), 30);
+        assert!(
+            points
+                .iter()
+                .any(|p| p.y.abs() < 1e-9 && (p.x - 10.0).abs() < 1e-9)
+        );
+        assert!(points.iter().all(|p| p.x.abs() < 1e-9
+            || p.y.abs() < 1e-9
+            || (p.x - 20.0).abs() < 1e-9
+            || (p.y - 10.0).abs() < 1e-9));
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement/select.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement/select.rs
@@ -14,39 +14,27 @@
 
 use pcb_ir::geom::Point;
 
-/// Equivalent isotropic laminate, N/mm².
+/// Material, tab and process inputs the model is derived from.
 #[derive(Debug, Clone, Copy, serde::Serialize)]
-pub struct Laminate {
-    pub youngs_modulus: f64,
-    pub shear_modulus: f64,
+pub struct Physics {
+    /// Equivalent isotropic laminate, N/mm².
+    pub youngs_modulus_mpa: f64,
+    pub shear_modulus_mpa: f64,
     pub poisson_ratio: f64,
-}
-
-/// One tab as a beam of `width` and `length` between board and frame, with
-/// its section reduced by perforation.
-#[derive(Debug, Clone, Copy, serde::Serialize)]
-pub struct TabBeam {
-    pub width_mm: f64,
-    pub length_mm: f64,
-    pub perforation_factor: f64,
-}
-
-/// The frame rail a tab lands on: a strip of the board's thickness, held
-/// where cross rails meet it, one board span apart.
-#[derive(Debug, Clone, Copy, serde::Serialize)]
-pub struct Rail {
-    pub width_mm: f64,
-}
-
-#[derive(Debug, Clone, Copy, serde::Serialize)]
-pub struct Process {
+    /// The neck is a beam of this width between board and rail, its section
+    /// reduced by perforation.
+    pub neck_width_mm: f64,
+    pub neck_perforation_factor: f64,
+    /// The rail a tab lands on: a strip of the board's thickness, held where
+    /// cross rails meet it.
+    pub rail_width_mm: f64,
     /// Point load that may act anywhere on the board, N.
     pub load_n: f64,
     /// Allowed deflection under that load, mm.
     pub deflection_limit_mm: f64,
 }
 
-/// Derived stiffnesses for one board thickness and rail span.
+/// Stiffnesses derived for one board's thickness, span and slot.
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct Model {
     pub thickness_mm: f64,
@@ -79,26 +67,31 @@ impl Model {
     pub fn new(
         thickness_mm: f64,
         rail_span_mm: f64,
-        laminate: Laminate,
-        tab: TabBeam,
-        rail: Rail,
-        process: Process,
+        neck_length_mm: f64,
+        physics: Physics,
         min_separation_mm: f64,
     ) -> Self {
-        let (e, g, nu) = (
-            laminate.youngs_modulus,
-            laminate.shear_modulus,
-            laminate.poisson_ratio,
-        );
-        let (w, l, t) = (tab.width_mm, tab.length_mm, thickness_mm);
-        let f = tab.perforation_factor;
+        let Physics {
+            youngs_modulus_mpa: e,
+            shear_modulus_mpa: g,
+            poisson_ratio: nu,
+            neck_width_mm: w,
+            neck_perforation_factor: f,
+            rail_width_mm,
+            load_n,
+            deflection_limit_mm,
+        } = physics;
+        let (t, l) = (thickness_mm, neck_length_mm);
         let neck_inertia = w * t.powi(3) / 12.0;
+        let rail_inertia = rail_width_mm * t.powi(3) / 12.0;
+        // Neck as a beam guided at both ends; rail loaded at mid-span between
+        // its supports, by a torque for the neck's bending and by a moment
+        // for the neck's twist.
         let neck_transverse = f * 12.0 * e * neck_inertia / l.powi(3);
         let neck_bending = f * 4.0 * e * neck_inertia / l;
         let neck_twist = f * g * torsion_constant(w, t) / l;
-        // A torque or moment applied at mid-span of a rail held at both ends.
-        let rail_twist = 4.0 * g * torsion_constant(rail.width_mm, t) / rail_span_mm;
-        let rail_bending = 12.0 * e * rail.width_mm * t.powi(3) / 12.0 / rail_span_mm;
+        let rail_twist = 4.0 * g * torsion_constant(rail_width_mm, t) / rail_span_mm;
+        let rail_bending = 12.0 * e * rail_inertia / rail_span_mm;
         let rigidity_n_mm = e * t.powi(3) / (12.0 * (1.0 - nu * nu));
         Self {
             thickness_mm,
@@ -107,11 +100,9 @@ impl Model {
             tab_transverse_n_per_mm: neck_transverse,
             tab_bending_n_mm: series(neck_bending, rail_twist),
             tab_twist_n_mm: series(neck_twist, rail_bending),
-            load_n: process.load_n,
-            deflection_limit_mm: process.deflection_limit_mm,
-            reach_mm: (BENDING_SPREAD * rigidity_n_mm * process.deflection_limit_mm
-                / process.load_n)
-                .sqrt(),
+            load_n,
+            deflection_limit_mm,
+            reach_mm: (BENDING_SPREAD * rigidity_n_mm * deflection_limit_mm / load_n).sqrt(),
             min_separation_mm,
         }
     }
@@ -135,7 +126,7 @@ pub struct Site {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum Violation {
-    NoSites,
+    NoTabs,
     Deflection { deflection_mm: f64, limit_mm: f64 },
     Separation { distance_mm: f64, minimum_mm: f64 },
 }
@@ -143,7 +134,7 @@ pub enum Violation {
 impl std::fmt::Display for Violation {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::NoSites => write!(f, "no candidate sites on the outline"),
+            Self::NoTabs => write!(f, "no candidate sites on the outline"),
             Self::Deflection {
                 deflection_mm,
                 limit_mm,
@@ -164,6 +155,8 @@ pub struct Selection {
     /// Index of the load point that deflects most.
     pub worst_point: Option<usize>,
     pub violations: Vec<Violation>,
+    /// Whether every smaller set was exhaustively ruled out.
+    pub proven: bool,
 }
 
 impl Selection {
@@ -171,53 +164,42 @@ impl Selection {
         self.violations.is_empty()
     }
 
+    /// Fewer violations first, then less deflection.
     fn better_than(&self, other: &Self) -> bool {
         (self.violations.len(), self.deflection_mm) < (other.violations.len(), other.deflection_mm)
     }
 }
 
+/// Exhaustive search stops after this many tabs.
+const EXHAUSTIVE_TABS: usize = 4;
+/// Subsets the exhaustive phase may enumerate per tab count.
+const EXHAUSTIVE_BUDGET: f64 = 3.0e6;
+
 /// Fewest tabs whose worst deflection is within the limit. A greedy pass
-/// with pruning and swapping gives a feasible set and an upper bound; the
-/// exhaustive search then looks for anything smaller, up to four tabs and as
-/// long as the enumeration stays affordable. Always returns a set; check
-/// `violations`.
+/// with pruning and swapping gives a feasible set; the exhaustive search
+/// then finds the best set no larger than it, smallest count first, up to
+/// [`EXHAUSTIVE_TABS`] and while the enumeration stays within budget, which
+/// is what `proven` records. Always returns a set; check `violations`.
 pub fn select(sites: &[Site], loads: &[Point], model: &Model) -> Selection {
-    if sites.is_empty() {
-        return Selection {
-            chosen: Vec::new(),
-            deflection_mm: f64::INFINITY,
-            worst_point: None,
-            violations: vec![Violation::NoSites],
-        };
-    }
     let evaluator = Evaluator::new(sites, loads, model);
-    let n = sites.len();
-    let greedy = evaluator.greedy();
-    let bound = if greedy.satisfied() {
+    let mut greedy = evaluator.greedy();
+    let largest = if greedy.satisfied() {
         greedy.chosen.len()
     } else {
-        n.min(4) + 1
+        EXHAUSTIVE_TABS
     };
-    for k in 1..bound.min(5) {
-        if combinations(n, k) > EXHAUSTIVE_BUDGET {
-            break;
+    for k in 1..=largest.min(EXHAUSTIVE_TABS).min(sites.len()) {
+        if combinations(sites.len(), k) > EXHAUSTIVE_BUDGET {
+            return greedy;
         }
-        let mut best: Option<Selection> = None;
-        evaluator.search(k, &mut Vec::with_capacity(k), &mut |chosen| {
-            let candidate = evaluator.evaluate(chosen);
-            if candidate.satisfied() && best.as_ref().is_none_or(|b| candidate.better_than(b)) {
-                best = Some(candidate);
-            }
-        });
-        if let Some(best) = best {
+        if let Some(mut best) = evaluator.exhaustive(k) {
+            best.proven = true;
             return best;
         }
     }
+    greedy.proven = greedy.satisfied() && greedy.chosen.len() <= EXHAUSTIVE_TABS + 1;
     greedy
 }
-
-/// Subsets the exhaustive phase may enumerate per tab count.
-const EXHAUSTIVE_BUDGET: f64 = 3.0e6;
 
 fn combinations(n: usize, k: usize) -> f64 {
     (0..k).fold(1.0, |acc, i| acc * (n - i) as f64 / (i + 1) as f64)
@@ -237,6 +219,8 @@ struct Evaluator<'a> {
     rows: Vec<[f64; 3]>,
     /// Sites relative to the same centroid.
     offsets: Vec<Point>,
+    /// Distance between each pair of sites.
+    spacing: Vec<Vec<f64>>,
     /// Squared distance from each site to each load point.
     distance2: Vec<Vec<f64>>,
     /// Per site, the load points within reach, as bit words.
@@ -247,11 +231,6 @@ struct Evaluator<'a> {
 impl<'a> Evaluator<'a> {
     fn new(sites: &'a [Site], loads: &'a [Point], model: &'a Model) -> Self {
         let centroid = loads.iter().fold(Point::ZERO, |c, p| c + *p) / loads.len().max(1) as f64;
-        let rows = loads
-            .iter()
-            .map(|p| [1.0, p.x - centroid.x, p.y - centroid.y])
-            .collect();
-        let offsets = sites.iter().map(|s| s.point - centroid).collect();
         let distance2: Vec<Vec<f64>> = sites
             .iter()
             .map(|site| {
@@ -287,8 +266,15 @@ impl<'a> Evaluator<'a> {
         Self {
             sites,
             model,
-            rows,
-            offsets,
+            rows: loads
+                .iter()
+                .map(|p| [1.0, p.x - centroid.x, p.y - centroid.y])
+                .collect(),
+            offsets: sites.iter().map(|s| s.point - centroid).collect(),
+            spacing: sites
+                .iter()
+                .map(|a| sites.iter().map(|b| a.point.distance_to(b.point)).collect())
+                .collect(),
             distance2,
             within_reach,
             all_points,
@@ -304,7 +290,7 @@ impl<'a> Evaluator<'a> {
             .flat_map(|a| (a + 1..n).map(move |b| vec![a, b]))
             .map(|pair| self.evaluate(&pair))
             .reduce(|a, b| if b.better_than(&a) { b } else { a })
-            .unwrap_or_else(|| self.evaluate(&[0]));
+            .unwrap_or_else(|| self.evaluate(&(0..n).collect::<Vec<_>>()));
         while !incumbent.satisfied() {
             match self.best_neighbor(&incumbent, Move::Add) {
                 Some(better) if better.better_than(&incumbent) => incumbent = better,
@@ -329,43 +315,25 @@ impl<'a> Evaluator<'a> {
         incumbent
     }
 
-    /// The best selection one move away from `from`.
+    /// The best selection one move away from `from`. A neighbor whose running
+    /// maximum already exceeds the best one found cannot win, so its
+    /// evaluation stops there; starting from the incumbent's worst point
+    /// makes that happen early.
     fn best_neighbor(&self, from: &Selection, kind: Move) -> Option<Selection> {
         let n = self.sites.len();
+        let k = from.chosen.len();
         let unused = || (0..n).filter(|i| !from.chosen.contains(i));
-        let candidates: Vec<Vec<usize>> = match kind {
-            Move::Add => unused()
-                .map(|i| {
-                    let mut chosen = from.chosen.clone();
-                    chosen.push(i);
-                    chosen.sort_unstable();
-                    chosen
-                })
-                .collect(),
-            Move::Drop => (0..from.chosen.len())
-                .map(|k| {
-                    let mut chosen = from.chosen.clone();
-                    chosen.remove(k);
-                    chosen
-                })
-                .collect(),
-            Move::Swap => (0..from.chosen.len())
-                .flat_map(|k| {
-                    unused().map(move |i| {
-                        let mut chosen = from.chosen.clone();
-                        chosen[k] = i;
-                        chosen.sort_unstable();
-                        chosen
-                    })
-                })
+        let neighbors: Vec<Vec<usize>> = match kind {
+            Move::Add => unused().map(|i| with(&from.chosen, k, i)).collect(),
+            Move::Drop => (0..k).map(|slot| without(&from.chosen, slot)).collect(),
+            Move::Swap => (0..k)
+                .flat_map(|slot| unused().map(move |i| (slot, i)))
+                .map(|(slot, i)| with(&without(&from.chosen, slot), slot, i))
                 .collect(),
         };
-        // A neighbor whose running maximum already exceeds the best one found
-        // cannot win, so evaluation stops there; starting from the incumbent's
-        // worst point makes that happen early.
         let start = from.worst_point.unwrap_or(0);
         let mut best: Option<Selection> = None;
-        for chosen in candidates.iter().filter(|chosen| !chosen.is_empty()) {
+        for chosen in &neighbors {
             let (bound, crowded) = best.as_ref().map_or((f64::INFINITY, 0), |b| {
                 (
                     b.deflection_mm,
@@ -382,8 +350,19 @@ impl<'a> Evaluator<'a> {
         best
     }
 
-    /// Visit every `k`-subset whose tabs are separated and whose local bending
-    /// alone stays within the limit.
+    /// Best rule-satisfying `k`-subset, enumerated with separation pruning
+    /// and skipping sets whose local bending alone exceeds the limit.
+    fn exhaustive(&self, k: usize) -> Option<Selection> {
+        let mut best: Option<Selection> = None;
+        self.search(k, &mut Vec::with_capacity(k), &mut |chosen| {
+            let candidate = self.evaluate(chosen);
+            if candidate.satisfied() && best.as_ref().is_none_or(|b| candidate.better_than(b)) {
+                best = Some(candidate);
+            }
+        });
+        best
+    }
+
     fn search(&self, k: usize, chosen: &mut Vec<usize>, visit: &mut impl FnMut(&[usize])) {
         if chosen.len() == k {
             if self.all_within_reach(chosen) {
@@ -393,10 +372,10 @@ impl<'a> Evaluator<'a> {
         }
         let start = chosen.last().map_or(0, |&i| i + 1);
         for i in start..=self.sites.len() - (k - chosen.len()) {
-            let separated = chosen.iter().all(|&j| {
-                self.sites[i].point.distance_to(self.sites[j].point) >= self.model.min_separation_mm
-            });
-            if separated {
+            if chosen
+                .iter()
+                .all(|&j| self.spacing[i][j] >= self.model.min_separation_mm)
+            {
                 chosen.push(i);
                 self.search(k, chosen, visit);
                 chosen.pop();
@@ -431,21 +410,29 @@ impl<'a> Evaluator<'a> {
         crowded: usize,
     ) -> Option<Selection> {
         let model = self.model;
-        let mut violations = Vec::new();
+        let mut selection = Selection {
+            chosen: chosen.to_vec(),
+            deflection_mm: f64::INFINITY,
+            worst_point: None,
+            violations: Vec::new(),
+            proven: false,
+        };
+        let Some(compliance) = self.rigid_compliance(chosen) else {
+            selection.violations.push(Violation::NoTabs);
+            return Some(selection);
+        };
         let separation = chosen
             .iter()
             .enumerate()
-            .flat_map(|(i, &a)| chosen[i + 1..].iter().map(move |&b| (a, b)))
-            .map(|(a, b)| self.sites[a].point.distance_to(self.sites[b].point))
+            .flat_map(|(i, &a)| chosen[i + 1..].iter().map(move |&b| self.spacing[a][b]))
             .fold(f64::INFINITY, f64::min);
         if separation < model.min_separation_mm {
-            violations.push(Violation::Separation {
+            selection.violations.push(Violation::Separation {
                 distance_mm: separation,
                 minimum_mm: model.min_separation_mm,
             });
         }
-        let compliance = self.rigid_compliance(chosen);
-        let (mut worst_point, mut deflection_mm) = (None, 0.0);
+        selection.deflection_mm = 0.0;
         let count = self.rows.len();
         for j in (start..count).chain(0..start) {
             let rigid = quadratic_form(&compliance, &self.rows[j]);
@@ -454,31 +441,27 @@ impl<'a> Evaluator<'a> {
                 .map(|&i| self.distance2[i][j])
                 .fold(f64::INFINITY, f64::min);
             let d = model.load_n * (rigid + nearest2 / (BENDING_SPREAD * model.rigidity_n_mm));
-            if d > deflection_mm {
-                (worst_point, deflection_mm) = (Some(j), d);
-                if d > bound && violations.len() >= crowded {
+            if d > selection.deflection_mm {
+                (selection.worst_point, selection.deflection_mm) = (Some(j), d);
+                if d > bound && selection.violations.len() >= crowded {
                     return None;
                 }
             }
         }
-        if deflection_mm > model.deflection_limit_mm {
-            violations.push(Violation::Deflection {
-                deflection_mm,
+        if selection.deflection_mm > model.deflection_limit_mm {
+            selection.violations.push(Violation::Deflection {
+                deflection_mm: selection.deflection_mm,
                 limit_mm: model.deflection_limit_mm,
             });
         }
-        Some(Selection {
-            chosen: chosen.to_vec(),
-            deflection_mm,
-            worst_point,
-            violations,
-        })
+        Some(selection)
     }
 
     /// Inverse stiffness of the rigid plane `[w, ∂w/∂x, ∂w/∂y]` on the chosen
     /// tabs: transverse springs at each tab, bending springs on the slope
     /// along each tab's normal, twist springs on the slope along its tangent.
-    fn rigid_compliance(&self, chosen: &[usize]) -> [[f64; 3]; 3] {
+    /// `None` without tabs, when the plane is free.
+    fn rigid_compliance(&self, chosen: &[usize]) -> Option<[[f64; 3]; 3]> {
         let model = self.model;
         let mut k = [[0.0; 3]; 3];
         for &i in chosen {
@@ -497,8 +480,23 @@ impl<'a> Evaluator<'a> {
                 }
             }
         }
-        invert_symmetric(k).unwrap_or([[f64::INFINITY; 3]; 3])
+        invert_symmetric(k)
     }
+}
+
+/// `chosen` with `site` inserted at `slot`.
+fn with(chosen: &[usize], slot: usize, site: usize) -> Vec<usize> {
+    let mut next = chosen.to_vec();
+    next.insert(slot, site);
+    next.sort_unstable();
+    next
+}
+
+/// `chosen` without the entry at `slot`.
+fn without(chosen: &[usize], slot: usize) -> Vec<usize> {
+    let mut next = chosen.to_vec();
+    next.remove(slot);
+    next
 }
 
 fn quadratic_form(m: &[[f64; 3]; 3], v: &[f64; 3]) -> f64 {
@@ -525,31 +523,23 @@ fn invert_symmetric(m: [[f64; 3]; 3]) -> Option<[[f64; 3]; 3]> {
 mod tests {
     use super::*;
 
+    const FR4: Physics = Physics {
+        youngs_modulus_mpa: 22_000.0,
+        shear_modulus_mpa: 4_500.0,
+        poisson_ratio: 0.13,
+        neck_width_mm: 2.0,
+        neck_perforation_factor: 0.5,
+        rail_width_mm: 6.0,
+        load_n: 5.0,
+        deflection_limit_mm: 0.25,
+    };
+
     fn model(thickness_mm: f64) -> Model {
-        Model::new(
-            thickness_mm,
-            60.0,
-            Laminate {
-                youngs_modulus: 22_000.0,
-                shear_modulus: 4_500.0,
-                poisson_ratio: 0.13,
-            },
-            TabBeam {
-                width_mm: 2.0,
-                length_mm: 2.0,
-                perforation_factor: 0.5,
-            },
-            Rail { width_mm: 6.0 },
-            Process {
-                load_n: 5.0,
-                deflection_limit_mm: 0.25,
-            },
-            10.0,
-        )
+        Model::new(thickness_mm, 60.0, 2.0, FR4, 10.0)
     }
 
-    /// Rectangle `w` by `h` at the origin, sampled every mm, with candidate
-    /// sites every `pitch` on all four sides.
+    /// Rectangle `w` by `h` at the origin, sampled every mm along the outline,
+    /// with candidate sites every `pitch` on all four sides.
     fn rectangle(w: f64, h: f64, pitch: f64) -> (Vec<Point>, Vec<Site>) {
         let mut outline = Vec::new();
         let mut sites = Vec::new();
@@ -616,16 +606,19 @@ mod tests {
     }
 
     #[test]
-    fn one_tab_is_a_finite_but_soft_cantilever() {
+    fn no_sites_and_one_tab_are_reported_not_solved() {
         let (outline, sites) = rectangle(40.0, 20.0, 5.0);
         let m = model(1.6);
+        let none = select(&[], &outline, &m);
+        assert_eq!(none.violations, vec![Violation::NoTabs]);
+        assert!(none.chosen.is_empty() && !none.proven);
         let one = Evaluator::new(&sites, &outline, &m).evaluate(&[0]);
         assert!(one.deflection_mm.is_finite());
         assert!(one.deflection_mm > m.deflection_limit_mm);
     }
 
     #[test]
-    fn count_grows_with_board_size() {
+    fn count_grows_with_board_size_and_small_counts_are_proven() {
         let small = tabs(20.0, 10.0, 1.6);
         let medium = tabs(60.0, 30.0, 1.6);
         let long = tabs(250.0, 30.0, 1.6);
@@ -633,6 +626,7 @@ mod tests {
         assert!(small.chosen.len() <= 2, "{:?}", small.chosen);
         assert!(medium.chosen.len() >= 3);
         assert!(long.chosen.len() > medium.chosen.len());
+        assert!(small.proven && medium.proven);
     }
 
     #[test]
@@ -649,7 +643,7 @@ mod tests {
     }
 
     #[test]
-    fn opposed_pair_hinges_where_a_triangle_holds() {
+    fn pairs_hinge_where_a_triangle_holds() {
         let (outline, sites) = rectangle(60.0, 30.0, 5.0);
         let m = model(1.6);
         let evaluator = Evaluator::new(&sites, &outline, &m);

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement/select.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement/select.rs
@@ -1,0 +1,681 @@
+//! Pure tab-set selection: the fewest sites that keep a board's worst-case
+//! deflection under a process load within a limit.
+//!
+//! Two mechanisms carry a point load on a board held by tabs. The board moves
+//! as a rigid plate on its tabs, each tab a short beam between board and
+//! rail with transverse, bending and twisting stiffness from its own
+//! geometry, in series with the twist and bending of the rail it lands on;
+//! a 3x3 solve gives that motion, so one tab is a soft cantilever hinge, two
+//! collinear tabs a stiffer one, and three spread tabs rigid. And the board
+//! bends locally between the load and its nearest tab, taken as a cantilever
+//! strip whose effective width grows with the distance. Nothing here counts
+//! tabs or sides; the count follows from thickness and size. Units are N
+//! and mm.
+
+use pcb_ir::geom::Point;
+
+/// Equivalent isotropic laminate, N/mm².
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct Laminate {
+    pub youngs_modulus: f64,
+    pub shear_modulus: f64,
+    pub poisson_ratio: f64,
+}
+
+/// One tab as a beam of `width` and `length` between board and frame, with
+/// its section reduced by perforation.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct TabBeam {
+    pub width_mm: f64,
+    pub length_mm: f64,
+    pub perforation_factor: f64,
+}
+
+/// The frame rail a tab lands on: a strip of the board's thickness, held
+/// where cross rails meet it, one board span apart.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct Rail {
+    pub width_mm: f64,
+}
+
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct Process {
+    /// Point load that may act anywhere on the board, N.
+    pub load_n: f64,
+    /// Allowed deflection under that load, mm.
+    pub deflection_limit_mm: f64,
+}
+
+/// Derived stiffnesses for one board thickness and rail span.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct Model {
+    pub thickness_mm: f64,
+    /// Distance between the cross rails holding the rail a tab lands on.
+    pub rail_span_mm: f64,
+    /// Plate flexural rigidity D = E t³ / 12(1 − ν²), N·mm.
+    pub rigidity_n_mm: f64,
+    /// Stiffness against board displacement across the slot, N/mm.
+    pub tab_transverse_n_per_mm: f64,
+    /// Stiffness against board rotation about the edge: neck bending in
+    /// series with rail twist, N·mm/rad.
+    pub tab_bending_n_mm: f64,
+    /// Stiffness against board rotation about the tab axis: neck twist in
+    /// series with rail bending, N·mm/rad.
+    pub tab_twist_n_mm: f64,
+    pub load_n: f64,
+    pub deflection_limit_mm: f64,
+    /// Farthest a load may sit from any tab before local bending alone
+    /// exceeds the limit; the search prunes with it.
+    pub reach_mm: f64,
+    /// Manufacturing: closest two tabs may sit.
+    pub min_separation_mm: f64,
+}
+
+/// A point load `d` from the nearest tab bends the board like a cantilever
+/// strip about `2d` wide: F d³ / (3 D · 2d) = F d² / (6 D).
+const BENDING_SPREAD: f64 = 6.0;
+
+impl Model {
+    pub fn new(
+        thickness_mm: f64,
+        rail_span_mm: f64,
+        laminate: Laminate,
+        tab: TabBeam,
+        rail: Rail,
+        process: Process,
+        min_separation_mm: f64,
+    ) -> Self {
+        let (e, g, nu) = (
+            laminate.youngs_modulus,
+            laminate.shear_modulus,
+            laminate.poisson_ratio,
+        );
+        let (w, l, t) = (tab.width_mm, tab.length_mm, thickness_mm);
+        let f = tab.perforation_factor;
+        let neck_inertia = w * t.powi(3) / 12.0;
+        let neck_transverse = f * 12.0 * e * neck_inertia / l.powi(3);
+        let neck_bending = f * 4.0 * e * neck_inertia / l;
+        let neck_twist = f * g * torsion_constant(w, t) / l;
+        // A torque or moment applied at mid-span of a rail held at both ends.
+        let rail_twist = 4.0 * g * torsion_constant(rail.width_mm, t) / rail_span_mm;
+        let rail_bending = 12.0 * e * rail.width_mm * t.powi(3) / 12.0 / rail_span_mm;
+        let rigidity_n_mm = e * t.powi(3) / (12.0 * (1.0 - nu * nu));
+        Self {
+            thickness_mm,
+            rail_span_mm,
+            rigidity_n_mm,
+            tab_transverse_n_per_mm: neck_transverse,
+            tab_bending_n_mm: series(neck_bending, rail_twist),
+            tab_twist_n_mm: series(neck_twist, rail_bending),
+            load_n: process.load_n,
+            deflection_limit_mm: process.deflection_limit_mm,
+            reach_mm: (BENDING_SPREAD * rigidity_n_mm * process.deflection_limit_mm
+                / process.load_n)
+                .sqrt(),
+            min_separation_mm,
+        }
+    }
+}
+
+/// Saint-Venant torsion constant of a rectangular section.
+fn torsion_constant(a: f64, b: f64) -> f64 {
+    let (wide, thin) = (a.max(b), a.min(b));
+    wide * thin.powi(3) / 3.0 * (1.0 - 0.63 * thin / wide)
+}
+
+fn series(a: f64, b: f64) -> f64 {
+    a * b / (a + b)
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Site {
+    pub point: Point,
+    pub outward_normal: Point,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Violation {
+    NoSites,
+    Deflection { deflection_mm: f64, limit_mm: f64 },
+    Separation { distance_mm: f64, minimum_mm: f64 },
+}
+
+impl std::fmt::Display for Violation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NoSites => write!(f, "no candidate sites on the outline"),
+            Self::Deflection {
+                deflection_mm,
+                limit_mm,
+            } => write!(f, "deflects {deflection_mm:.2} mm, limit {limit_mm:.2}"),
+            Self::Separation {
+                distance_mm,
+                minimum_mm,
+            } => write!(f, "tabs {distance_mm:.1} mm apart, minimum {minimum_mm:.1}"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Selection {
+    pub chosen: Vec<usize>,
+    /// Worst deflection over the load points under the process load.
+    pub deflection_mm: f64,
+    /// Index of the load point that deflects most.
+    pub worst_point: Option<usize>,
+    pub violations: Vec<Violation>,
+}
+
+impl Selection {
+    pub fn satisfied(&self) -> bool {
+        self.violations.is_empty()
+    }
+
+    fn better_than(&self, other: &Self) -> bool {
+        (self.violations.len(), self.deflection_mm) < (other.violations.len(), other.deflection_mm)
+    }
+}
+
+/// Fewest tabs whose worst deflection is within the limit. A greedy pass
+/// with pruning and swapping gives a feasible set and an upper bound; the
+/// exhaustive search then looks for anything smaller, up to four tabs and as
+/// long as the enumeration stays affordable. Always returns a set; check
+/// `violations`.
+pub fn select(sites: &[Site], loads: &[Point], model: &Model) -> Selection {
+    if sites.is_empty() {
+        return Selection {
+            chosen: Vec::new(),
+            deflection_mm: f64::INFINITY,
+            worst_point: None,
+            violations: vec![Violation::NoSites],
+        };
+    }
+    let evaluator = Evaluator::new(sites, loads, model);
+    let n = sites.len();
+    let greedy = evaluator.greedy();
+    let bound = if greedy.satisfied() {
+        greedy.chosen.len()
+    } else {
+        n.min(4) + 1
+    };
+    for k in 1..bound.min(5) {
+        if combinations(n, k) > EXHAUSTIVE_BUDGET {
+            break;
+        }
+        let mut best: Option<Selection> = None;
+        evaluator.search(k, &mut Vec::with_capacity(k), &mut |chosen| {
+            let candidate = evaluator.evaluate(chosen);
+            if candidate.satisfied() && best.as_ref().is_none_or(|b| candidate.better_than(b)) {
+                best = Some(candidate);
+            }
+        });
+        if let Some(best) = best {
+            return best;
+        }
+    }
+    greedy
+}
+
+/// Subsets the exhaustive phase may enumerate per tab count.
+const EXHAUSTIVE_BUDGET: f64 = 3.0e6;
+
+fn combinations(n: usize, k: usize) -> f64 {
+    (0..k).fold(1.0, |acc, i| acc * (n - i) as f64 / (i + 1) as f64)
+}
+
+#[derive(Clone, Copy)]
+enum Move {
+    Add,
+    Drop,
+    Swap,
+}
+
+struct Evaluator<'a> {
+    sites: &'a [Site],
+    model: &'a Model,
+    /// Load points relative to their centroid, as rigid-plane rows [1, x, y].
+    rows: Vec<[f64; 3]>,
+    /// Sites relative to the same centroid.
+    offsets: Vec<Point>,
+    /// Squared distance from each site to each load point.
+    distance2: Vec<Vec<f64>>,
+    /// Per site, the load points within reach, as bit words.
+    within_reach: Vec<Vec<u64>>,
+    all_points: Vec<u64>,
+}
+
+impl<'a> Evaluator<'a> {
+    fn new(sites: &'a [Site], loads: &'a [Point], model: &'a Model) -> Self {
+        let centroid = loads.iter().fold(Point::ZERO, |c, p| c + *p) / loads.len().max(1) as f64;
+        let rows = loads
+            .iter()
+            .map(|p| [1.0, p.x - centroid.x, p.y - centroid.y])
+            .collect();
+        let offsets = sites.iter().map(|s| s.point - centroid).collect();
+        let distance2: Vec<Vec<f64>> = sites
+            .iter()
+            .map(|site| {
+                loads
+                    .iter()
+                    .map(|p| {
+                        let d = *p - site.point;
+                        d.x * d.x + d.y * d.y
+                    })
+                    .collect()
+            })
+            .collect();
+        let words = loads.len().div_ceil(64);
+        let reach2 = model.reach_mm * model.reach_mm;
+        let within_reach = distance2
+            .iter()
+            .map(|row| {
+                let mut bits = vec![0u64; words];
+                for (j, d2) in row.iter().enumerate() {
+                    if *d2 <= reach2 {
+                        bits[j / 64] |= 1 << (j % 64);
+                    }
+                }
+                bits
+            })
+            .collect();
+        let mut all_points = vec![u64::MAX; words];
+        if let Some(last) = all_points.last_mut()
+            && !loads.len().is_multiple_of(64)
+        {
+            *last = (1u64 << (loads.len() % 64)) - 1;
+        }
+        Self {
+            sites,
+            model,
+            rows,
+            offsets,
+            distance2,
+            within_reach,
+            all_points,
+        }
+    }
+
+    /// Best pair, then add whichever site helps most while adding still
+    /// helps, then drop and swap tabs while that keeps the limit and lowers
+    /// the deflection.
+    fn greedy(&self) -> Selection {
+        let n = self.sites.len();
+        let mut incumbent = (0..n)
+            .flat_map(|a| (a + 1..n).map(move |b| vec![a, b]))
+            .map(|pair| self.evaluate(&pair))
+            .reduce(|a, b| if b.better_than(&a) { b } else { a })
+            .unwrap_or_else(|| self.evaluate(&[0]));
+        while !incumbent.satisfied() {
+            match self.best_neighbor(&incumbent, Move::Add) {
+                Some(better) if better.better_than(&incumbent) => incumbent = better,
+                _ => break,
+            }
+        }
+        loop {
+            let pruned = self
+                .best_neighbor(&incumbent, Move::Drop)
+                .filter(|s| s.satisfied());
+            if let Some(pruned) = pruned {
+                incumbent = pruned;
+                continue;
+            }
+            match self.best_neighbor(&incumbent, Move::Swap) {
+                Some(swapped) if swapped.satisfied() && swapped.better_than(&incumbent) => {
+                    incumbent = swapped
+                }
+                _ => break,
+            }
+        }
+        incumbent
+    }
+
+    /// The best selection one move away from `from`.
+    fn best_neighbor(&self, from: &Selection, kind: Move) -> Option<Selection> {
+        let n = self.sites.len();
+        let unused = || (0..n).filter(|i| !from.chosen.contains(i));
+        let candidates: Vec<Vec<usize>> = match kind {
+            Move::Add => unused()
+                .map(|i| {
+                    let mut chosen = from.chosen.clone();
+                    chosen.push(i);
+                    chosen.sort_unstable();
+                    chosen
+                })
+                .collect(),
+            Move::Drop => (0..from.chosen.len())
+                .map(|k| {
+                    let mut chosen = from.chosen.clone();
+                    chosen.remove(k);
+                    chosen
+                })
+                .collect(),
+            Move::Swap => (0..from.chosen.len())
+                .flat_map(|k| {
+                    unused().map(move |i| {
+                        let mut chosen = from.chosen.clone();
+                        chosen[k] = i;
+                        chosen.sort_unstable();
+                        chosen
+                    })
+                })
+                .collect(),
+        };
+        // A neighbor whose running maximum already exceeds the best one found
+        // cannot win, so evaluation stops there; starting from the incumbent's
+        // worst point makes that happen early.
+        let start = from.worst_point.unwrap_or(0);
+        let mut best: Option<Selection> = None;
+        for chosen in candidates.iter().filter(|chosen| !chosen.is_empty()) {
+            let (bound, crowded) = best.as_ref().map_or((f64::INFINITY, 0), |b| {
+                (
+                    b.deflection_mm,
+                    b.violations.len()
+                        - usize::from(b.deflection_mm > self.model.deflection_limit_mm),
+                )
+            });
+            if let Some(candidate) = self.evaluate_bounded(chosen, start, bound, crowded)
+                && best.as_ref().is_none_or(|b| candidate.better_than(b))
+            {
+                best = Some(candidate);
+            }
+        }
+        best
+    }
+
+    /// Visit every `k`-subset whose tabs are separated and whose local bending
+    /// alone stays within the limit.
+    fn search(&self, k: usize, chosen: &mut Vec<usize>, visit: &mut impl FnMut(&[usize])) {
+        if chosen.len() == k {
+            if self.all_within_reach(chosen) {
+                visit(chosen);
+            }
+            return;
+        }
+        let start = chosen.last().map_or(0, |&i| i + 1);
+        for i in start..=self.sites.len() - (k - chosen.len()) {
+            let separated = chosen.iter().all(|&j| {
+                self.sites[i].point.distance_to(self.sites[j].point) >= self.model.min_separation_mm
+            });
+            if separated {
+                chosen.push(i);
+                self.search(k, chosen, visit);
+                chosen.pop();
+            }
+        }
+    }
+
+    fn all_within_reach(&self, chosen: &[usize]) -> bool {
+        self.all_points.iter().enumerate().all(|(w, &all)| {
+            chosen
+                .iter()
+                .fold(0u64, |acc, &i| acc | self.within_reach[i][w])
+                & all
+                == all
+        })
+    }
+
+    fn evaluate(&self, chosen: &[usize]) -> Selection {
+        self.evaluate_bounded(chosen, 0, f64::INFINITY, 0)
+            .expect("an unbounded evaluation always completes")
+    }
+
+    /// Evaluate `chosen`, scanning load points from `start`. Give up with
+    /// `None` once the deflection exceeds `bound`, unless this set has fewer
+    /// separation violations than the `crowded` count the bound came with,
+    /// since violations rank before deflection.
+    fn evaluate_bounded(
+        &self,
+        chosen: &[usize],
+        start: usize,
+        bound: f64,
+        crowded: usize,
+    ) -> Option<Selection> {
+        let model = self.model;
+        let mut violations = Vec::new();
+        let separation = chosen
+            .iter()
+            .enumerate()
+            .flat_map(|(i, &a)| chosen[i + 1..].iter().map(move |&b| (a, b)))
+            .map(|(a, b)| self.sites[a].point.distance_to(self.sites[b].point))
+            .fold(f64::INFINITY, f64::min);
+        if separation < model.min_separation_mm {
+            violations.push(Violation::Separation {
+                distance_mm: separation,
+                minimum_mm: model.min_separation_mm,
+            });
+        }
+        let compliance = self.rigid_compliance(chosen);
+        let (mut worst_point, mut deflection_mm) = (None, 0.0);
+        let count = self.rows.len();
+        for j in (start..count).chain(0..start) {
+            let rigid = quadratic_form(&compliance, &self.rows[j]);
+            let nearest2 = chosen
+                .iter()
+                .map(|&i| self.distance2[i][j])
+                .fold(f64::INFINITY, f64::min);
+            let d = model.load_n * (rigid + nearest2 / (BENDING_SPREAD * model.rigidity_n_mm));
+            if d > deflection_mm {
+                (worst_point, deflection_mm) = (Some(j), d);
+                if d > bound && violations.len() >= crowded {
+                    return None;
+                }
+            }
+        }
+        if deflection_mm > model.deflection_limit_mm {
+            violations.push(Violation::Deflection {
+                deflection_mm,
+                limit_mm: model.deflection_limit_mm,
+            });
+        }
+        Some(Selection {
+            chosen: chosen.to_vec(),
+            deflection_mm,
+            worst_point,
+            violations,
+        })
+    }
+
+    /// Inverse stiffness of the rigid plane `[w, ∂w/∂x, ∂w/∂y]` on the chosen
+    /// tabs: transverse springs at each tab, bending springs on the slope
+    /// along each tab's normal, twist springs on the slope along its tangent.
+    fn rigid_compliance(&self, chosen: &[usize]) -> [[f64; 3]; 3] {
+        let model = self.model;
+        let mut k = [[0.0; 3]; 3];
+        for &i in chosen {
+            let p = self.offsets[i];
+            let n = self.sites[i].outward_normal;
+            let t = Point::new(-n.y, n.x);
+            for (row, stiffness) in [
+                ([1.0, p.x, p.y], model.tab_transverse_n_per_mm),
+                ([0.0, n.x, n.y], model.tab_bending_n_mm),
+                ([0.0, t.x, t.y], model.tab_twist_n_mm),
+            ] {
+                for a in 0..3 {
+                    for b in 0..3 {
+                        k[a][b] += stiffness * row[a] * row[b];
+                    }
+                }
+            }
+        }
+        invert_symmetric(k).unwrap_or([[f64::INFINITY; 3]; 3])
+    }
+}
+
+fn quadratic_form(m: &[[f64; 3]; 3], v: &[f64; 3]) -> f64 {
+    (0..3)
+        .map(|a| v[a] * (0..3).map(|b| m[a][b] * v[b]).sum::<f64>())
+        .sum()
+}
+
+fn invert_symmetric(m: [[f64; 3]; 3]) -> Option<[[f64; 3]; 3]> {
+    let [[a, b, c], [_, d, e], [_, _, f]] = m;
+    let det = a * (d * f - e * e) - b * (b * f - c * e) + c * (b * e - c * d);
+    if !det.is_finite() || det.abs() <= f64::MIN_POSITIVE {
+        return None;
+    }
+    let cofactor = [
+        [d * f - e * e, c * e - b * f, b * e - c * d],
+        [c * e - b * f, a * f - c * c, b * c - a * e],
+        [b * e - c * d, b * c - a * e, a * d - b * b],
+    ];
+    Some(cofactor.map(|row| row.map(|x| x / det)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn model(thickness_mm: f64) -> Model {
+        Model::new(
+            thickness_mm,
+            60.0,
+            Laminate {
+                youngs_modulus: 22_000.0,
+                shear_modulus: 4_500.0,
+                poisson_ratio: 0.13,
+            },
+            TabBeam {
+                width_mm: 2.0,
+                length_mm: 2.0,
+                perforation_factor: 0.5,
+            },
+            Rail { width_mm: 6.0 },
+            Process {
+                load_n: 5.0,
+                deflection_limit_mm: 0.25,
+            },
+            10.0,
+        )
+    }
+
+    /// Rectangle `w` by `h` at the origin, sampled every mm, with candidate
+    /// sites every `pitch` on all four sides.
+    fn rectangle(w: f64, h: f64, pitch: f64) -> (Vec<Point>, Vec<Site>) {
+        let mut outline = Vec::new();
+        let mut sites = Vec::new();
+        let sides = [
+            (
+                Point::new(0.0, 0.0),
+                Point::new(1.0, 0.0),
+                Point::new(0.0, -1.0),
+                w,
+            ),
+            (
+                Point::new(w, 0.0),
+                Point::new(0.0, 1.0),
+                Point::new(1.0, 0.0),
+                h,
+            ),
+            (
+                Point::new(w, h),
+                Point::new(-1.0, 0.0),
+                Point::new(0.0, 1.0),
+                w,
+            ),
+            (
+                Point::new(0.0, h),
+                Point::new(0.0, -1.0),
+                Point::new(-1.0, 0.0),
+                h,
+            ),
+        ];
+        for (start, tangent, normal, length) in sides {
+            let mut s = 0.0;
+            while s < length {
+                outline.push(start + tangent * s);
+                s += 1.0;
+            }
+            let mut s = pitch / 2.0;
+            while s < length {
+                sites.push(Site {
+                    point: start + tangent * s,
+                    outward_normal: normal,
+                });
+                s += pitch;
+            }
+        }
+        (outline, sites)
+    }
+
+    fn tabs(w: f64, h: f64, thickness_mm: f64) -> Selection {
+        let (outline, sites) = rectangle(w, h, 5.0);
+        select(&sites, &outline, &model(thickness_mm))
+    }
+
+    #[test]
+    fn stiffnesses_follow_the_beam_formulas() {
+        let m = model(1.6);
+        let inertia = 2.0 * 1.6f64.powi(3) / 12.0;
+        assert!((m.tab_transverse_n_per_mm - 0.5 * 12.0 * 22_000.0 * inertia / 8.0).abs() < 1e-6);
+        // The rail's twist limits the neck's bending stiffness.
+        let neck_bending = 0.5 * 4.0 * 22_000.0 * inertia / 2.0;
+        assert!(m.tab_bending_n_mm < 0.25 * neck_bending && m.tab_bending_n_mm > 0.0);
+        assert!(m.tab_twist_n_mm > 0.0);
+        let rigidity = 22_000.0 * 1.6f64.powi(3) / (12.0 * (1.0 - 0.13 * 0.13));
+        assert!((m.rigidity_n_mm - rigidity).abs() < 1e-6);
+    }
+
+    #[test]
+    fn one_tab_is_a_finite_but_soft_cantilever() {
+        let (outline, sites) = rectangle(40.0, 20.0, 5.0);
+        let m = model(1.6);
+        let one = Evaluator::new(&sites, &outline, &m).evaluate(&[0]);
+        assert!(one.deflection_mm.is_finite());
+        assert!(one.deflection_mm > m.deflection_limit_mm);
+    }
+
+    #[test]
+    fn count_grows_with_board_size() {
+        let small = tabs(20.0, 10.0, 1.6);
+        let medium = tabs(60.0, 30.0, 1.6);
+        let long = tabs(250.0, 30.0, 1.6);
+        assert!(small.satisfied() && medium.satisfied() && long.satisfied());
+        assert!(small.chosen.len() <= 2, "{:?}", small.chosen);
+        assert!(medium.chosen.len() >= 3);
+        assert!(long.chosen.len() > medium.chosen.len());
+    }
+
+    #[test]
+    fn thinner_boards_take_more_tabs() {
+        let thick = tabs(120.0, 60.0, 1.6);
+        let thin = tabs(120.0, 60.0, 0.8);
+        assert!(thick.satisfied() && thin.satisfied());
+        assert!(
+            thin.chosen.len() > thick.chosen.len(),
+            "{} vs {}",
+            thin.chosen.len(),
+            thick.chosen.len()
+        );
+    }
+
+    #[test]
+    fn opposed_pair_hinges_where_a_triangle_holds() {
+        let (outline, sites) = rectangle(60.0, 30.0, 5.0);
+        let m = model(1.6);
+        let evaluator = Evaluator::new(&sites, &outline, &m);
+        let at = |x: f64, y: f64| {
+            sites
+                .iter()
+                .position(|s| (s.point.x - x).abs() < 1e-9 && (s.point.y - y).abs() < 1e-9)
+                .unwrap()
+        };
+        let opposed = evaluator.evaluate(&[at(32.5, 0.0), at(32.5, 30.0)]);
+        let same_edge = evaluator.evaluate(&[at(12.5, 0.0), at(47.5, 0.0)]);
+        let triangle = evaluator.evaluate(&[at(32.5, 0.0), at(2.5, 30.0), at(57.5, 30.0)]);
+        assert!(opposed.deflection_mm > 3.0 * triangle.deflection_mm);
+        assert!(same_edge.deflection_mm > 3.0 * triangle.deflection_mm);
+    }
+
+    #[test]
+    fn crowded_candidates_report_separation_instead_of_failing() {
+        let (outline, sites) = rectangle(60.0, 30.0, 5.0);
+        let crowded: Vec<_> = sites
+            .iter()
+            .copied()
+            .filter(|s| s.point.x < 12.0 && s.point.y == 0.0)
+            .collect();
+        let selection = select(&crowded, &outline, &model(1.6));
+        assert!(!selection.chosen.is_empty());
+        assert!(!selection.satisfied());
+    }
+}

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement/select.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement/select.rs
@@ -281,16 +281,18 @@ impl<'a> Evaluator<'a> {
         }
     }
 
-    /// Best pair, then add whichever site helps most while adding still
-    /// helps, then drop and swap tabs while that keeps the limit and lowers
-    /// the deflection.
+    /// Best separated pair, then add whichever site helps most while adding
+    /// still helps, then drop and swap tabs while that keeps the limit and
+    /// lowers the deflection. Moves only ever offer sites clear of the tabs
+    /// kept, so a separation violation never has to be repaired.
     fn greedy(&self) -> Selection {
         let n = self.sites.len();
         let mut incumbent = (0..n)
             .flat_map(|a| (a + 1..n).map(move |b| vec![a, b]))
+            .filter(|pair| self.clear(pair[0], &pair[1..]))
             .map(|pair| self.evaluate(&pair))
             .reduce(|a, b| if b.better_than(&a) { b } else { a })
-            .unwrap_or_else(|| self.evaluate(&(0..n).collect::<Vec<_>>()));
+            .unwrap_or_else(|| self.evaluate(&[]));
         while !incumbent.satisfied() {
             match self.best_neighbor(&incumbent, Move::Add) {
                 Some(better) if better.better_than(&incumbent) => incumbent = better,
@@ -315,6 +317,12 @@ impl<'a> Evaluator<'a> {
         incumbent
     }
 
+    /// Whether `site` is unused by and separated from every tab in `kept`.
+    fn clear(&self, site: usize, kept: &[usize]) -> bool {
+        kept.iter()
+            .all(|&j| j != site && self.spacing[site][j] >= self.model.min_separation_mm)
+    }
+
     /// The best selection one move away from `from`. A neighbor whose running
     /// maximum already exceeds the best one found cannot win, so its
     /// evaluation stops there; starting from the incumbent's worst point
@@ -322,26 +330,27 @@ impl<'a> Evaluator<'a> {
     fn best_neighbor(&self, from: &Selection, kind: Move) -> Option<Selection> {
         let n = self.sites.len();
         let k = from.chosen.len();
-        let unused = || (0..n).filter(|i| !from.chosen.contains(i));
         let neighbors: Vec<Vec<usize>> = match kind {
-            Move::Add => unused().map(|i| with(&from.chosen, k, i)).collect(),
+            Move::Add => (0..n)
+                .filter(|&i| self.clear(i, &from.chosen))
+                .map(|i| with(&from.chosen, k, i))
+                .collect(),
             Move::Drop => (0..k).map(|slot| without(&from.chosen, slot)).collect(),
             Move::Swap => (0..k)
-                .flat_map(|slot| unused().map(move |i| (slot, i)))
-                .map(|(slot, i)| with(&without(&from.chosen, slot), slot, i))
+                .flat_map(|slot| {
+                    let kept = without(&from.chosen, slot);
+                    (0..n)
+                        .filter(|&i| self.clear(i, &kept))
+                        .map(|i| with(&kept, slot, i))
+                        .collect::<Vec<_>>()
+                })
                 .collect(),
         };
         let start = from.worst_point.unwrap_or(0);
         let mut best: Option<Selection> = None;
         for chosen in &neighbors {
-            let (bound, crowded) = best.as_ref().map_or((f64::INFINITY, 0), |b| {
-                (
-                    b.deflection_mm,
-                    b.violations.len()
-                        - usize::from(b.deflection_mm > self.model.deflection_limit_mm),
-                )
-            });
-            if let Some(candidate) = self.evaluate_bounded(chosen, start, bound, crowded)
+            let bound = best.as_ref().map_or(f64::INFINITY, |b| b.deflection_mm);
+            if let Some(candidate) = self.evaluate_bounded(chosen, start, bound)
                 && best.as_ref().is_none_or(|b| candidate.better_than(b))
             {
                 best = Some(candidate);
@@ -372,10 +381,7 @@ impl<'a> Evaluator<'a> {
         }
         let start = chosen.last().map_or(0, |&i| i + 1);
         for i in start..=self.sites.len() - (k - chosen.len()) {
-            if chosen
-                .iter()
-                .all(|&j| self.spacing[i][j] >= self.model.min_separation_mm)
-            {
+            if self.clear(i, chosen) {
                 chosen.push(i);
                 self.search(k, chosen, visit);
                 chosen.pop();
@@ -394,21 +400,15 @@ impl<'a> Evaluator<'a> {
     }
 
     fn evaluate(&self, chosen: &[usize]) -> Selection {
-        self.evaluate_bounded(chosen, 0, f64::INFINITY, 0)
+        self.evaluate_bounded(chosen, 0, f64::INFINITY)
             .expect("an unbounded evaluation always completes")
     }
 
-    /// Evaluate `chosen`, scanning load points from `start`. Give up with
-    /// `None` once the deflection exceeds `bound`, unless this set has fewer
-    /// separation violations than the `crowded` count the bound came with,
-    /// since violations rank before deflection.
-    fn evaluate_bounded(
-        &self,
-        chosen: &[usize],
-        start: usize,
-        bound: f64,
-        crowded: usize,
-    ) -> Option<Selection> {
+    /// Evaluate `chosen`, scanning load points from `start`, and give up with
+    /// `None` once the deflection exceeds `bound`. Callers compare sets with
+    /// the same separation state, so a larger deflection can never rank
+    /// better.
+    fn evaluate_bounded(&self, chosen: &[usize], start: usize, bound: f64) -> Option<Selection> {
         let model = self.model;
         let mut selection = Selection {
             chosen: chosen.to_vec(),
@@ -443,7 +443,7 @@ impl<'a> Evaluator<'a> {
             let d = model.load_n * (rigid + nearest2 / (BENDING_SPREAD * model.rigidity_n_mm));
             if d > selection.deflection_mm {
                 (selection.worst_point, selection.deflection_mm) = (Some(j), d);
-                if d > bound && selection.violations.len() >= crowded {
+                if d > bound {
                     return None;
                 }
             }
@@ -658,6 +658,20 @@ mod tests {
         let triangle = evaluator.evaluate(&[at(32.5, 0.0), at(2.5, 30.0), at(57.5, 30.0)]);
         assert!(opposed.deflection_mm > 3.0 * triangle.deflection_mm);
         assert!(same_edge.deflection_mm > 3.0 * triangle.deflection_mm);
+    }
+
+    #[test]
+    fn dense_candidates_still_yield_a_separated_set() {
+        let (outline, sites) = rectangle(250.0, 30.0, 2.5);
+        let m = model(1.6);
+        let selection = select(&sites, &outline, &m);
+        assert!(selection.satisfied(), "{:?}", selection.violations);
+        assert!(selection.chosen.len() > 4);
+        for (i, &a) in selection.chosen.iter().enumerate() {
+            for &b in &selection.chosen[i + 1..] {
+                assert!(sites[a].point.distance_to(sites[b].point) >= m.min_separation_mm);
+            }
+        }
     }
 
     #[test]

--- a/crates/pcb-ir/src/geom/path.rs
+++ b/crates/pcb-ir/src/geom/path.rs
@@ -320,6 +320,30 @@ impl Segment {
         }
     }
 
+    /// Command continuing a path from this segment's start (or end when reversed).
+    /// Reversal preserves curves, changing arc direction and cubic control order.
+    pub fn to_path_cmd(self, reverse: bool) -> PathCmd {
+        let end = if reverse { self.start() } else { self.end() };
+        match self {
+            Self::Line { .. } => PathCmd::line_to(end),
+            Self::Arc(arc) => PathCmd::arc_to(end, arc.center, arc.clockwise ^ reverse),
+            Self::Ellipse(arc) => PathCmd::ellipse_to(
+                end,
+                arc.center,
+                arc.x_axis,
+                arc.y_axis,
+                arc.clockwise ^ reverse,
+            ),
+            Self::Cubic { c1, c2, .. } => {
+                if reverse {
+                    PathCmd::cubic_to(c2, c1, end)
+                } else {
+                    PathCmd::cubic_to(c1, c2, end)
+                }
+            }
+        }
+    }
+
     pub fn bbox(&self) -> BBox {
         match *self {
             Self::Line { start, end } => {
@@ -735,16 +759,7 @@ fn contour_from_segments(segments: &[Segment]) -> Option<ContourBuf> {
             current = segment.start();
             cmds.push(PathCmd::move_to(current));
         }
-        match *segment {
-            Segment::Line { end, .. } => cmds.push(PathCmd::line_to(end)),
-            Segment::Arc(arc) => {
-                cmds.push(PathCmd::arc_to(arc.end, arc.center, arc.clockwise));
-            }
-            Segment::Ellipse(arc) => cmds.push(PathCmd::from_elliptical_arc(arc)),
-            Segment::Cubic { c1, c2, end, .. } => {
-                cmds.push(PathCmd::cubic_to(c1, c2, end));
-            }
-        }
+        cmds.push(segment.to_path_cmd(false));
         current = segment.end();
     }
     Some(ContourBuf::new(cmds))
@@ -989,6 +1004,48 @@ pub(crate) fn ir_point(point: kurbo::Point) -> Point {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn segment_commands_preserve_forward_and_reversed_curves() {
+        for command in [
+            PathCmd::line_to(Point::new(-2.0, 1.0)),
+            PathCmd::arc_to(Point::new(0.0, 3.0), Point::ZERO, false),
+            PathCmd::ellipse_to(
+                Point::new(0.0, 1.0),
+                Point::ZERO,
+                Point::new(3.0, 0.0),
+                Point::new(0.0, 1.0),
+                false,
+            ),
+            PathCmd::cubic_to(
+                Point::new(2.0, 4.0),
+                Point::new(-1.0, 2.0),
+                Point::new(4.0, -2.0),
+            ),
+        ] {
+            let source = ContourBuf::new(vec![PathCmd::move_to(Point::new(3.0, 0.0)), command]);
+            let segment = source.segments().next().unwrap();
+            for reverse in [false, true] {
+                let rebuilt = ContourBuf::new(vec![
+                    PathCmd::move_to(if reverse {
+                        segment.end()
+                    } else {
+                        segment.start()
+                    }),
+                    segment.to_path_cmd(reverse),
+                ]);
+                let rebuilt = rebuilt.segments().next().unwrap();
+                for t in [0.0, 0.17, 0.63, 1.0] {
+                    assert!(
+                        rebuilt
+                            .point_at(t)
+                            .distance_to(segment.point_at(if reverse { 1.0 - t } else { t }))
+                            < 1e-12
+                    );
+                }
+            }
+        }
+    }
 
     #[test]
     fn closed_arc_continuations_match_explicit_moves_through_preparation() {

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -261,6 +261,9 @@ enum BoardArrayCommands {
         /// Analyze outline eligibility only: writes JSON, NOT a mouse-bite panel.
         #[arg(long, requires_all = ["mouse_bite_width", "mouse_bite_inward", "mouse_bite_outward", "mouse_bite_clearance"], conflicts_with_all = ["auto", "sheet", "columns", "rows", "board_margin", "edge_rail", "copper_balance", "no_copper_balance"])]
         mouse_bite: bool,
+        /// Choose mouse-bite tab sites with the built-in preset: writes JSON, NOT a panel.
+        #[arg(long, conflicts_with_all = ["mouse_bite", "auto", "sheet", "columns", "rows", "board_margin", "edge_rail", "copper_balance", "no_copper_balance"])]
+        mouse_bite_placement: bool,
         /// Analysis band width along the cyclic outline, in mm; no manufacturing default.
         #[arg(long, requires = "mouse_bite")]
         mouse_bite_width: Option<f64>,
@@ -475,6 +478,7 @@ pub fn execute(args: Ipc2581Args, resolution: Resolution) -> anyhow::Result<()> 
             BoardArrayCommands::Create {
                 input,
                 mouse_bite,
+                mouse_bite_placement,
                 mouse_bite_width,
                 mouse_bite_inward,
                 mouse_bite_outward,
@@ -488,6 +492,9 @@ pub fn execute(args: Ipc2581Args, resolution: Resolution) -> anyhow::Result<()> 
                 copper_balance,
                 output,
             } => {
+                if mouse_bite_placement {
+                    return commands::board_array::placement::execute(&input, &output, resolution);
+                }
                 if mouse_bite {
                     return commands::board_array::eligibility::execute(
                         &input,
@@ -719,6 +726,14 @@ mod tests {
             crate::Cli::try_parse_from(base.into_iter().chain(["--mouse-bite-width", "2"]))
                 .is_err()
         );
+        let placement = ["--mouse-bite-placement"];
+        assert!(crate::Cli::try_parse_from(base.into_iter().chain(placement)).is_ok());
+        for conflicting in [vec!["--auto"], vec!["--mouse-bite"], vec!["--columns", "2"]] {
+            assert!(
+                crate::Cli::try_parse_from(base.into_iter().chain(placement).chain(conflicting))
+                    .is_err()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Add `--mouse-bite-placement` to `board-array create`, which chooses the fewest tab sites that keep a board within a deflection limit under a process load and reports them as JSON. Also ignore footprints without courtyards in mouse-bite eligibility and reject unusable ones.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1269" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Eligibility semantics changed (missing courtyards no longer block outline intervals), and new placement heuristics could disagree with manufacturing expectations despite being analysis-only.
> 
> **Overview**
> Adds **`--mouse-bite-placement`** to `board-array create`, which runs analysis-only tab placement and writes JSON (candidates, rejections, selected sites, deflection checks)—it does **not** emit a panel.
> 
> New **`placement`** pipeline reuses outline eligibility via **`prepare()`**, then scores tab sites along **Eligible** outline runs (corner/bend limits, slot/frame landing, obstacle strips) and picks a minimal tab set with a beam/plate stiffness model in **`placement/select`**.
> 
> **Mouse-bite eligibility** changes: footprints **without** courtyard evidence are **ignored** and listed in **`ignored_footprints`** instead of creating unknown obstruction evidence; **gapped or unusable** courtyards **error**. Courtyard joining tolerates fully enclosed open fragments; **`Segment::to_path_cmd`** supports reversed curve joins in **`pcb-ir`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8127fb250e7aeda1d6d1182d50582bb9681e02fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->