### PR TITLE
ENG-1717 Fix rotated mirrored schematic pin geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Wire rotated and mirrored schematic symbol pins at KiCad's physical pin anchors.
 - Preserve successful BOM matches when another line needs retrying.
 - Fix false missing-output errors after applying schematics.
 

--- a/crates/pcb-kicad-sch/src/field_autoplace.rs
+++ b/crates/pcb-kicad-sch/src/field_autoplace.rs
@@ -853,7 +853,7 @@ mod tests {
         assert_eq!(
             symbol.field("Reference").unwrap().justify,
             Some(FieldJustify::new(
-                Some(FieldHorizontalJustify::Left),
+                Some(FieldHorizontalJustify::Right),
                 Some(FieldVerticalJustify::Center),
             ))
         );

--- a/crates/pcb-kicad-sch/src/symbol.rs
+++ b/crates/pcb-kicad-sch/src/symbol.rs
@@ -520,20 +520,19 @@ fn matches_body_style(section: u32, selected: u32) -> bool {
 }
 
 pub(crate) fn transform_vector(mut point: Point, symbol: &Symbol) -> Point {
-    // KiCad composes the symbol matrix as rotation * mirror, so the mirror is
-    // applied to the library-local point before the rotation.
-    point = match symbol.mirror {
-        None => point,
-        Some(MirrorAxis::X) => Point::new(point.x, -point.y),
-        Some(MirrorAxis::Y) => Point::new(-point.x, point.y),
-    };
+    // KiCad parses the symbol's `at` rotation first, then composes the
+    // separately serialized mirror onto that transform.
     point = match symbol.rotation {
         Rotation::Deg0 => point,
         Rotation::Deg90 => Point::new(point.y, -point.x),
         Rotation::Deg180 => Point::new(-point.x, -point.y),
         Rotation::Deg270 => Point::new(-point.y, point.x),
     };
-    point
+    match symbol.mirror {
+        None => point,
+        Some(MirrorAxis::X) => Point::new(point.x, -point.y),
+        Some(MirrorAxis::Y) => Point::new(-point.x, point.y),
+    }
 }
 
 pub(crate) fn transform_point(point: Point, symbol: &Symbol) -> Point {
@@ -551,23 +550,13 @@ fn pin_outward_spin(rotation: Rotation) -> LabelSpin {
 }
 
 fn transform_spin(spin: LabelSpin, symbol: &Symbol) -> LabelSpin {
-    let mut direction = match spin {
+    let direction = match spin {
         LabelSpin::Left => Point::new(-1.0, 0.0),
         LabelSpin::Up => Point::new(0.0, -1.0),
         LabelSpin::Right => Point::new(1.0, 0.0),
         LabelSpin::Bottom => Point::new(0.0, 1.0),
     };
-    direction = match symbol.mirror {
-        None => direction,
-        Some(MirrorAxis::X) => Point::new(direction.x, -direction.y),
-        Some(MirrorAxis::Y) => Point::new(-direction.x, direction.y),
-    };
-    direction = match symbol.rotation {
-        Rotation::Deg0 => direction,
-        Rotation::Deg90 => Point::new(direction.y, -direction.x),
-        Rotation::Deg180 => Point::new(-direction.x, -direction.y),
-        Rotation::Deg270 => Point::new(-direction.y, direction.x),
-    };
+    let direction = transform_vector(direction, symbol);
     match (direction.x as i8, direction.y as i8) {
         (-1, 0) => LabelSpin::Left,
         (0, -1) => LabelSpin::Up,
@@ -652,17 +641,17 @@ mod tests {
             unsupported: Vec::new(),
         };
 
-        // KiCad's matrix is R90 * MirrorX: (2, 3) -> (2, -3) -> (-3, -2).
-        assert_eq!(
-            transform_point(Point::new(2.0, 3.0), &symbol),
-            Point::new(7.0, 18.0)
-        );
-
-        symbol.mirror = Some(MirrorAxis::Y);
-        // R90 * MirrorY: (2, 3) -> (-2, 3) -> (3, 2).
+        // KiCad's matrix is MirrorX * R90: (2, 3) -> (3, -2) -> (3, 2).
         assert_eq!(
             transform_point(Point::new(2.0, 3.0), &symbol),
             Point::new(13.0, 22.0)
+        );
+
+        symbol.mirror = Some(MirrorAxis::Y);
+        // MirrorY * R90: (2, 3) -> (3, -2) -> (-3, -2).
+        assert_eq!(
+            transform_point(Point::new(2.0, 3.0), &symbol),
+            Point::new(7.0, 18.0)
         );
     }
 }

--- a/crates/pcb-kicad-sch/tests/editor_core.rs
+++ b/crates/pcb-kicad-sch/tests/editor_core.rs
@@ -3,9 +3,10 @@ mod common;
 use std::collections::BTreeSet;
 
 use pcb_kicad_sch::{
-    Label, LabelKind, Point, SchDocument, SchItem, SchPage, Symbol, SymbolDefinition,
+    Label, LabelKind, MirrorAxis, Point, Rotation, SchDocument, SchItem, SchPage, Symbol,
+    SymbolDefinition,
     analysis::{SchematicIssue, SchematicIssueKey, inspect_schematic},
-    connectivity::{PhysicalConnectivity, PinVisibility},
+    connectivity::{PhysicalConnectivity, PinVisibility, Terminal},
     deterministic_uuid,
     reconcile::{plan_reconciliation, plan_repairs, sync_netlist_derived_symbol_properties},
 };
@@ -187,22 +188,92 @@ fn netlist_derived_symbol_properties_sync_without_repairing_topology() {
 }
 
 #[test]
-fn reconciliation_drives_each_physical_pin_of_a_logical_terminal() {
+fn reconciliation_wires_kicads_rotated_mirrored_physical_pin_anchors() {
     let netlist = common::compile_fixture("multi_pad", "root.zen");
-    let document = plan_reconciliation(None, &netlist, "MultiPad.kicad_sch")
+    let mut document = plan_reconciliation(None, &netlist, "MultiPad.kicad_sch")
         .unwrap()
         .apply(None)
         .unwrap();
+    let page = document
+        .pages
+        .iter_mut()
+        .find(|page| {
+            page.items.iter().any(|item| {
+                matches!(item, SchItem::Symbol(symbol) if symbol.lib_id.contains("MULTI_PAD"))
+            })
+        })
+        .expect("page containing multi-pin symbol");
+    let symbol = page
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SchItem::Symbol(symbol) if symbol.lib_id.contains("MULTI_PAD") => Some(symbol),
+            _ => None,
+        })
+        .expect("managed multi-pin symbol");
+    symbol.rotation = Rotation::Deg270;
+    symbol.mirror = Some(MirrorAxis::Y);
 
-    let inspection = inspect_schematic(&document, &netlist).unwrap();
+    let definition = &page.library.definitions[&symbol.lib_id];
+    let mut pin_anchors = definition
+        .placed_pins(symbol)
+        .unwrap()
+        .into_iter()
+        .map(|pin| (pin.number, pin.point))
+        .collect::<Vec<_>>();
+    pin_anchors.sort_by(|left, right| left.0.cmp(&right.0));
+    assert_eq!(
+        pin_anchors,
+        vec![
+            (
+                "1".to_string(),
+                Point::new(symbol.at.x - 2.54, symbol.at.y - 5.08),
+            ),
+            (
+                "2".to_string(),
+                Point::new(symbol.at.x - 2.54, symbol.at.y + 5.08),
+            ),
+            (
+                "3".to_string(),
+                Point::new(symbol.at.x + 2.54, symbol.at.y - 5.08),
+            ),
+            (
+                "4".to_string(),
+                Point::new(symbol.at.x + 2.54, symbol.at.y + 5.08),
+            ),
+        ],
+        "KiCad applies the 270-degree rotation before mirror y"
+    );
+
+    let repaired = plan_reconciliation(Some(&document), &netlist, "MultiPad.kicad_sch")
+        .unwrap()
+        .apply(Some(&document))
+        .unwrap();
+    let inspection = inspect_schematic(&repaired, &netlist).unwrap();
     assert!(
         inspection.analysis.is_equivalent(),
         "{:#?}",
         inspection.analysis.issues()
     );
-
-    let unchanged = plan_reconciliation(Some(&document), &netlist, "MultiPad.kicad_sch").unwrap();
-    assert!(unchanged.is_empty(), "{:#?}", unchanged.edits());
+    let physical = PhysicalConnectivity::from_kicad(&repaired, PinVisibility::VisibleOnly).unwrap();
+    for (net_name, expected_numbers) in [("LEFT", ["1", "3"]), ("RIGHT", ["2", "4"])] {
+        let group = physical
+            .graph
+            .groups
+            .iter()
+            .find(|group| group.names.contains(net_name))
+            .unwrap_or_else(|| panic!("missing native net {net_name}"));
+        let actual_numbers = group
+            .terminals
+            .iter()
+            .flat_map(|terminal| match terminal {
+                Terminal::ComponentPin { pin_numbers, .. } => pin_numbers.iter(),
+                Terminal::InterfacePort { .. } => unreachable!(),
+            })
+            .map(String::as_str)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(actual_numbers, BTreeSet::from(expected_numbers));
+    }
 }
 
 #[test]

--- a/crates/pcbc/tests/schematic_apply_flow.rs
+++ b/crates/pcbc/tests/schematic_apply_flow.rs
@@ -3,7 +3,8 @@ use super::schematic_apply_common as common;
 use std::{collections::BTreeSet, fs};
 
 use pcb_kicad_sch::{
-    Label, LabelKind, LabelShape, LabelSpin, PinInstance, Point, SchItem, SymbolDefinition, Wire,
+    Label, LabelKind, LabelShape, LabelSpin, MirrorAxis, PinInstance, Point, Rotation, SchItem,
+    SymbolDefinition, Wire,
     analysis::{SchematicIssue, inspect_schematic},
     reconcile::plan_repairs,
 };
@@ -28,7 +29,15 @@ fn linked_fixture(path: &std::path::Path) -> pcb_sch::Schematic {
 }
 
 fn linked_fixture_from(path: &std::path::Path, entrypoint: &str) -> pcb_sch::Schematic {
-    let mut netlist = common::compile_fixture("analysis", entrypoint);
+    linked_fixture_project(path, "analysis", entrypoint)
+}
+
+fn linked_fixture_project(
+    path: &std::path::Path,
+    fixture: &str,
+    entrypoint: &str,
+) -> pcb_sch::Schematic {
+    let mut netlist = common::compile_fixture(fixture, entrypoint);
     let root = netlist.root_ref.clone().unwrap();
     let package_root = path.parent().unwrap();
     netlist
@@ -1011,6 +1020,41 @@ fn repairs_a_disconnected_net_without_removing_remaining_wires() {
         .unwrap()
         .analysis;
     assert!(analysis.is_equivalent(), "{:?}", analysis.issues());
+}
+
+#[test]
+fn apply_repairs_rotated_mirrored_physical_pin_connectivity() {
+    let workspace = tempfile::tempdir().unwrap();
+    let project_dir = workspace.path().join("hardware");
+    let netlist = linked_fixture_project(&project_dir, "multi_pad", "root.zen");
+    apply_linked_schematic(&netlist).unwrap().unwrap();
+    let mut project = KicadProject::load(&project_dir).unwrap();
+    let symbol = project
+        .document
+        .pages
+        .iter_mut()
+        .flat_map(|page| &mut page.items)
+        .find_map(|item| match item {
+            SchItem::Symbol(symbol) if symbol.lib_id.contains("MULTI_PAD") => Some(symbol),
+            _ => None,
+        })
+        .expect("managed multi-pin symbol");
+    symbol.rotation = Rotation::Deg270;
+    symbol.mirror = Some(MirrorAxis::Y);
+    for file in project.document.to_kicad_sch_files() {
+        fs::write(project_dir.join(file.file_name.unwrap()), file.content).unwrap();
+    }
+
+    let applied = apply_linked_schematic(&netlist).unwrap().unwrap();
+    assert!(applied.changed);
+    let repaired = KicadProject::load(&project_dir).unwrap();
+    let inspection = inspect_schematic(&repaired.document, &netlist).unwrap();
+    assert!(
+        inspection.analysis.is_equivalent(),
+        "{:?}",
+        inspection.analysis.issues()
+    );
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- compose KiCad symbol transforms in native rotation-then-mirror order
- use the shared transform for pin anchors, body anchors, and outward direction
- add physical-pin and filesystem apply regressions for a 270-degree, mirror-Y multi-pin symbol

## Verification
- `cargo nextest run -p pcb-kicad-sch --no-fail-fast` (206 passed, 1 skipped)
- `cargo nextest run -p pcbc --test integration schematic_apply_flow` (22 passed)
- native KiCad 10.0.6 XML export: LEFT contains pins 1/3 and RIGHT contains pins 2/4
- targeted regressions rerun after rebase

Linear: https://linear.app/diodeinc/issue/ENG-1717/strict-schematic-build-misses-mirrored-pin-disconnects

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared symbol transform math used for pin placement, connectivity, and schematic repair; wrong behavior would affect any rotated/mirrored symbols, though the change matches KiCad and is heavily regression-tested.
> 
> **Overview**
> Fixes **incorrect physical pin positions** when schematic symbols use **rotation and mirror**, which caused strict schematic builds to miss wire-to-pin disconnects.
> 
> **`pcb-kicad-sch`** now composes symbol transforms in KiCad’s order (**rotation, then mirror**) in `transform_vector`, and routes pin anchors and outward pin direction through that shared path instead of applying mirror before rotation. Field autoplace picks up the corrected horizontal justification for rotated mirrored symbols.
> 
> **Regression coverage** adds a reconciliation test that checks pin anchors and LEFT/RIGHT net membership for a 270° mirror-Y multi-pad symbol, plus an end-to-end **`pcb apply schematic`** test that rewrites the project and proves equivalence after repair. **CHANGELOG** records the fix under Unreleased.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9cf373b8a4cd9eae5ae15787d783d69644ff830. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->