### PR TITLE
Fix false schematic apply open failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Preserve successful BOM matches when another line needs retrying.
+- Fix false missing-output errors after applying schematics.
 
 ## [0.4.52] - 2026-09-09
 

--- a/crates/pcb-kicad/src/lib.rs
+++ b/crates/pcb-kicad/src/lib.rs
@@ -28,6 +28,7 @@ struct PlatformDefaults {
     kicad_cli: &'static [&'static str],
     kicad_cli_command: &'static str,
     pcbnew: &'static [&'static str],
+    eeschema: &'static [&'static str],
 }
 
 struct KiCadInstallation {
@@ -35,6 +36,7 @@ struct KiCadInstallation {
     python_site_packages: Option<String>,
     kicad_cli: String,
     pcbnew: String,
+    eeschema: String,
 }
 
 impl KiCadInstallation {
@@ -56,6 +58,7 @@ impl KiCadInstallation {
                 defaults.kicad_cli,
             ),
             pcbnew: discover_path("KICAD_PCBNEW", None, defaults.pcbnew),
+            eeschema: discover_path("KICAD_EESCHEMA", None, defaults.eeschema),
         }
     }
 
@@ -120,6 +123,9 @@ fn platform_defaults() -> PlatformDefaults {
         pcbnew: &[
             "/Applications/KiCad/KiCad.app/Contents/Applications/pcbnew.app/Contents/MacOS/pcbnew",
         ],
+        eeschema: &[
+            "/Applications/KiCad/KiCad.app/Contents/Applications/eeschema.app/Contents/MacOS/eeschema",
+        ],
     }
 }
 
@@ -139,6 +145,10 @@ fn platform_defaults() -> PlatformDefaults {
             r"C:\Program Files\KiCad\10.0\bin\pcbnew.exe",
             r"C:\Program Files\KiCad\9.0\bin\pcbnew.exe",
         ],
+        eeschema: &[
+            r"C:\Program Files\KiCad\10.0\bin\eeschema.exe",
+            r"C:\Program Files\KiCad\9.0\bin\eeschema.exe",
+        ],
     }
 }
 
@@ -149,6 +159,7 @@ fn platform_defaults() -> PlatformDefaults {
         kicad_cli: &["/usr/bin/kicad-cli"],
         kicad_cli_command: "kicad-cli",
         pcbnew: &["/usr/bin/pcbnew"],
+        eeschema: &["/usr/bin/eeschema"],
     }
 }
 
@@ -309,6 +320,38 @@ fn spawn_pcbnew_command(mut cmd: Command, pcbnew_path: &str, pcb_path: &Path) ->
                 pcb_path.display()
             )
         })
