### PR TITLE
Route mouse-bite panels from board-array create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Add `--mouse-bite` to `board-array create` to route boards out with perforated tabs instead of V-scores.
 - Add `--mouse-bite-placement` to `board-array create` to report where breakaway tabs would go on a board.
 
 ### Changed

--- a/crates/ipc2581/src/write.rs
+++ b/crates/ipc2581/src/write.rs
@@ -198,8 +198,21 @@ pub fn hole(writer: &mut XmlWriter, units: Units, hole: &Hole, name: &str) {
 }
 
 pub fn profile(writer: &mut XmlWriter, units: Units, polygon: &Polygon) {
+    profile_with_cutouts(writer, units, polygon, &[]);
+}
+
+/// Write a step profile whose material has `cutouts` removed from it.
+pub fn profile_with_cutouts(
+    writer: &mut XmlWriter,
+    units: Units,
+    polygon: &Polygon,
+    cutouts: &[Polygon],
+) {
     writer.start_element("Profile", &[]);
     self::polygon(writer, units, polygon);
+    for cutout in cutouts {
+        polygon_element(writer, "Cutout", units, cutout);
+    }
     writer.end_element("Profile");
 }
 

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/eligibility.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/eligibility.rs
@@ -50,11 +50,14 @@ pub fn analyze(
     exclusions: &[OutlineObstacle<'_>],
     resolution: Resolution,
 ) -> Result<Value> {
-    Ok(prepare(xml, footprint, clearance_mm, exclusions, resolution)?.report)
+    let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
+    let mut report = prepare(&ipc, footprint, clearance_mm, exclusions, resolution)?.report;
+    report["source_xml_sha256"] = json!(hex::encode(Sha256::digest(xml.as_bytes())));
+    Ok(report)
 }
 
 pub(super) fn prepare(
-    xml: &str,
+    ipc: &Ipc2581,
     footprint: OutlineFootprint,
     clearance_mm: f64,
     exclusions: &[OutlineObstacle<'_>],
@@ -63,16 +66,15 @@ pub(super) fn prepare(
     if !clearance_mm.is_finite() || clearance_mm < 0.0 {
         bail!("clearance must be finite and nonnegative");
     }
-    let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
-    validate_courtyard_references(&ipc)?;
-    let thickness_mm = crate::accessors::IpcAccessor::new(&ipc)
+    validate_courtyard_references(ipc)?;
+    let thickness_mm = crate::accessors::IpcAccessor::new(ipc)
         .stackup_details()
         .and_then(|stackup| stackup.overall_thickness_mm)
         .filter(|t| t.is_finite() && *t > 0.0);
     // Keep small substrate cutouts and courtyard regions; accuracy remains the
     // caller's existing geometry budget (--accuracy-um in the CLI).
     let resolution = resolution.strict();
-    let imported = import_design(&ipc, resolution)?;
+    let imported = import_design(ipc, resolution)?;
     let doc = &imported.geometry;
     // Both BoardOutlines and ArtworkScope::Board must select the same board.
     // Do not resolve mixed-board panels in this analysis-only phase.
@@ -133,7 +135,6 @@ pub(super) fn prepare(
         "phase": "outline-eligibility-only",
         "manufacturing_ready": false,
         "scope": "canonical-board",
-        "source_xml_sha256": hex::encode(Sha256::digest(xml.as_bytes())),
         "units": "mm",
         "ignored_footprints": ignored_footprints,
         "policy": {
@@ -479,27 +480,6 @@ fn closed_component(mut segments: Vec<Segment>, uncertainty: f64) -> Result<Cont
     }
     cmds.push(PathCmd::close());
     Ok(ContourBuf::new(cmds).with_uncertainty(uncertainty))
-}
-
-#[cfg(feature = "cli")]
-pub fn execute(
-    input: &std::path::Path,
-    output: &std::path::Path,
-    footprint: OutlineFootprint,
-    clearance_mm: f64,
-    resolution: Resolution,
-) -> Result<()> {
-    let xml = crate::utils::file::load_ipc_file(input)?;
-    let report = analyze(&xml, footprint, clearance_mm, &[], resolution)?;
-    let mut json = serde_json::to_vec_pretty(&report)?;
-    json.push(b'\n');
-    if output.as_os_str() == "-" {
-        pcb_ui::write_stdout(|stdout| stdout.write_all(&json))?;
-    } else {
-        std::fs::write(output, json)?;
-    }
-    anstream::eprintln!("Outline eligibility analysis only; no mouse-bite panel generated.");
-    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -1,9 +1,10 @@
-use pcb_ir::geom::Resolution;
+use pcb_ir::geom::{ContourSet, FillRule, Resolution};
 use std::collections::HashSet;
 #[cfg(feature = "cli")]
 use std::path::Path;
 
 pub mod eligibility;
+pub mod mouse_bite;
 pub mod placement;
 
 use super::board_array_auto::{
@@ -190,6 +191,33 @@ pub struct BoardArrayCreateOptions {
     pub edge_rail_mm: BoardMarginMm,
 }
 
+/// How boards separate from the array: scored lines, or routed slots bridged
+/// by perforated tabs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Separation {
+    VScore,
+    MouseBite,
+}
+
+impl Separation {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::VScore => "v-score",
+            Self::MouseBite => "mouse-bite",
+        }
+    }
+
+    /// The cell a board occupies in the array: its outline, plus the routed
+    /// slot around it when boards are routed out, so margins, rails and
+    /// tooling keep their distances from the slot rather than the board.
+    fn cell(self, board: pcb_ir::geom::BBox) -> pcb_ir::geom::BBox {
+        match self {
+            Self::VScore => board,
+            Self::MouseBite => board.expand(placement::PRESET.routing_gap_mm),
+        }
+    }
+}
+
 /// Generated board-array IPC plus optional per-layer copper-balance accounting.
 #[derive(Debug, Clone)]
 pub struct BoardArrayCreation {
@@ -239,7 +267,11 @@ struct BoardArraySpec {
     array_name: String,
     board_cell_name: String,
     board_name: String,
-    vcut_spec_name: String,
+    vcut_spec_name: Option<String>,
+    /// Routed material in the array profile; empty for scored arrays.
+    profile_cutouts: Vec<Polygon>,
+    separation: Separation,
+    tabs_per_board: usize,
     board_outline_layer_names: Vec<String>,
     content_step_refs: Vec<String>,
     content_layer_refs: Vec<String>,
@@ -414,10 +446,11 @@ pub fn execute(
     output: &Path,
     options: &BoardArrayCreateOptions,
     balance_copper: bool,
+    separation: Separation,
     resolution: Resolution,
 ) -> Result<()> {
     let content = file_utils::load_ipc_file(input)?;
-    let creation = create_board_array(&content, options, balance_copper, resolution)?;
+    let creation = create_board_array(&content, options, balance_copper, separation, resolution)?;
     print_copper_balance_summary(creation.copper_balance.as_ref());
     write_board_array_output(output, &creation.xml)?;
     Ok(())
@@ -429,10 +462,12 @@ pub fn execute_auto(
     output: &Path,
     sheet: Option<AutoSheetSize>,
     balance_copper: bool,
+    separation: Separation,
     resolution: Resolution,
 ) -> Result<()> {
     let content = file_utils::load_ipc_file(input)?;
-    let creation = create_auto_board_array(&content, sheet, balance_copper, resolution)?;
+    let creation =
+        create_auto_board_array(&content, sheet, balance_copper, separation, resolution)?;
     print_copper_balance_summary(creation.copper_balance.as_ref());
     write_board_array_output(output, &creation.xml)?;
     Ok(())
@@ -465,6 +500,7 @@ pub fn create_board_array(
     xml: &str,
     options: &BoardArrayCreateOptions,
     balance_copper: bool,
+    separation: Separation,
     resolution: Resolution,
 ) -> Result<BoardArrayCreation> {
     let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
@@ -477,6 +513,8 @@ pub fn create_board_array(
             sheet: None,
             sheet_target_mm: None,
         },
+        separation,
+        resolution,
     )?;
     write_board_array_creation(xml, spec, balance_copper, resolution)
 }
@@ -489,7 +527,7 @@ pub fn create_board_array(
 fn create_board_array_xml(xml: &str, options: &BoardArrayCreateOptions) -> Result<String> {
     let resolution = Resolution::default();
 
-    Ok(create_board_array(xml, options, false, resolution)?.xml)
+    Ok(create_board_array(xml, options, false, Separation::VScore, resolution)?.xml)
 }
 
 #[cfg(test)]
@@ -502,12 +540,20 @@ pub fn create_auto_board_array(
     xml: &str,
     sheet: Option<AutoSheetSize>,
     balance_copper: bool,
+    separation: Separation,
     resolution: Resolution,
 ) -> Result<BoardArrayCreation> {
     let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
     let (options, validation_mode, panelization) =
-        auto_board_array_options(&ipc, sheet, resolution)?;
-    let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization)?;
+        auto_board_array_options(&ipc, sheet, separation, resolution)?;
+    let spec = build_board_array_spec(
+        &ipc,
+        &options,
+        validation_mode,
+        panelization,
+        separation,
+        resolution,
+    )?;
     write_board_array_creation(xml, spec, balance_copper, resolution)
 }
 
@@ -518,12 +564,13 @@ fn create_auto_board_array_xml_with_sheet(
 ) -> Result<String> {
     let resolution = Resolution::default();
 
-    Ok(create_auto_board_array(xml, sheet, false, resolution)?.xml)
+    Ok(create_auto_board_array(xml, sheet, false, Separation::VScore, resolution)?.xml)
 }
 
 fn auto_board_array_options(
     ipc: &Ipc2581,
     sheet: Option<AutoSheetSize>,
+    separation: Separation,
     resolution: Resolution,
 ) -> Result<(
     BoardArrayCreateOptions,
@@ -531,9 +578,10 @@ fn auto_board_array_options(
     BoardArrayPanelizationMetadata,
 )> {
     let board = primary_board_layout(ipc)?;
-    let board_margin = auto_board_margin(ipc, board.bbox, resolution)?;
-    let board_width = board.bbox.width();
-    let board_height = board.bbox.height();
+    let cell = separation.cell(board.bbox);
+    let board_margin = auto_board_margin(ipc, cell, resolution)?;
+    let board_width = cell.width();
+    let board_height = cell.height();
 
     let plan = match sheet {
         Some(sheet) => Some((
@@ -727,6 +775,8 @@ fn build_board_array_spec(
     options: &BoardArrayCreateOptions,
     validation_mode: BoardArrayValidationMode,
     panelization: BoardArrayPanelizationMetadata,
+    separation: Separation,
+    resolution: Resolution,
 ) -> Result<BoardArraySpec> {
     validate_options(options, validation_mode)?;
 
@@ -744,8 +794,9 @@ fn build_board_array_spec(
     }
 
     let root = primary_board_layout(ipc)?;
-    let board_width = root.bbox.width();
-    let board_height = root.bbox.height();
+    let cell = separation.cell(root.bbox);
+    let board_width = cell.width();
+    let board_height = cell.height();
 
     let columns = options.columns;
     let rows = options.rows;
@@ -764,8 +815,8 @@ fn build_board_array_spec(
         + edge_rail.bottom
         + edge_rail.top;
     validate_array_dimensions(array_width, array_height, validation_mode)?;
-    let board_repeat_x = board_margin.left - root.bbox.min.x;
-    let board_repeat_y = board_margin.bottom - root.bbox.min.y;
+    let board_repeat_x = board_margin.left - cell.min.x;
+    let board_repeat_y = board_margin.bottom - cell.min.y;
 
     let board_name = ipc.resolve(root.source_step_ref).to_string();
     let existing_step_names = ecad
@@ -784,7 +835,6 @@ fn build_board_array_spec(
         .keys()
         .map(|name| ipc.resolve(*name).to_string())
         .collect::<HashSet<_>>();
-    let vcut_spec_name = unique_name(&existing_spec_names, VCUT_SPEC_BASE_NAME);
     let mut used_layer_names = ecad
         .cad_data
         .layers
@@ -792,24 +842,65 @@ fn build_board_array_spec(
         .map(|layer| ipc.resolve(layer.name).to_string())
         .collect::<HashSet<_>>();
     let mut generated_geometry = BoardArrayGeneratedGeometry::default();
-    add_vcut_lines(
-        &mut generated_geometry,
-        &mut used_layer_names,
-        vcut_spec_name.clone(),
-        array_width,
-        vcut_lines(VcutLineSpec {
-            columns,
-            rows,
-            board_width_mm: board_width,
-            board_height_mm: board_height,
-            margin_x_mm: margin_x,
-            margin_y_mm: margin_y,
-            pitch_x_mm: pitch_x,
-            pitch_y_mm: pitch_y,
-            array_width_mm: array_width,
-            array_height_mm: array_height,
-        })?,
-    );
+    let vcut_spec_name = (separation == Separation::VScore)
+        .then(|| unique_name(&existing_spec_names, VCUT_SPEC_BASE_NAME));
+    if let Some(vcut_spec_name) = &vcut_spec_name {
+        add_vcut_lines(
+            &mut generated_geometry,
+            &mut used_layer_names,
+            vcut_spec_name.clone(),
+            array_width,
+            vcut_lines(VcutLineSpec {
+                columns,
+                rows,
+                board_width_mm: board_width,
+                board_height_mm: board_height,
+                margin_x_mm: margin_x,
+                margin_y_mm: margin_y,
+                pitch_x_mm: pitch_x,
+                pitch_y_mm: pitch_y,
+                array_width_mm: array_width,
+                array_height_mm: array_height,
+            })?,
+        );
+    }
+    let (profile_cutouts, tabs_per_board) = match separation {
+        Separation::VScore => (Vec::new(), 0),
+        Separation::MouseBite => {
+            let preset = &placement::PRESET;
+            let placement = placement::place(ipc, preset, resolution)?;
+            let stock = array_stock(array_width, array_height, resolution)?;
+            let offsets = (0..rows)
+                .flat_map(|row| {
+                    (0..columns).map(move |column| {
+                        pcb_ir::geom::Point::new(
+                            edge_rail.left + board_repeat_x + f64::from(column) * pitch_x,
+                            edge_rail.bottom + board_repeat_y + f64::from(row) * pitch_y,
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            let tabs = mouse_bite::generate(&placement, &stock, &offsets, preset, resolution)?;
+            let layer =
+                ensure_tooling_hole_layer_name(&mut generated_geometry, &mut used_layer_names);
+            generated_geometry.add_layer_feature(
+                GeneratedFeatureScope::Array,
+                layer,
+                Polarity::Positive,
+                round_nonplated_hole_features(
+                    tabs.holes.iter().map(|hole| (hole.center.x, hole.center.y)),
+                    pcb_ir::geom::mouse_bite::SparkFunShallow::HOLE_DIAMETER_MM,
+                ),
+            );
+            (
+                tabs.cutouts
+                    .iter()
+                    .map(mouse_bite::cutout_polygon)
+                    .collect::<Result<Vec<_>>>()?,
+                tabs.per_board,
+            )
+        }
+    };
     add_board_array_corner_tooling(
         &mut generated_geometry,
         &mut used_layer_names,
@@ -863,6 +954,9 @@ fn build_board_array_spec(
         board_cell_name,
         board_name,
         vcut_spec_name,
+        profile_cutouts,
+        separation,
+        tabs_per_board,
         board_outline_layer_names,
         content_step_refs,
         content_layer_refs,
@@ -882,6 +976,25 @@ fn build_board_array_spec(
         generated_geometry,
         units: ecad.cad_header.units,
     })
+}
+
+/// The array's stock: its rounded outline with the corner at the origin.
+fn array_stock(width_mm: f64, height_mm: f64, resolution: Resolution) -> Result<ContourSet> {
+    let outline = pcb_ir::geom::shapes::rounded_rect(
+        width_mm,
+        height_mm,
+        ARRAY_CORNER_RADIUS_MM,
+        pcb_ir::geom::shapes::ALL_CORNERS,
+    )
+    .context("invalid array dimensions")?;
+    let centered = ContourSet::from_contours(&[outline], FillRule::EvenOdd, resolution.strict())?;
+    Ok(pcb_ir::geom::attachment::transform_region(
+        &centered,
+        pcb_ir::geom::Affine2::translation(pcb_ir::geom::Point::new(
+            width_mm / 2.0,
+            height_mm / 2.0,
+        )),
+    )?)
 }
 
 fn validate_options(

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -206,16 +206,6 @@ impl Separation {
             Self::MouseBite => "mouse-bite",
         }
     }
-
-    /// The cell a board occupies in the array: its outline, grown a little
-    /// when boards are routed out so the slot takes only part of the margin's
-    /// clearance from the fiducials, rails and tooling.
-    fn cell(self, board: pcb_ir::geom::BBox) -> pcb_ir::geom::BBox {
-        match self {
-            Self::VScore => board,
-            Self::MouseBite => board.expand(placement::PRESET.cell_growth_mm),
-        }
-    }
 }
 
 /// Generated board-array IPC plus optional per-layer copper-balance accounting.
@@ -545,7 +535,7 @@ pub fn create_auto_board_array(
 ) -> Result<BoardArrayCreation> {
     let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
     let (options, validation_mode, panelization) =
-        auto_board_array_options(&ipc, sheet, separation, resolution)?;
+        auto_board_array_options(&ipc, sheet, resolution)?;
     let spec = build_board_array_spec(
         &ipc,
         &options,
@@ -570,7 +560,6 @@ fn create_auto_board_array_xml_with_sheet(
 fn auto_board_array_options(
     ipc: &Ipc2581,
     sheet: Option<AutoSheetSize>,
-    separation: Separation,
     resolution: Resolution,
 ) -> Result<(
     BoardArrayCreateOptions,
@@ -578,10 +567,9 @@ fn auto_board_array_options(
     BoardArrayPanelizationMetadata,
 )> {
     let board = primary_board_layout(ipc)?;
-    let cell = separation.cell(board.bbox);
-    let board_margin = auto_board_margin(ipc, cell, resolution)?;
-    let board_width = cell.width();
-    let board_height = cell.height();
+    let board_margin = auto_board_margin(ipc, board.bbox, resolution)?;
+    let board_width = board.bbox.width();
+    let board_height = board.bbox.height();
 
     let plan = match sheet {
         Some(sheet) => Some((
@@ -794,9 +782,8 @@ fn build_board_array_spec(
     }
 
     let root = primary_board_layout(ipc)?;
-    let cell = separation.cell(root.bbox);
-    let board_width = cell.width();
-    let board_height = cell.height();
+    let board_width = root.bbox.width();
+    let board_height = root.bbox.height();
 
     let columns = options.columns;
     let rows = options.rows;
@@ -815,8 +802,8 @@ fn build_board_array_spec(
         + edge_rail.bottom
         + edge_rail.top;
     validate_array_dimensions(array_width, array_height, validation_mode)?;
-    let board_repeat_x = board_margin.left - cell.min.x;
-    let board_repeat_y = board_margin.bottom - cell.min.y;
+    let board_repeat_x = board_margin.left - root.bbox.min.x;
+    let board_repeat_y = board_margin.bottom - root.bbox.min.y;
 
     let board_name = ipc.resolve(root.source_step_ref).to_string();
     let existing_step_names = ecad

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mod.rs
@@ -207,13 +207,13 @@ impl Separation {
         }
     }
 
-    /// The cell a board occupies in the array: its outline, plus the routed
-    /// slot around it when boards are routed out, so margins, rails and
-    /// tooling keep their distances from the slot rather than the board.
+    /// The cell a board occupies in the array: its outline, grown a little
+    /// when boards are routed out so the slot takes only part of the margin's
+    /// clearance from the fiducials, rails and tooling.
     fn cell(self, board: pcb_ir::geom::BBox) -> pcb_ir::geom::BBox {
         match self {
             Self::VScore => board,
-            Self::MouseBite => board.expand(placement::PRESET.routing_gap_mm),
+            Self::MouseBite => board.expand(placement::PRESET.cell_growth_mm),
         }
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mouse_bite.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mouse_bite.rs
@@ -1,0 +1,320 @@
+//! Routed slots and perforated tabs for a board array: the material the
+//! router removes around every board instance, the tabs left bridging each
+//! slot, and their break holes. Pure geometry in panel coordinates; the
+//! array spec turns the removal into profile cutouts and the holes into
+//! non-plated drills.
+//!
+//! Each tab comes from the single-tab builder in pcb-ir, given the board
+//! instance, the frame around it and a local window of stock. A board's
+//! removal is its slot minus every tab footprint on it, so tabs never erase
+//! one another; the holes are the builder's. The retained panel is then
+//! checked as a whole: every board connected to the frame before the break
+//! rows are cut, every board free of the frame and of each other after.
+
+use std::collections::HashSet;
+
+use anyhow::{Context, Result, bail, ensure};
+use ipc2581::types::Polygon;
+use pcb_ir::geom::{
+    Affine2, ContourBuf, ContourSet, LineCap, LineJoin, Point, Resolution, StrokeToFillStyle,
+    attachment::{BoundaryQuery, QueryTolerance, material_after_break, transform_region},
+    mouse_bite::{Attachment, Npth, SparkFunShallow, build},
+    path::stroke_to_fill,
+    region::ring_signed_area,
+};
+
+use super::placement::{Placement, Preset, select};
+use super::xml::poly_segment;
+
+pub struct Tabs {
+    /// Connected routed voids in panel coordinates, one profile cutout each.
+    pub cutouts: Vec<ContourSet>,
+    /// Break perforations in panel coordinates.
+    pub holes: Vec<Npth>,
+    pub per_board: usize,
+    /// Candidate sites the builder could not turn into a tab, with the reason.
+    pub dropped: Vec<String>,
+}
+
+/// Tab and slot geometry for `placement`'s board repeated at `offsets`
+/// inside `stock`. Sites the builder rejects are dropped and the placement
+/// is re-solved without them, so the result always holds the board or fails
+/// with the placement's own reason.
+pub(super) fn generate(
+    placement: &Placement,
+    stock: &ContourSet,
+    offsets: &[Point],
+    preset: &Preset,
+    resolution: Resolution,
+) -> Result<Tabs> {
+    let tolerance = QueryTolerance {
+        boundary_mm: 0.0,
+        numerical_mm: pcb_ir::geom::tol::EPSILON_MM,
+    };
+    // Slots follow the outer boundary; a board's own holes stay the board's.
+    let substrate = &placement.prepared.substrate;
+    let outer = ContourSet::from_regularized(
+        substrate
+            .rings
+            .iter()
+            .filter(|ring| ring_signed_area(ring) > 0.0)
+            .cloned()
+            .collect(),
+        substrate.resolution,
+        substrate.uncertainty_mm,
+    );
+    let boards = offsets
+        .iter()
+        .map(|&offset| transform_region(&outer, Affine2::translation(offset)))
+        .collect::<Result<Vec<_>, _>>()?;
+    let grown = boards
+        .iter()
+        .map(|board| board.disk_dilate(preset.routing_gap_mm))
+        .collect::<Result<Vec<_>, _>>()?;
+    let frame = grown
+        .iter()
+        .try_fold(stock.clone(), |frame, slot| frame.difference(slot))?;
+    ensure!(
+        significant_components(&frame, resolution) == 1,
+        "the rails between routed slots do not form one connected frame"
+    );
+    let candidates = &placement.sites.candidates;
+    let reach = preset.routing_gap_mm + preset.frame_landing_mm;
+    let mut excluded = HashSet::new();
+    let mut dropped = Vec::new();
+    loop {
+        let kept: Vec<usize> = (0..candidates.len())
+            .filter(|i| !excluded.contains(i))
+            .collect();
+        let sites: Vec<_> = kept.iter().map(|&i| candidates[i].site).collect();
+        let selection = select::select(&sites, &placement.loads, &placement.model);
+        if !selection.satisfied() {
+            bail!(
+                "tabs cannot hold the board: {}{}",
+                selection
+                    .violations
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("; "),
+                if dropped.is_empty() {
+                    String::new()
+                } else {
+                    format!("; sites dropped: {}", dropped.join("; "))
+                }
+            );
+        }
+        let chosen: Vec<usize> = selection.chosen.iter().map(|&k| kept[k]).collect();
+
+        let mut cutouts = Vec::new();
+        let mut holes = Vec::new();
+        let mut perforations = ContourSet::empty(resolution);
+        let mut break_rows = Vec::new();
+        let mut witnesses = vec![frame_witness(&frame)?];
+        let mut failure = None;
+        'boards: for ((board, slot), offset) in boards.iter().zip(&grown).zip(offsets) {
+            // The builder wants stock well beyond the support it lands on, so
+            // the support ring stops short of the local stock window.
+            let support = frame.intersection(&slot.disk_dilate(preset.frame_landing_mm + 1.0)?)?;
+            let window = slot
+                .disk_dilate(preset.frame_landing_mm + 4.0)?
+                .intersection(stock)?;
+            let query = BoundaryQuery::new(board, tolerance)?;
+            let mut footprints = ContourSet::empty(resolution);
+            for &c in &chosen {
+                let site = candidates[c].site;
+                let point = site.point + *offset;
+                let normal = site.outward_normal;
+                let projection = query
+                    .boundaries()
+                    .map(|id| query.project(id, point))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .into_iter()
+                    .min_by(|a, b| a.distance.mm.total_cmp(&b.distance.mm))
+                    .context("board instance has no boundary")?;
+                let attachment = Attachment {
+                    stock: &window,
+                    board,
+                    support: &support,
+                    boundary: projection.site.boundary,
+                    station_mm: projection.site.station_mm,
+                    support_anchor: point + normal * (preset.routing_gap_mm + reach) / 2.0,
+                    board_witness: point - normal * WITNESS_DEPTH_MM,
+                    tolerance,
+                };
+                match build(attachment) {
+                    Ok(tab) => {
+                        footprints = footprints.union(&tab.attachment_footprint)?;
+                        perforations = perforations.union(&tab.perforations)?;
+                        holes.extend(tab.npth);
+                        break_rows.push(tab.break_path);
+                        if witnesses.len() == cutouts.len() + 1 {
+                            witnesses.push(attachment_witness(point, normal));
+                        }
+                    }
+                    Err(error) => {
+                        failure = Some(format!(
+                            "site {c} at ({:.2}, {:.2}): {error}",
+                            site.point.x, site.point.y
+                        ));
+                        break 'boards;
+                    }
+                }
+            }
+            let removal = slot.difference(board)?.difference(&footprints)?;
+            cutouts.push(removal);
+        }
+        if let Some(failure) = failure {
+            let c = failure
+                .split(' ')
+                .nth(1)
+                .and_then(|s| s.parse::<usize>().ok())
+                .expect("failure names its site");
+            excluded.insert(c);
+            dropped.push(failure);
+            continue;
+        }
+
+        let cutouts: Vec<ContourSet> = cutouts
+            .iter()
+            .flat_map(|removal| significant(removal, resolution))
+            .collect();
+        check_release(
+            stock,
+            &cutouts,
+            &perforations,
+            &break_rows,
+            &witnesses,
+            tolerance,
+        )?;
+        return Ok(Tabs {
+            cutouts,
+            holes,
+            per_board: chosen.len(),
+            dropped,
+        });
+    }
+}
+
+/// How far inside the board the builder's witness point sits.
+const WITNESS_DEPTH_MM: f64 = 1.0;
+
+fn attachment_witness(point: Point, normal: Point) -> Point {
+    point - normal * WITNESS_DEPTH_MM
+}
+
+/// A point on the bottom rail, away from the rounded corners.
+fn frame_witness(frame: &ContourSet) -> Result<Point> {
+    let bbox = frame.bbox();
+    let point = Point::new(bbox.center().x, bbox.min.y + 1.0);
+    ensure!(
+        frame.contains_point(point),
+        "the bottom rail is not frame material at its middle"
+    );
+    Ok(point)
+}
+
+/// Connected pieces of `region` at the cutter's own significance: a void or
+/// an island smaller than the cutter radius squared is not something a router
+/// cuts or leaves, only residue of booleans along coincident edges.
+fn significant(region: &ContourSet, resolution: Resolution) -> Vec<ContourSet> {
+    let routable = resolution.with_tolerance(SparkFunShallow::CUTTER_RADIUS_MM);
+    region
+        .connected_components()
+        .into_iter()
+        .map(|piece| {
+            ContourSet::from_regularized(piece.rings.clone(), routable, piece.uncertainty_mm)
+        })
+        .filter(|piece| !piece.is_empty())
+        .collect()
+}
+
+fn significant_components(region: &ContourSet, resolution: Resolution) -> usize {
+    significant(region, resolution).len()
+}
+
+/// Every board must connect to the frame through its tabs, and cutting every
+/// break row must free every board from the frame and from each other.
+fn check_release(
+    stock: &ContourSet,
+    cutouts: &[ContourSet],
+    perforations: &ContourSet,
+    break_rows: &[ContourBuf],
+    witnesses: &[Point],
+    tolerance: QueryTolerance,
+) -> Result<()> {
+    let resolution = stock.resolution.strict();
+    let retained = cutouts
+        .iter()
+        .try_fold(stock.clone(), |kept, cutout| kept.difference(cutout))?
+        .difference(perforations)?;
+    let boards = 1..witnesses.len();
+    let held = material_after_break(
+        &retained,
+        &ContourSet::empty(resolution),
+        witnesses,
+        tolerance,
+    )?;
+    ensure!(
+        boards
+            .clone()
+            .all(|i| held.connected(0, i) == Ok(Some(true))),
+        "not every board is connected to the frame through its tabs"
+    );
+    let rows = stroke_to_fill(
+        break_rows,
+        StrokeToFillStyle::new(BREAK_PROBE_MM, LineCap::Round, LineJoin::Round),
+        resolution.accuracy,
+    )?
+    .context("break rows have no width")?;
+    let rows = ContourSet::from_filled_contours(&rows, resolution)?;
+    let released = material_after_break(&retained, &rows, witnesses, tolerance)?;
+    ensure!(
+        boards
+            .clone()
+            .all(|i| released.connected(0, i) == Ok(Some(false)))
+            && boards
+                .clone()
+                .flat_map(|i| boards.clone().filter(move |&j| j > i).map(move |j| (i, j)))
+                .all(|(i, j)| released.connected(i, j) == Ok(Some(false))),
+        "breaking every tab row does not separate every board from the frame and from each other"
+    );
+    Ok(())
+}
+
+/// Width of the virtual removal along a break row: a polygon topology probe,
+/// not a kerf.
+const BREAK_PROBE_MM: f64 = 0.002;
+
+/// One simply connected routed void as an IPC-2581 polygon.
+pub fn cutout_polygon(cutout: &ContourSet) -> Result<Polygon> {
+    let [ring] = cutout.rings.as_slice() else {
+        bail!(
+            "a routed void has {} rings; each must be a single loop (areas {:?}, bbox {:?})",
+            cutout.rings.len(),
+            cutout
+                .rings
+                .iter()
+                .map(ring_signed_area)
+                .collect::<Vec<_>>(),
+            cutout.bbox()
+        );
+    };
+    ensure!(
+        ring_signed_area(ring) > 0.0 && ring.len() >= 3,
+        "a routed void has no area (signed area {}, {} vertices)",
+        ring_signed_area(ring),
+        ring.len()
+    );
+    Ok(Polygon {
+        begin: ipc2581::types::Point {
+            x: ring[0][0],
+            y: ring[0][1],
+        },
+        steps: ring[1..]
+            .iter()
+            .chain(std::iter::once(&ring[0]))
+            .map(|p| poly_segment(p[0], p[1]))
+            .collect(),
+    })
+}

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mouse_bite.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mouse_bite.rs
@@ -33,8 +33,6 @@ pub struct Tabs {
     /// Break perforations in panel coordinates.
     pub holes: Vec<Npth>,
     pub per_board: usize,
-    /// Candidate sites the builder could not turn into a tab, with the reason.
-    pub dropped: Vec<String>,
 }
 
 /// Tab and slot geometry for `placement`'s board repeated at `offsets`
@@ -179,7 +177,6 @@ pub(super) fn generate(
             cutouts,
             holes,
             per_board: chosen.len(),
-            dropped,
         });
     }
 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/mouse_bite.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/mouse_bite.rs
@@ -5,20 +5,21 @@
 //! non-plated drills.
 //!
 //! Each tab comes from the single-tab builder in pcb-ir, given the board
-//! instance, the frame around it and a local window of stock. A board's
-//! removal is its slot minus every tab footprint on it, so tabs never erase
-//! one another; the holes are the builder's. The retained panel is then
-//! checked as a whole: every board connected to the frame before the break
-//! rows are cut, every board free of the frame and of each other after.
+//! instance, the frame around it and a local window of stock; the holes and
+//! break rows are the builder's. A board's removal is its slot minus every
+//! tab neck, opened by the cutter around the necks so the fillets a router
+//! leaves beside them are part of the void's shape. The retained panel is
+//! then checked as a whole: every board connected to the frame before the
+//! break rows are cut, every board free of the frame and of each other after.
 
 use std::collections::HashSet;
 
 use anyhow::{Context, Result, bail, ensure};
 use ipc2581::types::Polygon;
 use pcb_ir::geom::{
-    Affine2, ContourBuf, ContourSet, LineCap, LineJoin, Point, Resolution, StrokeToFillStyle,
+    Affine2, BBox, ContourBuf, ContourSet, LineCap, LineJoin, Point, Resolution, StrokeToFillStyle,
     attachment::{BoundaryQuery, QueryTolerance, material_after_break, transform_region},
-    mouse_bite::{Attachment, Npth, SparkFunShallow, build},
+    mouse_bite::{Attachment, Npth, SparkFunShallow, TabGeometry, build},
     path::stroke_to_fill,
     region::ring_signed_area,
 };
@@ -75,11 +76,11 @@ pub(super) fn generate(
         .iter()
         .try_fold(stock.clone(), |frame, slot| frame.difference(slot))?;
     ensure!(
-        significant_components(&frame, resolution) == 1,
+        routable_components(&frame, resolution) == 1,
         "the rails between routed slots do not form one connected frame"
     );
     let candidates = &placement.sites.candidates;
-    let reach = preset.routing_gap_mm + preset.frame_landing_mm;
+    let radius = SparkFunShallow::CUTTER_RADIUS_MM;
     let mut excluded = HashSet::new();
     let mut dropped = Vec::new();
     loop {
@@ -110,75 +111,62 @@ pub(super) fn generate(
         let mut holes = Vec::new();
         let mut perforations = ContourSet::empty(resolution);
         let mut break_rows = Vec::new();
-        let mut witnesses = vec![frame_witness(&frame)?];
-        let mut failure = None;
-        'boards: for ((board, slot), offset) in boards.iter().zip(&grown).zip(offsets) {
-            // The builder wants stock well beyond the support it lands on, so
-            // the support ring stops short of the local stock window.
-            let support = frame.intersection(&slot.disk_dilate(preset.frame_landing_mm + 1.0)?)?;
-            let window = slot
-                .disk_dilate(preset.frame_landing_mm + 4.0)?
-                .intersection(stock)?;
-            let query = BoundaryQuery::new(board, tolerance)?;
-            let mut footprints = ContourSet::empty(resolution);
+        let mut rejected = None;
+        'boards: for ((board, slot), &offset) in boards.iter().zip(&grown).zip(offsets) {
+            let mut necks = ContourSet::empty(resolution);
             for &c in &chosen {
                 let site = candidates[c].site;
-                let point = site.point + *offset;
-                let normal = site.outward_normal;
-                let projection = query
-                    .boundaries()
-                    .map(|id| query.project(id, point))
-                    .collect::<Result<Vec<_>, _>>()?
-                    .into_iter()
-                    .min_by(|a, b| a.distance.mm.total_cmp(&b.distance.mm))
-                    .context("board instance has no boundary")?;
-                let attachment = Attachment {
-                    stock: &window,
+                let tab = build_tab(
+                    site.point + offset,
+                    site.outward_normal,
                     board,
-                    support: &support,
-                    boundary: projection.site.boundary,
-                    station_mm: projection.site.station_mm,
-                    support_anchor: point + normal * (preset.routing_gap_mm + reach) / 2.0,
-                    board_witness: point - normal * WITNESS_DEPTH_MM,
+                    slot,
+                    &frame,
+                    stock,
+                    preset,
+                    resolution,
                     tolerance,
-                };
-                match build(attachment) {
+                );
+                match tab {
                     Ok(tab) => {
-                        footprints = footprints.union(&tab.attachment_footprint)?;
+                        necks = necks.union(&tab.neck)?;
                         perforations = perforations.union(&tab.perforations)?;
                         holes.extend(tab.npth);
                         break_rows.push(tab.break_path);
-                        if witnesses.len() == cutouts.len() + 1 {
-                            witnesses.push(attachment_witness(point, normal));
-                        }
                     }
                     Err(error) => {
-                        failure = Some(format!(
-                            "site {c} at ({:.2}, {:.2}): {error}",
-                            site.point.x, site.point.y
+                        rejected = Some((
+                            c,
+                            format!(
+                                "site at ({:.2}, {:.2}): {error:#}",
+                                site.point.x, site.point.y
+                            ),
                         ));
                         break 'boards;
                     }
                 }
             }
-            let removal = slot.difference(board)?.difference(&footprints)?;
-            cutouts.push(removal);
+            // The router clears the slot except where necks bridge it. Its
+            // disk cannot reach into the corners where a neck meets the slot
+            // walls, so the void is opened by the cutter around the necks and
+            // follows the outline exactly everywhere else.
+            let void = slot.difference(board)?.difference(&necks)?;
+            let removal = void
+                .disk_open(radius)?
+                .union(&void.difference(&necks.disk_dilate(2.0 * radius)?)?)?;
+            cutouts.extend(removal.connected_components());
         }
-        if let Some(failure) = failure {
-            let c = failure
-                .split(' ')
-                .nth(1)
-                .and_then(|s| s.parse::<usize>().ok())
-                .expect("failure names its site");
+        if let Some((c, reason)) = rejected {
             excluded.insert(c);
-            dropped.push(failure);
+            dropped.push(reason);
             continue;
         }
-
-        let cutouts: Vec<ContourSet> = cutouts
-            .iter()
-            .flat_map(|removal| significant(removal, resolution))
-            .collect();
+        let witnesses = std::iter::once(frame_witness(&frame)?)
+            .chain(offsets.iter().map(|&offset| {
+                let site = candidates[chosen[0]].site;
+                site.point + offset - site.outward_normal * WITNESS_DEPTH_MM
+            }))
+            .collect::<Vec<_>>();
         check_release(
             stock,
             &cutouts,
@@ -196,11 +184,69 @@ pub(super) fn generate(
     }
 }
 
-/// How far inside the board the builder's witness point sits.
+/// How far inside the board a witness point sits.
 const WITNESS_DEPTH_MM: f64 = 1.0;
+/// Half-size of the window a tab is built in: the drill row, neck, shoulders
+/// and frame landing all lie within a few millimetres of the site.
+const LOCAL_MM: f64 = 10.0;
 
-fn attachment_witness(point: Point, normal: Point) -> Point {
-    point - normal * WITNESS_DEPTH_MM
+/// One tab at `point` on `board`, built in a window around the site so the
+/// cost of a tab does not grow with the panel. The builder wants stock beyond
+/// the support it lands on, so the support ring stops short of the window.
+#[allow(clippy::too_many_arguments)]
+fn build_tab(
+    point: Point,
+    normal: Point,
+    board: &ContourSet,
+    slot: &ContourSet,
+    frame: &ContourSet,
+    stock: &ContourSet,
+    preset: &Preset,
+    resolution: Resolution,
+    tolerance: QueryTolerance,
+) -> Result<TabGeometry> {
+    let reach = preset.routing_gap_mm + preset.frame_landing_mm;
+    let window = ContourSet::rectangle(
+        BBox::new(
+            point - Point::new(LOCAL_MM, LOCAL_MM),
+            point + Point::new(LOCAL_MM, LOCAL_MM),
+        ),
+        resolution,
+    );
+    let local_board = board.intersection(&window)?;
+    let support_anchor = point + normal * (preset.routing_gap_mm + reach) / 2.0;
+    // The frame the tab lands on; a small board's window can also hold
+    // frame beyond its far side or inside its notches.
+    let local_support = frame
+        .intersection(
+            &slot
+                .intersection(&window)?
+                .disk_dilate(preset.frame_landing_mm + 1.0)?
+                .intersection(&window)?,
+        )?
+        .connected_components()
+        .into_iter()
+        .find(|piece| piece.contains_point(support_anchor))
+        .context("the tab's landing is not frame material")?;
+    let local_stock = stock.intersection(&window)?;
+    let query = BoundaryQuery::new(&local_board, tolerance)?;
+    let projection = query
+        .boundaries()
+        .map(|id| query.project(id, point))
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
+        .min_by(|a, b| a.distance.mm.total_cmp(&b.distance.mm))
+        .context("board instance has no boundary")?;
+    Ok(build(Attachment {
+        stock: &local_stock,
+        board: &local_board,
+        support: &local_support,
+        boundary: projection.site.boundary,
+        station_mm: projection.site.station_mm,
+        support_anchor,
+        board_witness: point - normal * WITNESS_DEPTH_MM,
+        tolerance,
+    })?)
 }
 
 /// A point on the bottom rail, away from the rounded corners.
@@ -214,23 +260,19 @@ fn frame_witness(frame: &ContourSet) -> Result<Point> {
     Ok(point)
 }
 
-/// Connected pieces of `region` at the cutter's own significance: a void or
-/// an island smaller than the cutter radius squared is not something a router
-/// cuts or leaves, only residue of booleans along coincident edges.
-fn significant(region: &ContourSet, resolution: Resolution) -> Vec<ContourSet> {
+/// Connected pieces of `region` at the cutter's own significance: an island
+/// smaller than the cutter radius squared is residue of booleans along
+/// coincident edges, not something a router leaves.
+fn routable_components(region: &ContourSet, resolution: Resolution) -> usize {
     let routable = resolution.with_tolerance(SparkFunShallow::CUTTER_RADIUS_MM);
     region
         .connected_components()
         .into_iter()
-        .map(|piece| {
-            ContourSet::from_regularized(piece.rings.clone(), routable, piece.uncertainty_mm)
+        .filter(|piece| {
+            !ContourSet::from_regularized(piece.rings.clone(), routable, piece.uncertainty_mm)
+                .is_empty()
         })
-        .filter(|piece| !piece.is_empty())
-        .collect()
-}
-
-fn significant_components(region: &ContourSet, resolution: Resolution) -> usize {
-    significant(region, resolution).len()
+        .count()
 }
 
 /// Every board must connect to the frame through its tabs, and cutting every
@@ -290,21 +332,13 @@ const BREAK_PROBE_MM: f64 = 0.002;
 pub fn cutout_polygon(cutout: &ContourSet) -> Result<Polygon> {
     let [ring] = cutout.rings.as_slice() else {
         bail!(
-            "a routed void has {} rings; each must be a single loop (areas {:?}, bbox {:?})",
-            cutout.rings.len(),
-            cutout
-                .rings
-                .iter()
-                .map(ring_signed_area)
-                .collect::<Vec<_>>(),
-            cutout.bbox()
+            "a routed void has {} rings; each must be a single loop",
+            cutout.rings.len()
         );
     };
     ensure!(
         ring_signed_area(ring) > 0.0 && ring.len() >= 3,
-        "a routed void has no area (signed area {}, {} vertices)",
-        ring_signed_area(ring),
-        ring.len()
+        "a routed void has no area"
     );
     Ok(Polygon {
         begin: ipc2581::types::Point {

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
@@ -31,6 +31,9 @@ pub struct Preset {
     pub courtyard_clearance_mm: f64,
     /// Routed slot between the board outline and the frame; the neck spans it.
     pub routing_gap_mm: f64,
+    /// How far the board's cell in the array grows beyond its outline; the
+    /// rest of the slot cuts into the margin, which has clearance to spare.
+    pub cell_growth_mm: f64,
     /// Frame material a tab must reach beyond the slot.
     pub frame_landing_mm: f64,
     /// Candidate spacing along eligible outline runs.
@@ -57,6 +60,7 @@ pub const PRESET: Preset = Preset {
     inward_mm: 0.2,
     courtyard_clearance_mm: 0.0,
     routing_gap_mm: 2.0,
+    cell_growth_mm: 1.0,
     frame_landing_mm: 1.0,
     candidate_pitch_mm: 2.5,
     min_tab_radius_mm: 10.0,

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
@@ -9,11 +9,13 @@
 pub mod candidates;
 pub mod select;
 
-use anyhow::{Result, ensure};
+use anyhow::{Context, Result, ensure};
+use ipc2581::Ipc2581;
 use pcb_ir::geom::{
     ContourSet, Resolution, attachment::outline::OutlineFootprint, mouse_bite::SparkFunShallow,
 };
 use serde_json::{Value, json};
+use sha2::Digest;
 
 use super::eligibility;
 use select::{Model, Physics};
@@ -38,6 +40,8 @@ pub struct Preset {
     /// keep-out on either side, than an arc of this radius would, which keeps
     /// tabs off corners without excluding round boards.
     pub min_tab_radius_mm: f64,
+    /// Distance kept from corners, or a quarter of the board's shorter side
+    /// on boards too small for that.
     pub corner_keepout_mm: f64,
     /// Closest two tabs may sit.
     pub min_separation_mm: f64,
@@ -89,10 +93,19 @@ impl Preset {
     }
 }
 
-/// Analyze one canonical board: eligibility plus tab placement.
-pub fn analyze(xml: &str, preset: &Preset, resolution: Resolution) -> Result<Value> {
+/// One board's eligibility, candidate sites and chosen tabs.
+pub(super) struct Placement {
+    pub prepared: eligibility::Prepared,
+    pub sites: candidates::Sites,
+    pub loads: Vec<pcb_ir::geom::Point>,
+    pub model: Model,
+    pub selection: select::Selection,
+}
+
+/// Place tabs on the canonical board of `ipc`.
+pub(super) fn place(ipc: &Ipc2581, preset: &Preset, resolution: Resolution) -> Result<Placement> {
     let prepared = eligibility::prepare(
-        xml,
+        ipc,
         preset.footprint(),
         preset.courtyard_clearance_mm,
         &[],
@@ -121,7 +134,28 @@ pub fn analyze(xml: &str, preset: &Preset, resolution: Resolution) -> Result<Val
         &loads,
         &model,
     );
+    Ok(Placement {
+        prepared,
+        sites,
+        loads,
+        model,
+        selection,
+    })
+}
 
+/// Analyze one canonical board: eligibility plus tab placement, as JSON.
+pub fn analyze(xml: &str, preset: &Preset, resolution: Resolution) -> Result<Value> {
+    let ipc = Ipc2581::parse(xml).context("Failed to parse IPC-2581 input")?;
+    let placement = place(&ipc, preset, resolution)?;
+    let Placement {
+        prepared,
+        sites,
+        loads,
+        model,
+        selection,
+    } = &placement;
+    let substrate = &prepared.substrate;
+    let bbox = substrate.bbox();
     let rings = |region: &ContourSet| {
         region
             .rings
@@ -131,6 +165,7 @@ pub fn analyze(xml: &str, preset: &Preset, resolution: Resolution) -> Result<Val
     };
     let mut report = prepared.report.clone();
     report["phase"] = json!("tab-placement-only");
+    report["source_xml_sha256"] = json!(hex::encode(sha2::Sha256::digest(xml.as_bytes())));
     report["placement"] = json!({
         "preset": preset,
         "model": model,

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
@@ -33,11 +33,11 @@ pub struct Preset {
     pub frame_landing_mm: f64,
     /// Candidate spacing along eligible outline runs.
     pub candidate_pitch_mm: f64,
-    /// Outline may turn at most this much within the tab's own width.
-    pub tab_bend_degrees: f64,
-    /// Outline may turn at most this much within the tab plus the keep-out on
-    /// either side: clear of corners without excluding round boards.
-    pub corner_bend_degrees: f64,
+    /// Tightest curve a tab may sit on; the coupon-validated radius. The
+    /// outline may turn no more within the tab, or within the tab plus the
+    /// keep-out on either side, than an arc of this radius would, which keeps
+    /// tabs off corners without excluding round boards.
+    pub min_tab_radius_mm: f64,
     pub corner_keepout_mm: f64,
     /// Closest two tabs may sit.
     pub min_separation_mm: f64,
@@ -55,8 +55,7 @@ pub const PRESET: Preset = Preset {
     routing_gap_mm: 2.0,
     frame_landing_mm: 1.0,
     candidate_pitch_mm: 2.5,
-    tab_bend_degrees: 15.0,
-    corner_bend_degrees: 60.0,
+    min_tab_radius_mm: 10.0,
     corner_keepout_mm: 5.0,
     min_separation_mm: 10.0,
     load_point_spacing_mm: 2.0,
@@ -150,6 +149,7 @@ pub fn analyze(xml: &str, preset: &Preset, resolution: Resolution) -> Result<Val
         "rejected": sites.rejected.iter().map(|r| json!({
             "ring": r.ring, "station_mm": r.station_mm, "point": [r.point.x, r.point.y], "reason": r.reason,
         })).collect::<Vec<_>>(),
+        "tight": sites.tight.iter().map(|run| run.iter().map(|p| json!([p.x, p.y])).collect::<Vec<_>>()).collect::<Vec<_>>(),
         "selected": selection.chosen,
         "tab_count": selection.chosen.len(),
         "proven_minimal": selection.proven,

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement.rs
@@ -29,11 +29,10 @@ pub struct Preset {
     pub inward_mm: f64,
     /// Growth applied to courtyards before they count as obstacles.
     pub courtyard_clearance_mm: f64,
-    /// Routed slot between the board outline and the frame; the neck spans it.
+    /// Routed slot between the board outline and the frame; the neck spans
+    /// it. It is cut from the board's margin, so the array fits exactly as a
+    /// scored one does.
     pub routing_gap_mm: f64,
-    /// How far the board's cell in the array grows beyond its outline; the
-    /// rest of the slot cuts into the margin, which has clearance to spare.
-    pub cell_growth_mm: f64,
     /// Frame material a tab must reach beyond the slot.
     pub frame_landing_mm: f64,
     /// Candidate spacing along eligible outline runs.
@@ -59,8 +58,7 @@ pub const PRESET: Preset = Preset {
     tab_width_mm: SparkFunShallow::NECK_WIDTH_MM + 2.0 * SparkFunShallow::CUTTER_RADIUS_MM,
     inward_mm: 0.2,
     courtyard_clearance_mm: 0.0,
-    routing_gap_mm: 2.0,
-    cell_growth_mm: 1.0,
+    routing_gap_mm: 1.4,
     frame_landing_mm: 1.0,
     candidate_pitch_mm: 2.5,
     min_tab_radius_mm: 10.0,
@@ -76,7 +74,8 @@ pub const PRESET: Preset = Preset {
         // Perforation halves the neck's section.
         neck_width_mm: SparkFunShallow::NECK_WIDTH_MM,
         neck_perforation_factor: 0.5,
-        // Two default 5 mm board margins minus a slot on each side.
+        // Below what two default 5 mm board margins leave once a slot is
+        // routed on each side.
         rail_width_mm: 6.0,
         // A finger or placement nozzle anywhere on the board, and the sag that
         // still leaves the surface flat enough for placement.

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement/candidates.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement/candidates.rs
@@ -31,6 +31,9 @@ pub struct Rejection {
 pub struct Sites {
     pub candidates: Vec<Candidate>,
     pub rejected: Vec<Rejection>,
+    /// Outline stretches too tightly curved or too close to a corner for a
+    /// tab, as polylines, whatever the obstacle evidence says there.
+    pub tight: Vec<Vec<Point>>,
     /// Frame material beyond an outline-following slot, local to this board.
     pub frame: ContourSet,
 }
@@ -60,6 +63,7 @@ pub fn find(
     let mut sites = Sites {
         candidates: Vec::new(),
         rejected: Vec::new(),
+        tight: Vec::new(),
         frame: ContourSet::empty(resolution),
     };
     for id in boundary
@@ -68,6 +72,9 @@ pub fn find(
     {
         let perimeter = boundary.perimeter(id)?;
         let turns = turning_angles(&substrate.rings[id.ring]);
+        sites
+            .tight
+            .extend(tight_runs(&boundary, id, &turns, perimeter, preset)?);
         for (lo, hi) in eligible_runs(intervals, id, perimeter) {
             let bins = ((hi - lo) / preset.candidate_pitch_mm).ceil().max(1.0) as usize;
             for k in 0..bins {
@@ -112,21 +119,8 @@ impl Checker<'_> {
         perimeter: f64,
     ) -> Result<Option<String>> {
         let p = self.preset;
-        let half = p.tab_width_mm / 2.0;
-        let tab_bend = bend_within(turns, perimeter, site.station_mm, half);
-        if tab_bend > p.tab_bend_degrees {
-            return Ok(Some(format!("outline turns {tab_bend:.0}° within the tab")));
-        }
-        let corner_bend = bend_within(
-            turns,
-            perimeter,
-            site.station_mm,
-            half + p.corner_keepout_mm,
-        );
-        if corner_bend > p.corner_bend_degrees {
-            return Ok(Some(format!(
-                "outline turns {corner_bend:.0}° within the corner keep-out"
-            )));
+        if let Some(reason) = too_tight(turns, perimeter, site.station_mm, p) {
+            return Ok(Some(reason));
         }
         let across = self.strip(site, 0.0, p.routing_gap_mm)?;
         if across.intersection(self.substrate)?.area() > 0.0 {
@@ -160,6 +154,57 @@ impl Checker<'_> {
             self.resolution,
         )?)
     }
+}
+
+/// Why the outline at `station` is too curved for a tab, if it is: it may
+/// turn no more within the tab width, or within the tab plus the keep-out
+/// on either side, than an arc of the minimum radius would over that length.
+fn too_tight(
+    turns: &[(f64, f64)],
+    perimeter: f64,
+    station: f64,
+    preset: &Preset,
+) -> Option<String> {
+    let limit = |window: f64| (window / preset.min_tab_radius_mm).to_degrees();
+    let half = preset.tab_width_mm / 2.0;
+    let tab_bend = bend_within(turns, perimeter, station, half);
+    if tab_bend > limit(preset.tab_width_mm) {
+        return Some(format!("outline turns {tab_bend:.0}° within the tab"));
+    }
+    let corner_bend = bend_within(turns, perimeter, station, half + preset.corner_keepout_mm);
+    if corner_bend > limit(preset.tab_width_mm + 2.0 * preset.corner_keepout_mm) {
+        return Some(format!(
+            "outline turns {corner_bend:.0}° within the corner keep-out"
+        ));
+    }
+    None
+}
+
+/// Stretches of one ring that are too tight for a tab, sampled finely and
+/// returned as polylines for inspection.
+fn tight_runs(
+    boundary: &BoundaryQuery<'_>,
+    id: BoundaryId,
+    turns: &[(f64, f64)],
+    perimeter: f64,
+    preset: &Preset,
+) -> Result<Vec<Vec<Point>>> {
+    let step = preset.candidate_pitch_mm / 5.0;
+    let mut runs: Vec<Vec<Point>> = Vec::new();
+    let mut open = false;
+    for k in 0..(perimeter / step).ceil() as usize {
+        let station = k as f64 * step;
+        let tight = too_tight(turns, perimeter, station, preset).is_some();
+        if tight {
+            let point = boundary.site(id, station)?.point;
+            match runs.last_mut() {
+                Some(run) if open => run.push(point),
+                _ => runs.push(vec![point]),
+            }
+        }
+        open = tight;
+    }
+    Ok(runs)
 }
 
 /// Contiguous Eligible arclength runs on one ring, joined across the seam.

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/placement/candidates.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/placement/candidates.rs
@@ -54,10 +54,16 @@ pub fn find(
     let reach = preset.routing_gap_mm + preset.frame_landing_mm;
     let frame = ContourSet::rectangle(substrate.bbox().expand(reach + 1.0), resolution)
         .difference(&substrate.disk_dilate(preset.routing_gap_mm)?)?;
+    // Small boards cannot keep a full keep-out from every corner.
+    let bbox = substrate.bbox();
+    let keepout_mm = preset
+        .corner_keepout_mm
+        .min(bbox.width().min(bbox.height()) / 4.0);
     let checker = Checker {
         substrate,
         frame: &frame,
         preset,
+        keepout_mm,
         resolution,
     };
     let mut sites = Sites {
@@ -72,9 +78,9 @@ pub fn find(
     {
         let perimeter = boundary.perimeter(id)?;
         let turns = turning_angles(&substrate.rings[id.ring]);
-        sites
-            .tight
-            .extend(tight_runs(&boundary, id, &turns, perimeter, preset)?);
+        sites.tight.extend(tight_runs(
+            &boundary, id, &turns, perimeter, preset, keepout_mm,
+        )?);
         for (lo, hi) in eligible_runs(intervals, id, perimeter) {
             let bins = ((hi - lo) / preset.candidate_pitch_mm).ceil().max(1.0) as usize;
             for k in 0..bins {
@@ -107,6 +113,7 @@ struct Checker<'a> {
     substrate: &'a ContourSet,
     frame: &'a ContourSet,
     preset: &'a Preset,
+    keepout_mm: f64,
     resolution: Resolution,
 }
 
@@ -119,7 +126,7 @@ impl Checker<'_> {
         perimeter: f64,
     ) -> Result<Option<String>> {
         let p = self.preset;
-        if let Some(reason) = too_tight(turns, perimeter, site.station_mm, p) {
+        if let Some(reason) = too_tight(turns, perimeter, site.station_mm, p, self.keepout_mm) {
             return Ok(Some(reason));
         }
         let across = self.strip(site, 0.0, p.routing_gap_mm)?;
@@ -164,6 +171,7 @@ fn too_tight(
     perimeter: f64,
     station: f64,
     preset: &Preset,
+    keepout_mm: f64,
 ) -> Option<String> {
     let limit = |window: f64| (window / preset.min_tab_radius_mm).to_degrees();
     let half = preset.tab_width_mm / 2.0;
@@ -171,8 +179,8 @@ fn too_tight(
     if tab_bend > limit(preset.tab_width_mm) {
         return Some(format!("outline turns {tab_bend:.0}° within the tab"));
     }
-    let corner_bend = bend_within(turns, perimeter, station, half + preset.corner_keepout_mm);
-    if corner_bend > limit(preset.tab_width_mm + 2.0 * preset.corner_keepout_mm) {
+    let corner_bend = bend_within(turns, perimeter, station, half + keepout_mm);
+    if corner_bend > limit(preset.tab_width_mm + 2.0 * keepout_mm) {
         return Some(format!(
             "outline turns {corner_bend:.0}° within the corner keep-out"
         ));
@@ -188,13 +196,14 @@ fn tight_runs(
     turns: &[(f64, f64)],
     perimeter: f64,
     preset: &Preset,
+    keepout_mm: f64,
 ) -> Result<Vec<Vec<Point>>> {
     let step = preset.candidate_pitch_mm / 5.0;
     let mut runs: Vec<Vec<Point>> = Vec::new();
     let mut open = false;
     for k in 0..(perimeter / step).ceil() as usize {
         let station = k as f64 * step;
-        let tight = too_tight(turns, perimeter, station, preset).is_some();
+        let tight = too_tight(turns, perimeter, station, preset, keepout_mm).is_some();
         if tight {
             let point = boundary.site(id, station)?.point;
             match runs.last_mut() {

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -180,8 +180,16 @@ fn generated_board_array_has_a_certified_safe_balancing_region() {
     let input = board_fixture_with_mask_bbox_mm(12.0, 10.0);
     let source = Ipc2581::parse(&input).unwrap();
     let (options, validation_mode, panelization) =
-        auto_board_array_options(&source, None, resolution).unwrap();
-    let spec = build_board_array_spec(&source, &options, validation_mode, panelization).unwrap();
+        auto_board_array_options(&source, None, Separation::VScore, resolution).unwrap();
+    let spec = build_board_array_spec(
+        &source,
+        &options,
+        validation_mode,
+        panelization,
+        Separation::VScore,
+        resolution,
+    )
+    .unwrap();
     // Safe-region discovery runs on the completed but not-yet-balanced array;
     // otherwise the generated balance copper becomes its own obstacle.
     let xml = write_board_array_xml(&input, &spec).unwrap();
@@ -243,8 +251,16 @@ fn board_array_balancing_solves_every_copper_layer() {
     let ipc = Ipc2581::parse(&input).unwrap();
     let sheet = Some(AutoSheetSize::A7);
     let (options, validation_mode, panelization) =
-        auto_board_array_options(&ipc, sheet, resolution).unwrap();
-    let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization).unwrap();
+        auto_board_array_options(&ipc, sheet, Separation::VScore, resolution).unwrap();
+    let spec = build_board_array_spec(
+        &ipc,
+        &options,
+        validation_mode,
+        panelization,
+        Separation::VScore,
+        resolution,
+    )
+    .unwrap();
     let provisional_xml = write_board_array_xml(&input, &spec).unwrap();
     let provisional = Ipc2581::parse(&provisional_xml).unwrap();
     let balance =
@@ -302,13 +318,20 @@ fn board_array_creation_reports_and_emits_the_balance() {
     let resolution = Resolution::default();
 
     let input = two_layer_board_xml();
-    let creation =
-        create_auto_board_array(&input, Some(AutoSheetSize::A7), true, resolution).unwrap();
+    let creation = create_auto_board_array(
+        &input,
+        Some(AutoSheetSize::A7),
+        true,
+        Separation::VScore,
+        resolution,
+    )
+    .unwrap();
     let copper_balance = creation.copper_balance.as_ref().unwrap();
     let coarser = create_auto_board_array(
         &input,
         Some(AutoSheetSize::A7),
         true,
+        Separation::VScore,
         resolution.with_accuracy(pcb_ir::geom::GeometryAccuracy::micrometres(30)),
     )
     .unwrap();
@@ -357,6 +380,7 @@ fn board_array_creation_accepts_no_source_copper_layers() {
             edge_rail_mm: BoardMarginMm::all(20.0),
         },
         true,
+        Separation::VScore,
         resolution,
     )
     .unwrap();
@@ -368,8 +392,14 @@ fn board_array_creation_accepts_no_source_copper_layers() {
 fn board_array_creation_can_skip_copper_balancing() {
     let resolution = Resolution::default();
 
-    let creation =
-        create_auto_board_array(board_fixture_with_top_line_mm(), None, false, resolution).unwrap();
+    let creation = create_auto_board_array(
+        board_fixture_with_top_line_mm(),
+        None,
+        false,
+        Separation::VScore,
+        resolution,
+    )
+    .unwrap();
 
     assert!(creation.copper_balance.is_none());
     Ipc2581::parse(&creation.xml).unwrap();
@@ -385,8 +415,16 @@ fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_laye
     // how much panel surrounds it.
     let sheet = Some(AutoSheetSize::A6);
     let (options, validation_mode, panelization) =
-        auto_board_array_options(&ipc, sheet, resolution).unwrap();
-    let spec = build_board_array_spec(&ipc, &options, validation_mode, panelization).unwrap();
+        auto_board_array_options(&ipc, sheet, Separation::VScore, resolution).unwrap();
+    let spec = build_board_array_spec(
+        &ipc,
+        &options,
+        validation_mode,
+        panelization,
+        Separation::VScore,
+        resolution,
+    )
+    .unwrap();
     let provisional_xml = write_board_array_xml(input, &spec).unwrap();
     let provisional = Ipc2581::parse(&provisional_xml).unwrap();
     let layout = geometry::extract_layout(&provisional).unwrap();
@@ -897,6 +935,8 @@ fn generated_array_geometry_writes_fiducials_and_nonplated_holes() {
             sheet: None,
             sheet_target_mm: None,
         },
+        Separation::VScore,
+        Resolution::default(),
     )
     .unwrap();
 
@@ -1026,6 +1066,8 @@ fn explicit_copper_balance_region_round_trips_as_panel_geometry() {
             sheet: None,
             sheet_target_mm: None,
         },
+        Separation::VScore,
+        Resolution::default(),
     )
     .unwrap();
     let safe_region = ContourSet::rectangle(
@@ -2482,4 +2524,51 @@ fn panel_fixture() -> &'static str {
 </CadData>
   </Ecad>
 </IPC-2581>"#
+}
+
+#[test]
+fn mouse_bite_array_routes_slots_bridged_by_perforated_tabs() {
+    let resolution = Resolution::default();
+    let input = board_fixture_with_top_line_mm();
+    let creation = create_board_array(
+        input,
+        &BoardArrayCreateOptions {
+            columns: 2,
+            rows: 2,
+            board_margin_mm: BoardMarginMm::all(5.0),
+            edge_rail_mm: BoardMarginMm::all(20.0),
+        },
+        false,
+        Separation::MouseBite,
+        resolution,
+    )
+    .unwrap();
+    let xml = creation.xml;
+    assert!(!xml.contains("V-Score") && !xml.contains("V_Cut"));
+    assert!(xml.contains(r#"name="diode.panelize.separation" type="STRING" value="mouse-bite""#));
+    let tabs_per_board: usize = xml
+        .split(r#"name="diode.panelize.tabs_per_board" type="INTEGER" value=""#)
+        .nth(1)
+        .and_then(|rest| rest.split('"').next())
+        .and_then(|value| value.parse().ok())
+        .unwrap();
+    assert!(tabs_per_board >= 1);
+    // Every tab splits its board's slot once, so a board with k tabs leaves
+    // k routed voids, and every tab carries five break holes.
+    assert_eq!(xml.matches("<Cutout>").count(), 4 * tabs_per_board);
+    let holes = xml.matches(r#"diameter="0.381""#).count();
+    assert_eq!(holes, 4 * tabs_per_board * 5);
+    let reparsed = Ipc2581::parse(&xml).unwrap();
+    let array = reparsed
+        .ecad()
+        .unwrap()
+        .cad_data
+        .steps
+        .iter()
+        .find(|step| reparsed.resolve(step.name) == "array")
+        .unwrap();
+    assert_eq!(
+        array.profile.as_ref().unwrap().cutouts.len(),
+        4 * tabs_per_board
+    );
 }

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/tests.rs
@@ -180,7 +180,7 @@ fn generated_board_array_has_a_certified_safe_balancing_region() {
     let input = board_fixture_with_mask_bbox_mm(12.0, 10.0);
     let source = Ipc2581::parse(&input).unwrap();
     let (options, validation_mode, panelization) =
-        auto_board_array_options(&source, None, Separation::VScore, resolution).unwrap();
+        auto_board_array_options(&source, None, resolution).unwrap();
     let spec = build_board_array_spec(
         &source,
         &options,
@@ -251,7 +251,7 @@ fn board_array_balancing_solves_every_copper_layer() {
     let ipc = Ipc2581::parse(&input).unwrap();
     let sheet = Some(AutoSheetSize::A7);
     let (options, validation_mode, panelization) =
-        auto_board_array_options(&ipc, sheet, Separation::VScore, resolution).unwrap();
+        auto_board_array_options(&ipc, sheet, resolution).unwrap();
     let spec = build_board_array_spec(
         &ipc,
         &options,
@@ -415,7 +415,7 @@ fn automatic_balancing_regions_scope_panel_fiducials_to_both_surface_copper_laye
     // how much panel surrounds it.
     let sheet = Some(AutoSheetSize::A6);
     let (options, validation_mode, panelization) =
-        auto_board_array_options(&ipc, sheet, Separation::VScore, resolution).unwrap();
+        auto_board_array_options(&ipc, sheet, resolution).unwrap();
     let spec = build_board_array_spec(
         &ipc,
         &options,

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/xml.rs
@@ -106,11 +106,13 @@ fn write_content_refs_xml(spec: &BoardArraySpec) -> String {
 
 pub(super) fn write_generated_specs_xml(spec: &BoardArraySpec) -> String {
     let mut writer = XmlWriter::new();
-    writer.start_element("Spec", &[("name", spec.vcut_spec_name.as_str())]);
-    writer.start_element("V_Cut", &[("type", "OFFSET")]);
-    writer.empty_element("Property", &[("value", "0"), ("unit", "MM")]);
-    writer.end_element("V_Cut");
-    writer.end_element("Spec");
+    if let Some(vcut_spec_name) = &spec.vcut_spec_name {
+        writer.start_element("Spec", &[("name", vcut_spec_name.as_str())]);
+        writer.start_element("V_Cut", &[("type", "OFFSET")]);
+        writer.empty_element("Property", &[("value", "0"), ("unit", "MM")]);
+        writer.end_element("V_Cut");
+        writer.end_element("Spec");
+    }
     writer.into_string()
 }
 
@@ -179,7 +181,7 @@ pub(super) fn write_array_step_xml(spec: &BoardArraySpec) -> Result<String> {
     write_panelization_metadata(&mut writer, spec);
     write::location(&mut writer, "Datum", 0.0, 0.0, spec.units);
 
-    write::profile(
+    write::profile_with_cutouts(
         &mut writer,
         spec.units,
         &rounded_rectangle_polygon(
@@ -187,6 +189,7 @@ pub(super) fn write_array_step_xml(spec: &BoardArraySpec) -> Result<String> {
             spec.array_height_mm,
             ARRAY_CORNER_RADIUS_MM,
         ),
+        &spec.profile_cutouts,
     );
 
     write_array_step_repeat(&mut writer, spec);
@@ -210,6 +213,18 @@ pub(super) fn write_panelization_metadata(writer: &mut XmlWriter, spec: &BoardAr
         write_metadata_double(writer, "diode.panelize.sheet_height_mm", target.height);
     }
 
+    write_metadata_string(
+        writer,
+        "diode.panelize.separation",
+        spec.separation.as_str(),
+    );
+    if spec.separation == Separation::MouseBite {
+        write_metadata_integer(
+            writer,
+            "diode.panelize.tabs_per_board",
+            spec.tabs_per_board as u32,
+        );
+    }
     write_metadata_integer(writer, "diode.panelize.columns", spec.columns);
     write_metadata_integer(writer, "diode.panelize.rows", spec.rows);
     write_margin_metadata(writer, "diode.panelize.board_margin", spec.board_margin_mm);

--- a/crates/pcb-ipc2581-tools/src/commands/dfm.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/dfm.rs
@@ -1103,6 +1103,7 @@ reason = "old finding"
                 edge_rail_mm: EdgeInsetsMm::all(5.0),
             },
             false,
+            crate::commands::board_array::Separation::VScore,
             resolution,
         )
         .unwrap()

--- a/crates/pcb-ir/src/geom/mouse_bite.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite.rs
@@ -108,48 +108,116 @@ fn stroke(path: &ContourBuf, width: f64, resolution: Resolution) -> Result<Conto
     Ok(ContourSet::from_filled_contours(&contours, resolution)?)
 }
 
-/// Extract an exact portion of the supplied polygon boundary, including its
-/// vertices and requested drill stations, even when it crosses the cyclic seam.
+/// The portion of the offset boundary carrying the drill row, with its
+/// vertices, and the drill centers. Consecutive centers sit one pitch apart
+/// in a straight line rather than along the curve, so the web between holes
+/// is the same on any curvature while the row still follows the boundary.
 fn row(
     region: &ContourSet,
     query: &BoundaryQuery<'_>,
     boundary: BoundaryId,
     center: f64,
-) -> Result<(ContourBuf, Vec<Point>), QueryError> {
-    let half = 2.0 * SparkFunShallow::PITCH_MM + SparkFunShallow::CUTTER_RADIUS_MM;
+) -> Result<(ContourBuf, Vec<(f64, Point)>), QueryError> {
+    let ring = &region.rings[boundary.ring];
     let perimeter = query.perimeter(boundary)?;
-    if perimeter <= 2.0 * half {
+    let mut centers = vec![(center, query.site(boundary, center)?.point)];
+    for direction in [1.0, -1.0] {
+        let mut last = centers[0];
+        for _ in 0..SparkFunShallow::HOLE_COUNT / 2 {
+            last = chord_step(ring, perimeter, last, SparkFunShallow::PITCH_MM, direction)?;
+            if direction > 0.0 {
+                centers.push(last);
+            } else {
+                centers.insert(0, last);
+            }
+        }
+    }
+    let first = centers[0].0 - SparkFunShallow::CUTTER_RADIUS_MM;
+    let length = centers[centers.len() - 1].0 + SparkFunShallow::CUTTER_RADIUS_MM - first;
+    if length >= perimeter {
         return Err(QueryError::InvalidInput("attachment boundary too short"));
     }
-    let start = center - half;
-    let mut stations = vec![0.0, 2.0 * half];
+    let mut stations = vec![0.0, length];
     let mut cumulative = 0.0;
-    for (a, b) in super::region::ring_edges(&region.rings[boundary.ring]) {
-        let s = (cumulative - start).rem_euclid(perimeter);
-        if s > 0.0 && s < 2.0 * half {
+    for (a, b) in super::region::ring_edges(ring) {
+        let s = (cumulative - first).rem_euclid(perimeter);
+        if s > 0.0 && s < length {
             stations.push(s);
         }
         cumulative += a.distance_to(b);
     }
-    let drill_stations = (0..SparkFunShallow::HOLE_COUNT)
-        .map(|i| half + (i as f64 - 2.0) * SparkFunShallow::PITCH_MM)
-        .collect::<Vec<_>>();
-    stations.extend(&drill_stations);
+    stations.extend(centers.iter().map(|(s, _)| s - first));
     stations.sort_by(f64::total_cmp);
     stations.dedup();
     let points = stations
         .into_iter()
-        .map(|s| query.site(boundary, start + s).map(|site| site.point))
+        .map(|s| query.site(boundary, first + s).map(|site| site.point))
         .collect::<Result<Vec<_>, _>>()?;
     let mut cmds = vec![PathCmd::move_to(points[0])];
     cmds.extend(points[1..].iter().copied().map(PathCmd::line_to));
-    let centers = drill_stations
-        .into_iter()
-        .map(|s| query.site(boundary, start + s).map(|site| site.point))
-        .collect::<Result<Vec<_>, _>>()?;
     Ok((
         ContourBuf::new(cmds).with_uncertainty(region.uncertainty_mm),
         centers,
+    ))
+}
+
+/// Walk the ring from `from` in `direction` to the first point a straight
+/// `chord` away from it, returning that point with its unwrapped station.
+fn chord_step(
+    ring: &[[f64; 2]],
+    perimeter: f64,
+    from: (f64, Point),
+    chord: f64,
+    direction: f64,
+) -> Result<(f64, Point), QueryError> {
+    let n = ring.len();
+    let vertex = |i: usize| Point::new(ring[i % n][0], ring[i % n][1]);
+    let mut stations = vec![0.0];
+    for i in 0..n {
+        stations.push(stations[i] + vertex(i).distance_to(vertex(i + 1)));
+    }
+    let forward = direction > 0.0;
+    let s = match from.0.rem_euclid(perimeter) {
+        0.0 if !forward => perimeter,
+        s => s,
+    };
+    let mut edge = if forward {
+        stations.partition_point(|&v| v <= s)
+    } else {
+        stations.partition_point(|&v| v < s)
+    }
+    .saturating_sub(1)
+    .min(n - 1);
+    let (mut station, mut point) = from;
+    for _ in 0..=n {
+        let end = if forward {
+            vertex(edge + 1)
+        } else {
+            vertex(edge)
+        };
+        let segment = end - point;
+        let length = segment.length();
+        if length > 0.0 {
+            // Leaving the circle of radius `chord` around the origin: the
+            // larger root, since the walk starts inside it.
+            let offset = point - from.1;
+            let a = segment.x * segment.x + segment.y * segment.y;
+            let b = 2.0 * (offset.x * segment.x + offset.y * segment.y);
+            let c = offset.x * offset.x + offset.y * offset.y - chord * chord;
+            let discriminant = b * b - 4.0 * a * c;
+            if discriminant >= 0.0 {
+                let t = (-b + discriminant.sqrt()) / (2.0 * a);
+                if t > 0.0 && t <= 1.0 {
+                    return Ok((station + direction * t * length, point + segment * t));
+                }
+            }
+        }
+        station += direction * length;
+        point = end;
+        edge = if forward { edge + 1 } else { edge + n - 1 } % n;
+    }
+    Err(QueryError::InvalidInput(
+        "boundary too short for the drill row",
     ))
 }
 
@@ -240,6 +308,7 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
         projection.site.boundary,
         projection.site.station_mm,
     )?;
+    let centers: Vec<Point> = centers.into_iter().map(|(_, p)| p).collect();
     let diameter = SparkFunShallow::HOLE_DIAMETER_MM;
     let minimum_ligament_mm = centers
         .iter()
@@ -250,10 +319,14 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
                 .map(move |b| a.distance_to(*b) - diameter)
         })
         .fold(f64::INFINITY, f64::min);
+    // The web between any two holes is a straight-line DFM distance and may
+    // not fall below the pattern's nominal ligament, less the uncertainty.
     let boundary_band = input.tolerance.boundary_mm.max(offset.uncertainty_mm);
-    if minimum_ligament_mm <= 2.0 * boundary_band + input.tolerance.numerical_mm {
+    if minimum_ligament_mm
+        < SparkFunShallow::NOMINAL_LIGAMENT_MM - 2.0 * boundary_band - input.tolerance.numerical_mm
+    {
         return Err(QueryError::InvalidInput(
-            "drill ligaments unresolved or overlapping",
+            "drill web below the pattern's ligament",
         ));
     }
     let circle = ContourSet::from_filled_contours(

--- a/crates/pcb-ir/src/geom/mouse_bite.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite.rs
@@ -63,6 +63,10 @@ pub struct TabGeometry {
     /// Open polygon path following the offset boundary, through every drill.
     /// This is a proposed fracture locus, NOT a predicted crack trajectory.
     pub break_path: ContourBuf,
+    /// The straight bridge from the board boundary to the support anchor,
+    /// before the cutter's fillets: subtract it from a wider void and open
+    /// with the cutter to continue the footprint beyond this construction.
+    pub neck: ContourSet,
     /// Complete unperforated footprint for downstream obstacle clearance checks.
     pub attachment_footprint: ContourSet,
     /// Rounded material added by disk-opening the ideal routing void.
@@ -229,33 +233,48 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
     BoundaryQuery::new(input.stock, input.tolerance)?;
     BoundaryQuery::new(input.support, input.tolerance)?;
     let site = query.site(input.boundary, input.station_mm)?;
-    if input.board.connected_components().len() != 1
-        || input.support.connected_components().len() != 1
-        || !input.board.intersection(input.support)?.is_empty()
-        || !input
-            .board
-            .union(input.support)?
-            .difference(input.stock)?
-            .is_empty()
-        || ![
-            (input.support, input.support_anchor),
-            (input.board, input.board_witness),
-        ]
-        .into_iter()
-        .all(|(region, point)| {
-            point.is_finite()
-                && region
-                    .prepare_query()
-                    .signed_distance(point)
-                    .is_some_and(|d| {
-                        d.mm < -input.tolerance.boundary_mm.max(d.uncertainty_mm)
-                            - input.tolerance.numerical_mm
-                    })
-        })
-    {
-        return Err(QueryError::InvalidInput(
-            "expected disjoint connected board/support inside stock with interior witnesses",
-        ));
+    let interior = |region: &ContourSet, point: Point| {
+        point.is_finite()
+            && region
+                .prepare_query()
+                .signed_distance(point)
+                .is_some_and(|d| {
+                    d.mm < -input.tolerance.boundary_mm.max(d.uncertainty_mm)
+                        - input.tolerance.numerical_mm
+                })
+    };
+    let expected = [
+        (
+            input.board.connected_components().len() == 1,
+            "expected one connected board",
+        ),
+        (
+            input.support.connected_components().len() == 1,
+            "expected one connected support",
+        ),
+        (
+            input.board.intersection(input.support)?.is_empty(),
+            "expected disjoint board and support",
+        ),
+        (
+            input
+                .board
+                .union(input.support)?
+                .difference(input.stock)?
+                .is_empty(),
+            "expected board and support inside stock",
+        ),
+        (
+            interior(input.support, input.support_anchor),
+            "expected the support anchor inside support",
+        ),
+        (
+            interior(input.board, input.board_witness),
+            "expected the board witness inside the board",
+        ),
+    ];
+    if let Some((_, message)) = expected.iter().find(|(holds, _)| !holds) {
+        return Err(QueryError::InvalidInput(message));
     }
     let radius = SparkFunShallow::CUTTER_RADIUS_MM;
     let resolution = input.stock.resolution.strict().with_accuracy(
@@ -285,8 +304,18 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
         .disk_open(radius)?
         .intersection(input.stock)?;
     let undrilled = input.stock.difference(&routed_removal)?;
-    let shoulders = undrilled.difference(&protected)?;
-    let attachment_footprint = undrilled.difference(&input.board.union(input.support)?)?;
+    // Opening can also leave material in slivers of void too narrow for the
+    // cutter anywhere in the stock; the attachment is only what joins the neck.
+    let mut attachment_footprint = ContourSet::empty(resolution);
+    for piece in undrilled
+        .difference(&input.board.union(input.support)?)?
+        .connected_components()
+    {
+        if !piece.intersection(&neck)?.is_empty() {
+            attachment_footprint = attachment_footprint.union(&piece)?;
+        }
+    }
+    let shoulders = attachment_footprint.difference(&protected)?;
 
     // Offset the whole region first, rather than guessing normals on a curved
     // row or assigning straight-line pitch to the source curve's arc length.
@@ -372,6 +401,7 @@ pub fn build(input: Attachment<'_>) -> Result<TabGeometry, QueryError> {
         npth,
         perforations,
         break_path,
+        neck,
         attachment_footprint,
         shoulders,
         minimum_ligament_mm,

--- a/crates/pcb-ir/src/geom/mouse_bite/README.md
+++ b/crates/pcb-ir/src/geom/mouse_bite/README.md
@@ -17,8 +17,8 @@ The paper's recommendations, **not** its introductory industry survey, are:
 | Dimension | `SparkFunShallow` | Provenance |
 |---|---:|---|
 | NPTH diameter | 0.381 mm (0.015 in) | Paper p9 |
-| Center pitch | 0.635 mm (0.025 in) | Paper p9; applied to offset polygon arc length |
-| Nominal straight ligament | 0.254 mm | Pitch − diameter; curved chord ligaments are measured separately |
+| Center pitch | 0.635 mm (0.025 in) | Paper p9; applied as a straight chord between consecutive centers along the offset polygon, so the web is the same on curves |
+| Nominal straight ligament | 0.254 mm | Pitch − diameter; the all-pairs chord ligament may not fall below it |
 | Outward center offset | 0.127 mm (0.005 in) | **Experimental project adaptation**, not a SparkFun measurement |
 | Nominal straight board intrusion | 0.0635 mm | Radius − outward offset, not a damage-zone prediction |
 | Hole count / straight neck width | 5 / 2.0 mm | Project construction choice; 2.54 mm center span overlaps shoulders |
@@ -40,8 +40,10 @@ tool's jaw access, support shape, or curved-tab compatibility.
 The straight 2 mm neck connects the explicit anchor to the supplied site. Opening
 the ideal routing void with the 0.5 mm cutter disk leaves rounded shoulders.
 The board's outward disk offset supplies a cyclic polygon break row, preserving
-all intervening vertices and five equally spaced stations. This avoids inventing
-smooth-curve tangents, curvature thresholds, or arc-length error bounds.
+all intervening vertices, with five centers each one straight pitch from the
+last along it. This avoids inventing smooth-curve tangents, curvature
+thresholds, or arc-length error bounds, and keeps the web between holes a
+straight-line distance on curves.
 
 Outputs keep retained substrate, routed removal, full drill masks, analytic
 NPTH centers/diameters, attachment footprint and shoulder material distinct.

--- a/crates/pcb-ir/src/geom/mouse_bite/tests.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite/tests.rs
@@ -61,8 +61,13 @@ fn straight_and_curved_retention_release_intrusion_and_cutter_access() -> Result
         let (board, support, stock) = fixture(curved);
         let tab = tab(&board, &support, &stock).unwrap();
         assert_eq!(tab.npth.len(), 5);
-        assert!(tab.minimum_ligament_mm > 0.25);
-        assert!(tab.minimum_ligament_mm <= SparkFunShallow::NOMINAL_LIGAMENT_MM + 1e-6);
+        // Consecutive centers are one pitch apart in a straight line on the
+        // curve as on the straight edge, so the web is exactly nominal.
+        for pair in tab.npth.windows(2) {
+            let chord = pair[0].center.distance_to(pair[1].center);
+            assert!((chord - SparkFunShallow::PITCH_MM).abs() < 1e-9, "{chord}");
+        }
+        assert!((tab.minimum_ligament_mm - SparkFunShallow::NOMINAL_LIGAMENT_MM).abs() < 1e-9);
         // Repeated overlays on curved polygons can leave sub-micron slivers.
         // Check both area and penetration for every material/removal pair,
         // including drill boundaries whose last-bit rounding varies by platform.

--- a/crates/pcb-ir/src/geom/mouse_bite/tests.rs
+++ b/crates/pcb-ir/src/geom/mouse_bite/tests.rs
@@ -176,11 +176,13 @@ fn witnesses_must_be_interior_to_the_original_regions() {
         .unwrap()
         .site
         .station_mm;
-    for (support_anchor, board_witness) in [
-        (Point::new(0.0, 3.0), Point::new(0.0, -5.0)),
-        (Point::new(0.0, 3.0 - 1e-7), Point::new(0.0, -5.0)),
-        (Point::new(0.0, 5.0), Point::ZERO),
-        (Point::new(0.0, 5.0), Point::new(0.0, 1e-7)),
+    let anchor = "expected the support anchor inside support";
+    let witness = "expected the board witness inside the board";
+    for (support_anchor, board_witness, expected) in [
+        (Point::new(0.0, 3.0), Point::new(0.0, -5.0), anchor),
+        (Point::new(0.0, 3.0 - 1e-7), Point::new(0.0, -5.0), anchor),
+        (Point::new(0.0, 5.0), Point::ZERO, witness),
+        (Point::new(0.0, 5.0), Point::new(0.0, 1e-7), witness),
     ] {
         assert!(matches!(
             build(Attachment {
@@ -193,9 +195,7 @@ fn witnesses_must_be_interior_to_the_original_regions() {
                 board_witness,
                 tolerance: TOL,
             }),
-            Err(QueryError::InvalidInput(
-                "expected disjoint connected board/support inside stock with interior witnesses"
-            ))
+            Err(QueryError::InvalidInput(message)) if message == expected
         ));
     }
 }

--- a/crates/pcbc/src/ipc2581.rs
+++ b/crates/pcbc/src/ipc2581.rs
@@ -258,24 +258,12 @@ enum BoardArrayCommands {
         /// Input IPC-2581 XML; --mouse-bite requires one board definition.
         #[arg(value_hint = clap::ValueHint::FilePath)]
         input: PathBuf,
-        /// Analyze outline eligibility only: writes JSON, NOT a mouse-bite panel.
-        #[arg(long, requires_all = ["mouse_bite_width", "mouse_bite_inward", "mouse_bite_outward", "mouse_bite_clearance"], conflicts_with_all = ["auto", "sheet", "columns", "rows", "board_margin", "edge_rail", "copper_balance", "no_copper_balance"])]
+        /// Separate boards with routed slots and perforated mouse-bite tabs instead of V-scores.
+        #[arg(long, conflicts_with = "mouse_bite_placement")]
         mouse_bite: bool,
-        /// Choose mouse-bite tab sites with the built-in preset: writes JSON, NOT a panel.
-        #[arg(long, conflicts_with_all = ["mouse_bite", "auto", "sheet", "columns", "rows", "board_margin", "edge_rail", "copper_balance", "no_copper_balance"])]
+        /// Analyze where mouse-bite tabs would go on the board: writes JSON, not a panel.
+        #[arg(long, conflicts_with_all = ["auto", "sheet", "columns", "rows", "board_margin", "edge_rail", "copper_balance", "no_copper_balance"])]
         mouse_bite_placement: bool,
-        /// Analysis band width along the cyclic outline, in mm; no manufacturing default.
-        #[arg(long, requires = "mouse_bite")]
-        mouse_bite_width: Option<f64>,
-        /// Analysis band depth into substrate, in mm.
-        #[arg(long, requires = "mouse_bite")]
-        mouse_bite_inward: Option<f64>,
-        /// Analysis band depth outside substrate, in mm.
-        #[arg(long, requires = "mouse_bite")]
-        mouse_bite_outward: Option<f64>,
-        /// Isotropic courtyard/exclusion expansion in mm (0 adds no clearance).
-        #[arg(long, requires = "mouse_bite")]
-        mouse_bite_clearance: Option<f64>,
         /// Choose the smallest fitting A-series board array automatically.
         #[arg(long)]
         auto: bool,
@@ -296,7 +284,7 @@ enum BoardArrayCommands {
         edge_rail: Vec<f64>,
         #[command(flatten)]
         copper_balance: CopperBalanceArgs,
-        /// Output IPC-2581 XML (eligibility JSON with --mouse-bite), or '-' for stdout
+        /// Output IPC-2581 XML (placement JSON with --mouse-bite-placement), or '-' for stdout
         #[arg(short, long, value_hint = clap::ValueHint::AnyPath)]
         output: PathBuf,
     },
@@ -479,10 +467,6 @@ pub fn execute(args: Ipc2581Args, resolution: Resolution) -> anyhow::Result<()> 
                 input,
                 mouse_bite,
                 mouse_bite_placement,
-                mouse_bite_width,
-                mouse_bite_inward,
-                mouse_bite_outward,
-                mouse_bite_clearance,
                 auto,
                 sheet,
                 columns,
@@ -495,19 +479,11 @@ pub fn execute(args: Ipc2581Args, resolution: Resolution) -> anyhow::Result<()> 
                 if mouse_bite_placement {
                     return commands::board_array::placement::execute(&input, &output, resolution);
                 }
-                if mouse_bite {
-                    return commands::board_array::eligibility::execute(
-                        &input,
-                        &output,
-                        pcb_ir::geom::attachment::outline::OutlineFootprint {
-                            width_mm: mouse_bite_width.expect("required by clap"),
-                            inward_mm: mouse_bite_inward.expect("required by clap"),
-                            outward_mm: mouse_bite_outward.expect("required by clap"),
-                        },
-                        mouse_bite_clearance.expect("required by clap"),
-                        resolution,
-                    );
-                }
+                let separation = if mouse_bite {
+                    commands::board_array::Separation::MouseBite
+                } else {
+                    commands::board_array::Separation::VScore
+                };
                 let copper_balance = copper_balance.resolve(true);
                 if auto || sheet.is_some() {
                     if columns.is_some()
@@ -524,6 +500,7 @@ pub fn execute(args: Ipc2581Args, resolution: Resolution) -> anyhow::Result<()> 
                         &output,
                         sheet,
                         copper_balance,
+                        separation,
                         resolution,
                     )
                 } else {
@@ -550,6 +527,7 @@ pub fn execute(args: Ipc2581Args, resolution: Resolution) -> anyhow::Result<()> 
                             edge_rail_mm,
                         },
                         copper_balance,
+                        separation,
                         resolution,
                     )
                 }
@@ -680,7 +658,7 @@ mod tests {
     use clap::Parser;
 
     #[test]
-    fn mouse_bite_requires_explicit_policy_and_rejects_panel_options() {
+    fn mouse_bite_flags_combine_with_layout_but_placement_analysis_stands_alone() {
         let base = [
             "pcb",
             "ipc2581",
@@ -688,56 +666,25 @@ mod tests {
             "create",
             "board.xml",
             "-o",
-            "-",
+            "out",
         ];
-        assert!(crate::Cli::try_parse_from(base).is_ok());
-        let policy = [
-            "--mouse-bite",
-            "--mouse-bite-width",
-            "2",
-            "--mouse-bite-inward",
-            "0.2",
-            "--mouse-bite-outward",
-            "2",
-            "--mouse-bite-clearance",
-            "0",
-        ];
-        assert!(crate::Cli::try_parse_from(base.into_iter().chain(policy)).is_ok());
-        for omitted in [1, 3, 5, 7] {
-            let args = policy
-                .iter()
-                .enumerate()
-                .filter(|(i, _)| *i != omitted && *i != omitted + 1)
-                .map(|(_, arg)| *arg);
-            assert!(crate::Cli::try_parse_from(base.into_iter().chain(args)).is_err());
-        }
-        for conflicting in [
-            vec!["--auto"],
-            vec!["--columns", "2"],
-            vec!["--no-copper-balance"],
-            vec!["--board-margin", "5"],
+        for args in [
+            vec!["--mouse-bite", "--auto"],
+            vec!["--mouse-bite", "--columns", "2"],
         ] {
-            assert!(
-                crate::Cli::try_parse_from(base.into_iter().chain(policy).chain(conflicting))
-                    .is_err()
-            );
+            assert!(crate::Cli::try_parse_from(base.into_iter().chain(args)).is_ok());
         }
-        assert!(
-            crate::Cli::try_parse_from(base.into_iter().chain(["--mouse-bite-width", "2"]))
-                .is_err()
-        );
-        let placement = ["--mouse-bite-placement"];
-        assert!(crate::Cli::try_parse_from(base.into_iter().chain(placement)).is_ok());
-        for conflicting in [vec!["--auto"], vec!["--mouse-bite"], vec!["--columns", "2"]] {
-            assert!(
-                crate::Cli::try_parse_from(base.into_iter().chain(placement).chain(conflicting))
-                    .is_err()
-            );
+        for args in [
+            vec!["--mouse-bite-placement", "--auto"],
+            vec!["--mouse-bite-placement", "--mouse-bite"],
+            vec!["--mouse-bite-placement", "--no-copper-balance"],
+        ] {
+            assert!(crate::Cli::try_parse_from(base.into_iter().chain(args)).is_err());
         }
     }
 
     #[test]
-    fn mouse_bite_create_writes_analysis_json_instead_of_panel_xml() {
+    fn mouse_bite_placement_writes_analysis_json_instead_of_panel_xml() {
         let dir = tempfile::tempdir().unwrap();
         let input = dir.path().join("board.xml");
         let output = dir.path().join("report.json");
@@ -752,15 +699,7 @@ mod tests {
             "board-array",
             "create",
             input.to_str().unwrap(),
-            "--mouse-bite",
-            "--mouse-bite-width",
-            "2",
-            "--mouse-bite-inward",
-            "0.2",
-            "--mouse-bite-outward",
-            "2",
-            "--mouse-bite-clearance",
-            "0",
+            "--mouse-bite-placement",
             "-o",
             output.to_str().unwrap(),
         ])
@@ -771,8 +710,9 @@ mod tests {
         execute(args, Resolution::default()).unwrap();
         let report: serde_json::Value =
             serde_json::from_slice(&std::fs::read(output).unwrap()).unwrap();
-        assert_eq!(report["phase"], "outline-eligibility-only");
+        assert_eq!(report["phase"], "tab-placement-only");
         assert_eq!(report["manufacturing_ready"], false);
         assert!(!report["intervals"].as_array().unwrap().is_empty());
+        assert!(report["placement"]["tab_count"].as_u64().unwrap() > 0);
     }
 }

--- a/crates/pcbc/tests/dfm.rs
+++ b/crates/pcbc/tests/dfm.rs
@@ -596,6 +596,7 @@ fn ipc_dfm_geometry_distinguishes_canonical_board_arrays_and_mixed_fab_scope() {
         IPC_BOARD,
         &array_options,
         false,
+        pcb_ipc2581_tools::commands::board_array::Separation::VScore,
         pcb_ir::geom::Resolution::default(),
     )
     .unwrap();
@@ -603,6 +604,7 @@ fn ipc_dfm_geometry_distinguishes_canonical_board_arrays_and_mixed_fab_scope() {
         &IPC_BOARD.replace("name=\"board\"", "name=\"other\""),
         &array_options,
         false,
+        pcb_ipc2581_tools::commands::board_array::Separation::VScore,
         pcb_ir::geom::Resolution::default(),
     )
     .unwrap();

--- a/crates/pcbc/tests/ipc2581.rs
+++ b/crates/pcbc/tests/ipc2581.rs
@@ -86,6 +86,7 @@ fn accuracy_reaches_ipc_manufacturing_geometry() {
             edge_rail_mm: BoardMarginMm::all(5.0),
         },
         false,
+        pcb_ipc2581_tools::commands::board_array::Separation::VScore,
         Resolution::default(),
     )
     .unwrap();


### PR DESCRIPTION
`board-array create --mouse-bite` now emits a routed array: outline-following 1.4 mm slots as profile cutouts, perforated tabs at the placed sites, and their break holes as non-plated drills. Tabs follow the SparkFun pattern with chord-spaced holes and cutter fillets, and the array fits its sheet exactly as the scored one does.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1271" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->