+}
+
+/// Open a KiCad schematic in the editor that matches this toolchain's discovered install.
+pub fn open_eeschema(schematic_path: impl AsRef<Path>) -> Result<()> {
+    let schematic_path = schematic_path.as_ref();
+    if !schematic_path.is_file() {
+        anyhow::bail!("Schematic file not found: {}", schematic_path.display());
+    }
+
+    let eeschema = KiCadInstallation::discover().eeschema;
+    if !Path::new(&eeschema).exists() {
+        anyhow::bail!(
+            "KiCad Schematic Editor not found at expected location: {eeschema}\n\
+             Please ensure KiCad is installed.\n\
+             If KiCad Schematic Editor is in a non-standard location, set the KICAD_EESCHEMA environment variable."
+        );
+    }
+
+    let mut cmd = Command::new(&eeschema);
+    cmd.arg(schematic_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .with_context(|| {
+            format!(
+                "Failed to launch KiCad Schematic Editor at {} for {}",
+                eeschema,
+                schematic_path.display()
+            )
+        })?;
+    Ok(())
 }
 
 /// Builder for KiCad CLI commands

--- a/crates/pcbc/src/apply.rs
+++ b/crates/pcbc/src/apply.rs
@@ -113,7 +113,7 @@ pub fn execute(args: ApplyArgs) -> Result<()> {
             if !args.shared.no_open
                 && let Some(result) = &result
             {
-                open_path(&result.root_schematic, "schematic")?;
+                pcb_kicad::open_eeschema(&result.root_schematic)?;
             }
             Ok(())
         }

--- a/crates/pcbc/tests/apply.rs
+++ b/crates/pcbc/tests/apply.rs
@@ -1,6 +1,6 @@
 #![cfg(not(target_os = "windows"))]
 
-use std::fs;
+use std::{fs, os::unix::fs::PermissionsExt};
 
 use pcb_kicad_sch::SchItem;
 use pcb_test_utils::sandbox::Sandbox;
@@ -71,6 +71,38 @@ fn apply_schematic_creates_repairs_and_clears_build_diagnostics() {
         .expect("build repaired schematic");
     let diagnostics = String::from_utf8(repaired.stdout).unwrap();
     assert!(!diagnostics.contains("\"kind\": \"sch."), "{diagnostics}");
+}
+
+#[test]
+fn apply_schematic_opens_the_created_output_with_kicad() {
+    let mut sandbox = Sandbox::new().with_workspace();
+    sandbox.write("board.zen", BOARD_ZEN);
+    let editor = sandbox.root_path().join("eeschema");
+    fs::write(&editor, "#!/bin/sh\nexit 0\n").unwrap();
+    fs::set_permissions(&editor, fs::Permissions::from_mode(0o755)).unwrap();
+    sandbox.env("KICAD_EESCHEMA", editor.to_string_lossy());
+    // No generic desktop opener is available. Applying must launch the KiCad
+    // schematic editor directly rather than misreporting the output as absent.
+    let empty_path = sandbox.root_path().to_string_lossy().into_owned();
+    sandbox.env("PATH", empty_path);
+
+    sandbox
+        .run("pcbc", ["apply", "schematic", "board.zen"])
+        .run()
+        .expect("create and open schematic project");
+
+    let output = sandbox.root_path().join("hardware/ApplyTest.kicad_sch");
+    assert!(output.is_file());
+    let reopened = sandbox
+        .run("pcbc", ["apply", "schematic", "board.zen"])
+        .stdout_capture()
+        .run()
+        .expect("reopen unchanged schematic project");
+    assert!(
+        String::from_utf8(reopened.stdout)
+            .unwrap()
+            .contains("schematic unchanged")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- launch the verified schematic output directly with KiCad instead of a generic desktop opener
- discover the KiCad schematic editor through platform defaults or `KICAD_EESCHEMA`
- cover create/open and idempotent reopen when desktop launchers are unavailable

## Root cause
`pcb apply schematic` completed its atomic write and reload verification successfully. The subsequent generic opener could return `ENOENT` when no desktop launcher executable was installed, and the added path context made that launcher failure look like the written schematic was missing.

## Verification
- `cargo nextest run -p pcbc 'apply::'`
- `cargo nextest run -p pcb-kicad`
- `cargo clippy -p pcb-kicad -p pcbc --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes ENG-1706.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to post-apply schematic launch behavior; layout and full-project open paths are unchanged.
> 
> **Overview**
> **`pcb apply schematic`** no longer opens the written `.kicad_sch` through a generic desktop launcher. After a successful apply it launches **KiCad eeschema** via new **`pcb_kicad::open_eeschema`**, with install discovery matching **`open_pcbnew`** (platform defaults and **`KICAD_EESCHEMA`**).
> 
> This fixes cases where **`ENOENT`** from a missing **`xdg-open`**/`open` helper was surfaced as if the schematic output did not exist, even though the file had been written and verified.
> 
> A sandbox test stubs **`KICAD_EESCHEMA`** with an empty **`PATH`** to assert create/open and unchanged reopen still succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d36e39cb356bd339a34d81992d43d67dc04cf6b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->