### PR TITLE
ENG-1674 Repair intentional no-connect markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Wire rotated and mirrored schematic symbol pins at KiCad's physical pin anchors.
+- Report and repair missing Zener `NotConnected()` intent as native KiCad no-connect markers.
 - Preserve successful BOM matches when another line needs retrying.
 - Fix false missing-output errors after applying schematics.
 

--- a/crates/pcb-kicad-sch/src/analysis.rs
+++ b/crates/pcb-kicad-sch/src/analysis.rs
@@ -10,7 +10,8 @@ use crate::{
     connectivity::{
         ComponentIdentity, ComponentOrigin, ConnectionGroup, ConnectionOrigin, ConnectivityGraph,
         ConnectivityItemRef, IslandRef, PhysicalConnectivity, PhysicalIsland, PinVisibility,
-        SymbolLocation, Terminal, TerminalIndex, not_connected_terminals, reduce_with_provenance,
+        SymbolLocation, Terminal, TerminalIndex, not_connected_terminals, points_connect,
+        reduce_with_provenance,
     },
     symbol,
 };
@@ -35,6 +36,15 @@ pub struct NetAnalysis {
     pub missing_terminals: Vec<Terminal>,
     pub islands: Vec<IslandRef>,
     pub connected_islands: Vec<Vec<IslandRef>>,
+}
+
+/// One physical component pin that needs a native KiCad no-connect marker.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NoConnectTarget {
+    pub page_id: String,
+    pub symbol_id: String,
+    pub pin_number: String,
+    pub at: crate::Point,
 }
 
 impl NetAnalysis {
@@ -89,6 +99,15 @@ pub enum SchematicIssue {
         islands: Vec<IslandRef>,
         terminals: Vec<Terminal>,
     },
+    MissingNoConnect {
+        page_id: String,
+        symbol_id: String,
+        pin_number: String,
+    },
+    UnexpectedNoConnect {
+        page_id: String,
+        id: String,
+    },
     Shorted {
         islands: Vec<IslandRef>,
         net_names: BTreeSet<String>,
@@ -110,6 +129,8 @@ impl SchematicIssue {
             SchematicIssue::MissingPort { .. } => "missing_port",
             SchematicIssue::UnexpectedNet { .. } => "unexpected_net",
             SchematicIssue::UnexpectedConnection { .. } => "unexpected_connection",
+            SchematicIssue::MissingNoConnect { .. } => "missing_no_connect",
+            SchematicIssue::UnexpectedNoConnect { .. } => "unexpected_no_connect",
             SchematicIssue::Shorted { .. } => "short",
         }
     }
@@ -177,6 +198,16 @@ impl SchematicIssue {
                 "{} pins the netlist keeps apart are joined",
                 terminals.len()
             ),
+            SchematicIssue::MissingNoConnect {
+                symbol_id,
+                pin_number,
+                ..
+            } => format!(
+                "component symbol '{symbol_id}' pin {pin_number} is missing a no-connect marker"
+            ),
+            SchematicIssue::UnexpectedNoConnect { id, .. } => {
+                format!("no-connect marker '{id}' is attached to a connected pin")
+            }
             SchematicIssue::Shorted { net_names, .. } => format!(
                 "nets {} are shorted together",
                 net_names
@@ -217,6 +248,15 @@ pub enum SchematicIssueKey {
     UnexpectedConnection {
         terminals: Vec<Terminal>,
         items: BTreeSet<ConnectivityItemRef>,
+    },
+    MissingNoConnect {
+        page_id: String,
+        symbol_id: String,
+        pin_number: String,
+    },
+    UnexpectedNoConnect {
+        page_id: String,
+        id: String,
     },
     Shorted {
         net_names: BTreeSet<String>,
@@ -272,6 +312,8 @@ pub fn inspect_schematic(
     apply_symbol_or_label_endpoint_requirements(document, netlist, &mut expected)?;
     let physical = observed_reconcilable_connectivity(document, netlist)?;
     let mut analysis = analyze_connectivity(&expected, &physical.graph);
+    let (_, no_connect_issues) = inspect_no_connects(document, netlist)?;
+    analysis.issues.extend(no_connect_issues);
     analysis.issues.splice(
         0..0,
         document.pages.iter().flat_map(|page| {
@@ -295,6 +337,85 @@ pub fn inspect_schematic(
         expected,
         physical,
         issues,
+    })
+}
+
+pub(crate) fn inspect_no_connects(
+    document: &SchDocument,
+    netlist: &Schematic,
+) -> anyhow::Result<(Vec<NoConnectTarget>, Vec<SchematicIssue>)> {
+    let physical = reduce_with_provenance(document, PinVisibility::IncludeHidden)?;
+    let pins = physical
+        .islands
+        .values()
+        .flat_map(|island| island.pin_terminals.iter())
+        .collect::<BTreeMap<_, _>>();
+    let expected_not_connected = not_connected_terminals(netlist);
+    let expected_connected = ConnectivityGraph::from_zener(netlist)?
+        .groups
+        .into_iter()
+        .flat_map(|group| group.terminals)
+        .collect::<BTreeSet<_>>();
+    let targets_for = |terminals: &BTreeSet<Terminal>| {
+        pins.iter()
+            .filter(|(_, pin_terminal)| {
+                terminals
+                    .iter()
+                    .any(|terminal| pin_terminal.matches(terminal))
+            })
+            .map(|(pin, _)| pin.no_connect_target())
+            .collect::<Vec<_>>()
+    };
+    let desired = targets_for(&expected_not_connected);
+    let connected = targets_for(&expected_connected);
+    let markers = document.pages.iter().flat_map(|page| {
+        page.items.iter().filter_map(|item| match item {
+            SchItem::NoConnect(marker) => Some((&page.id, marker)),
+            _ => None,
+        })
+    });
+    let missing = desired
+        .iter()
+        .filter(|target| !has_no_connect(document, target))
+        .map(|target| {
+            (
+                target.page_id.clone(),
+                target.symbol_id.clone(),
+                target.pin_number.clone(),
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    let mut issues = missing
+        .into_iter()
+        .map(
+            |(page_id, symbol_id, pin_number)| SchematicIssue::MissingNoConnect {
+                page_id,
+                symbol_id,
+                pin_number,
+            },
+        )
+        .collect::<Vec<_>>();
+    issues.extend(markers.filter_map(|(page_id, marker)| {
+        let at_desired = desired
+            .iter()
+            .any(|target| target.page_id == *page_id && points_connect(target.at, marker.at));
+        let at_connected = connected
+            .iter()
+            .any(|target| target.page_id == *page_id && points_connect(target.at, marker.at));
+        (at_connected && !at_desired).then(|| SchematicIssue::UnexpectedNoConnect {
+            page_id: page_id.clone(),
+            id: marker.id.clone(),
+        })
+    }));
+    Ok((desired, issues))
+}
+
+pub(crate) fn has_no_connect(document: &SchDocument, target: &NoConnectTarget) -> bool {
+    document.pages.iter().any(|page| {
+        page.id == target.page_id
+            && page.items.iter().any(|item| {
+                matches!(item, SchItem::NoConnect(marker) if points_connect(marker.at, target.at))
+            })
     })
 }
 
@@ -426,6 +547,31 @@ pub(crate) fn issue_context(
                 items,
             )
         }
+        SchematicIssue::MissingNoConnect {
+            page_id,
+            symbol_id,
+            pin_number,
+        } => (
+            SchematicIssueKey::MissingNoConnect {
+                page_id: page_id.clone(),
+                symbol_id: symbol_id.clone(),
+                pin_number: pin_number.clone(),
+            },
+            BTreeSet::new(),
+        ),
+        SchematicIssue::UnexpectedNoConnect { page_id, id } => {
+            let item = ConnectivityItemRef::NoConnect {
+                page_id: page_id.clone(),
+                id: id.clone(),
+            };
+            (
+                SchematicIssueKey::UnexpectedNoConnect {
+                    page_id: page_id.clone(),
+                    id: id.clone(),
+                },
+                BTreeSet::from([item]),
+            )
+        }
         SchematicIssue::Shorted {
             net_names,
             islands: issue_islands,
@@ -458,7 +604,9 @@ pub(crate) fn coarse_key(key: &SchematicIssueKey) -> SchematicIssueKey {
         | SchematicIssueKey::UnexpectedSymbol(_)
         | SchematicIssueKey::UnboundSymbol(_)
         | SchematicIssueKey::DisconnectedNet(_)
-        | SchematicIssueKey::MissingPort(_) => {}
+        | SchematicIssueKey::MissingPort(_)
+        | SchematicIssueKey::MissingNoConnect { .. }
+        | SchematicIssueKey::UnexpectedNoConnect { .. } => {}
     }
     key
 }
@@ -545,14 +693,14 @@ fn is_open_not_connected_group(
     islands: &BTreeMap<IslandRef, PhysicalIsland>,
     not_connected: &BTreeSet<Terminal>,
 ) -> bool {
-    if !group.names.is_empty() || group.terminals.len() != 1 {
+    if !group.names.is_empty() || group.terminals.is_empty() {
         return false;
     }
-    let terminal = group.terminals.first().expect("checked one terminal");
-    if !not_connected
-        .iter()
-        .any(|candidate| candidate.matches(terminal))
-    {
+    if !group.terminals.iter().all(|terminal| {
+        not_connected
+            .iter()
+            .any(|candidate| candidate.matches(terminal))
+    }) {
         return false;
     }
     let mut origins = group.origins.iter();
@@ -981,6 +1129,18 @@ mod tests {
     };
 
     #[test]
+    fn no_connect_matching_uses_kicad_internal_coordinate_units() {
+        assert!(points_connect(
+            Point::new(10.00004, 20.00004),
+            Point::new(10.0, 20.0)
+        ));
+        assert!(!points_connect(
+            Point::new(10.00006, 20.0),
+            Point::new(10.0, 20.0)
+        ));
+    }
+
+    #[test]
     fn indexed_group_matching_preserves_analysis_and_source_order() {
         let pin = |name: &str, number: &str| Terminal::ComponentPin {
             component: ComponentIdentity::ManagedPath("U1".into()),
@@ -1256,14 +1416,26 @@ mod tests {
             page_id: "page".to_string(),
             index: 0,
         };
-        let group = ConnectionGroup {
+        let mut group = ConnectionGroup {
             names: BTreeSet::new(),
             terminals: BTreeSet::from([terminal.clone()]),
             origins: BTreeSet::from([ConnectionOrigin::KiCadIsland(island.clone())]),
         };
         let mut islands = BTreeMap::from([(island, PhysicalIsland::default())]);
-        let not_connected = BTreeSet::from([terminal]);
+        let mut not_connected = BTreeSet::from([terminal]);
 
+        assert!(is_open_not_connected_group(
+            &group,
+            &islands,
+            &not_connected
+        ));
+        let stacked = Terminal::ComponentPin {
+            component: ComponentIdentity::ManagedPath("U1".to_string()),
+            pin_name: "NC2".to_string(),
+            pin_numbers: BTreeSet::from(["2".to_string()]),
+        };
+        group.terminals.insert(stacked.clone());
+        not_connected.insert(stacked);
         assert!(is_open_not_connected_group(
             &group,
             &islands,

--- a/crates/pcb-kicad-sch/src/analysis.rs
+++ b/crates/pcb-kicad-sch/src/analysis.rs
@@ -696,11 +696,17 @@ fn is_open_not_connected_group(
     if !group.names.is_empty() || group.terminals.is_empty() {
         return false;
     }
-    if !group.terminals.iter().all(|terminal| {
-        not_connected
+    // Multiple physical pins may realize one logical terminal (for example,
+    // stacked pins with the same name), but distinct NotConnected terminals
+    // touching directly are still an electrical connection. Require exactly
+    // one netlist terminal to account for the whole physical island.
+    let mut matching_not_connected = not_connected.iter().filter(|candidate| {
+        group
+            .terminals
             .iter()
-            .any(|candidate| candidate.matches(terminal))
-    }) {
+            .all(|terminal| candidate.matches(terminal))
+    });
+    if matching_not_connected.next().is_none() || matching_not_connected.next().is_some() {
         return false;
     }
     let mut origins = group.origins.iter();
@@ -1429,14 +1435,25 @@ mod tests {
             &islands,
             &not_connected
         ));
-        let stacked = Terminal::ComponentPin {
+        let repeated_physical_pin = Terminal::ComponentPin {
             component: ComponentIdentity::ManagedPath("U1".to_string()),
+            pin_name: "NC".to_string(),
+            pin_numbers: BTreeSet::from(["2".to_string()]),
+        };
+        group.terminals.insert(repeated_physical_pin);
+        assert!(is_open_not_connected_group(
+            &group,
+            &islands,
+            &not_connected
+        ));
+        let other = Terminal::ComponentPin {
+            component: ComponentIdentity::ManagedPath("U2".to_string()),
             pin_name: "NC2".to_string(),
             pin_numbers: BTreeSet::from(["2".to_string()]),
         };
-        group.terminals.insert(stacked.clone());
-        not_connected.insert(stacked);
-        assert!(is_open_not_connected_group(
+        group.terminals.insert(other.clone());
+        not_connected.insert(other);
+        assert!(!is_open_not_connected_group(
             &group,
             &islands,
             &not_connected

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -5,14 +5,14 @@ use pcb_sch::{ATTR_SCHEMATIC_PATH, Instance, InstanceKind, Schematic};
 use pcb_sexpr::Sexpr;
 
 use crate::{
-    CONNECTION_GRID_MM, GEOMETRY_EPS_MM, Label, LabelKind, LabelShape, LabelSpin, Paper, Point,
-    Rotation, SchDocument, SchItem, SchPage, Sheet, SheetPin, Symbol, SymbolDefinition,
+    CONNECTION_GRID_MM, GEOMETRY_EPS_MM, Label, LabelKind, LabelShape, LabelSpin, NoConnect, Paper,
+    Point, Rotation, SchDocument, SchItem, SchPage, Sheet, SheetPin, Symbol, SymbolDefinition,
     SymbolField, SymbolSlotKey, Wire,
     analysis::{ConnectivityInspection, SchematicIssue, SchematicIssueKey},
     component_slots,
     connectivity::{
         ConnectionOrigin, ConnectivityItemRef, IslandRef, PhysicalConnectivity, PhysicalIsland,
-        PhysicalPinRef, PinVisibility, SymbolLocation, named_connected_nets,
+        PhysicalPinRef, PinVisibility, SymbolLocation, named_connected_nets, points_connect,
         reduce_with_provenance,
     },
     deterministic_uuid, field_autoplace, hierarchy, net_symbols,
@@ -316,6 +316,8 @@ fn is_connectivity_issue(issue: &SchematicIssue) -> bool {
             | SchematicIssue::MissingPort { .. }
             | SchematicIssue::UnexpectedNet { .. }
             | SchematicIssue::UnexpectedConnection { .. }
+            | SchematicIssue::MissingNoConnect { .. }
+            | SchematicIssue::UnexpectedNoConnect { .. }
             | SchematicIssue::Shorted { .. }
     )
 }
@@ -376,6 +378,8 @@ fn repair_targets(
                 | SchematicIssue::MissingPort { .. }
                 | SchematicIssue::UnexpectedNet { .. }
                 | SchematicIssue::UnexpectedConnection { .. }
+                | SchematicIssue::MissingNoConnect { .. }
+                | SchematicIssue::UnexpectedNoConnect { .. }
                 | SchematicIssue::Shorted { .. } => {
                     selected_connectivity.insert(context.key.clone());
                 }
@@ -1967,6 +1971,31 @@ fn apply_connectivity_repair(
         root_page,
         reconnect_nets,
     )?;
+    for target in &intent.no_connect_additions {
+        if document.pages.iter().any(|page| {
+            page.id == target.page_id
+                && page.items.iter().any(
+                    |item| matches!(item, SchItem::NoConnect(marker) if points_connect(marker.at, target.at)),
+                )
+        }) {
+            continue;
+        }
+        let key = format!(
+            "zener:no-connect:{}:{}:{}",
+            target.page_id, target.symbol_id, target.pin_number
+        );
+        let id = available_deterministic_id(document, &key);
+        let page = document
+            .pages
+            .iter_mut()
+            .find(|page| page.id == target.page_id)
+            .with_context(|| format!("no-connect target page '{}' is absent", target.page_id))?;
+        page.items.push(SchItem::NoConnect(NoConnect {
+            id,
+            at: target.at,
+            unsupported: Vec::new(),
+        }));
+    }
     Ok(())
 }
 

--- a/crates/pcb-kicad-sch/src/connectivity/kicad.rs
+++ b/crates/pcb-kicad-sch/src/connectivity/kicad.rs
@@ -45,6 +45,7 @@ pub struct PhysicalIsland {
     pub names: BTreeSet<String>,
     pub terminals: BTreeSet<Terminal>,
     pub(crate) pins: BTreeSet<PhysicalPinRef>,
+    pub(crate) pin_terminals: BTreeMap<PhysicalPinRef, Terminal>,
 }
 
 /// Exact identity of one placed KiCad symbol pin.
@@ -77,6 +78,18 @@ impl PhysicalPinRef {
 
     pub(crate) fn is_on_symbol(&self, location: &SymbolLocation) -> bool {
         self.page_id == location.page_id && self.symbol_id == location.symbol_id
+    }
+
+    pub(crate) fn no_connect_target(&self) -> crate::analysis::NoConnectTarget {
+        crate::analysis::NoConnectTarget {
+            page_id: self.page_id.clone(),
+            symbol_id: self.symbol_id.clone(),
+            pin_number: self.number.clone(),
+            at: Point::new(
+                self.point.x as f64 / SCH_IU_PER_MM,
+                self.point.y as f64 / SCH_IU_PER_MM,
+            ),
+        }
     }
 }
 
@@ -691,6 +704,11 @@ fn collect_symbol(
         .filter(|pin| pin_visibility.includes(pin.hidden))
     {
         let pin_name = static_net_text("symbol pin name", &pin.name)?;
+        let terminal = Terminal::ComponentPin {
+            component: component.clone(),
+            pin_name: pin_name.clone(),
+            pin_numbers: pin.numbers.clone(),
+        };
         output.connectables.push(Connectable {
             geometry: Geometry::Point {
                 at: pin.point.into(),
@@ -702,11 +720,7 @@ fn collect_symbol(
                 role: DriverNameRole::NetName,
                 merge_by_name: true,
             }),
-            terminal: Some(Terminal::ComponentPin {
-                component: component.clone(),
-                pin_name,
-                pin_numbers: pin.numbers.clone(),
-            }),
+            terminal: Some(terminal.clone()),
             pin: Some(PhysicalPinRef::new(
                 &page.id,
                 &placed.id,
@@ -861,6 +875,10 @@ impl From<Point> for GridPoint {
             y: (point.y * SCH_IU_PER_MM).round() as i64,
         }
     }
+}
+
+pub(crate) fn points_connect(left: Point, right: Point) -> bool {
+    GridPoint::from(left) == GridPoint::from(right)
 }
 
 #[derive(Debug, Clone)]
@@ -1062,6 +1080,11 @@ fn connection_groups(
             for item in items {
                 if let Some(source) = &item.source {
                     provenance.items.insert(source.clone());
+                }
+                if let (Some(pin), Some(terminal)) = (&item.pin, &item.terminal) {
+                    provenance
+                        .pin_terminals
+                        .insert(pin.clone(), terminal.clone());
                 }
                 provenance.pins.extend(item.pin);
                 if let Some(driver) = item.driver {

--- a/crates/pcb-kicad-sch/src/connectivity/mod.rs
+++ b/crates/pcb-kicad-sch/src/connectivity/mod.rs
@@ -9,7 +9,9 @@ mod raw;
 mod zener;
 
 pub use kicad::{ConnectivityItemRef, PhysicalConnectivity, PhysicalIsland, PinVisibility};
-pub(crate) use kicad::{CutGraph, CutNode, PhysicalPinRef, cut_graph, reduce_with_provenance};
+pub(crate) use kicad::{
+    CutGraph, CutNode, PhysicalPinRef, cut_graph, points_connect, reduce_with_provenance,
+};
 pub(crate) use raw::TerminalIndex;
 pub(crate) use zener::{named_connected_nets, not_connected_terminals};
 

--- a/crates/pcb-kicad-sch/src/lib.rs
+++ b/crates/pcb-kicad-sch/src/lib.rs
@@ -29,6 +29,7 @@ mod symbol;
 pub mod analysis;
 mod compose;
 
+pub use analysis::NoConnectTarget;
 pub use field_autoplace::Bounds;
 pub use identity::{
     KiCadUuidPath, ROOT_PAGE_KEY, SymbolSlotKey, UUID_NAMESPACE_URL, canonical_component_path,

--- a/crates/pcb-kicad-sch/src/repair.rs
+++ b/crates/pcb-kicad-sch/src/repair.rs
@@ -11,14 +11,16 @@ use pcb_sch::Schematic;
 use crate::{
     GEOMETRY_EPS_MM, Point, SchDocument, SchItem, SchPage, Symbol,
     analysis::{
-        ConnectivityAnalysis, ConnectivityInspection, SchematicIssue, SchematicIssueKey,
-        analyze_connectivity, ensure_issues_resolved, ensure_no_new_issues, inspect_schematic,
-        issue_context, logical_name, observed_reconcilable_connectivity,
+        ConnectivityAnalysis, ConnectivityInspection, NoConnectTarget, SchematicIssue,
+        SchematicIssueKey, analyze_connectivity, ensure_issues_resolved, ensure_no_new_issues,
+        has_no_connect, inspect_no_connects, inspect_schematic, issue_context, logical_name,
+        observed_reconcilable_connectivity,
     },
     compose,
     connectivity::{
         ComponentIdentity, ConnectivityGraph, ConnectivityItemRef, CutNode, PhysicalConnectivity,
         PhysicalIsland, PinVisibility, SymbolLocation, Terminal, TerminalIndex, cut_graph,
+        points_connect, reduce_with_provenance,
     },
     cut,
     net_symbols::NetSymbolSpec,
@@ -26,10 +28,10 @@ use crate::{
 
 /// A deterministic, UUID-addressed connectivity repair decision.
 ///
-/// The intent says what must change, never where geometry goes: exact items to
-/// remove, symbols that must move, nets whose connectivity a realizer rebuilds,
-/// and the name driver each of those nets needs on each page. Planning does
-/// not mutate the input document. A realizer applies the intent and then
+/// The intent says what must change: exact items to remove, symbols that must
+/// move, nets whose connectivity a realizer rebuilds, the name driver each net
+/// needs, and exact native no-connect marker targets. Planning does not mutate
+/// the input document. A realizer applies the intent and then
 /// [`verify_connectivity_repair`] judges the result.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConnectivityRepairIntent {
@@ -38,6 +40,7 @@ pub struct ConnectivityRepairIntent {
     pub(crate) relocated_symbols: BTreeSet<SymbolLocation>,
     pub(crate) reconnect_nets: BTreeSet<String>,
     pub(crate) drivers: BTreeMap<String, BTreeMap<String, NetDriverKind>>,
+    pub(crate) no_connect_additions: Vec<NoConnectTarget>,
 }
 
 impl ConnectivityRepairIntent {
@@ -50,6 +53,7 @@ impl ConnectivityRepairIntent {
             relocated_symbols: BTreeSet::new(),
             reconnect_nets: BTreeSet::new(),
             drivers: BTreeMap::new(),
+            no_connect_additions: Vec::new(),
         }
     }
 
@@ -86,9 +90,14 @@ impl ConnectivityRepairIntent {
         self.drivers.get(net_name)?.get(page_id)
     }
 
+    /// Native KiCad no-connect markers the realizer must add.
+    pub fn no_connect_additions(&self) -> &[NoConnectTarget] {
+        &self.no_connect_additions
+    }
+
     /// Apply the removals and symbol relocations of this intent: everything
     /// PCB decided must change, with no new geometry. A consumer's realizer
-    /// starts from this document and only adds connections.
+    /// starts from this document and adds connections and no-connect markers.
     pub fn apply_edits(&self, document: &SchDocument) -> Result<SchDocument> {
         let mut repaired = document.clone();
         remove_items(&mut repaired, &self.removals)?;
@@ -172,6 +181,7 @@ pub(crate) fn plan_connectivity_repair_core(
         .flat_map(|context| repair_problems(&context.issue))
         .collect::<BTreeSet<_>>();
     let mut reconnect_nets = BTreeSet::new();
+    let mut selected_no_connects = BTreeSet::new();
 
     for context in &selected {
         match &context.issue {
@@ -215,6 +225,23 @@ pub(crate) fn plan_connectivity_repair_core(
                         reconnect_nets.extend(expected_nets.for_island(provenance));
                     }
                 }
+            }
+            SchematicIssue::MissingNoConnect {
+                page_id,
+                symbol_id,
+                pin_number,
+            } => {
+                selected_no_connects.insert((
+                    page_id.clone(),
+                    symbol_id.clone(),
+                    pin_number.clone(),
+                ));
+            }
+            SchematicIssue::UnexpectedNoConnect { page_id, id } => {
+                removals.insert(ConnectivityItemRef::NoConnect {
+                    page_id: page_id.clone(),
+                    id: id.clone(),
+                });
             }
             SchematicIssue::MissingSheet { .. }
             | SchematicIssue::UnboundSymbol { .. }
@@ -376,13 +403,100 @@ pub(crate) fn plan_connectivity_repair_core(
     }
 
     removals.extend(orphaned_junctions(document, &simulated, &removals));
+    removals.extend(no_connects_on_relocated_symbols(
+        document,
+        netlist,
+        &relocate_symbols,
+    )?);
+
+    // Additions are coordinates in the document after this intent's edits.
+    // Relocation leaves pin-attached annotations behind, so remove those and
+    // regenerate NC markers on the moved pins along with explicitly selected
+    // missing-marker issues.
+    let mut post_edits = document.clone();
+    remove_items(&mut post_edits, &removals)?;
+    compose::relocate_symbols(&mut post_edits, &relocate_symbols)?;
+    let required_no_connects = inspect_no_connects(&post_edits, netlist)?
+        .0
+        .into_iter()
+        .filter(|target| {
+            !has_no_connect(&post_edits, target)
+                && (selected_no_connects.contains(&(
+                    target.page_id.clone(),
+                    target.symbol_id.clone(),
+                    target.pin_number.clone(),
+                )) || relocate_symbols.contains(&SymbolLocation {
+                    page_id: target.page_id.clone(),
+                    symbol_id: target.symbol_id.clone(),
+                }))
+        })
+        .collect::<Vec<_>>();
+    // Every physical pin requirement participates in issue selection above.
+    // One native marker satisfies all pins that deliberately share a point.
+    let mut no_connect_additions = Vec::<NoConnectTarget>::new();
+    for target in required_no_connects {
+        if !no_connect_additions.iter().any(|existing| {
+            existing.page_id == target.page_id && points_connect(existing.at, target.at)
+        }) {
+            no_connect_additions.push(target);
+        }
+    }
     Ok(ConnectivityRepairIntent {
         selected_keys: selected_keys.clone(),
         removals,
         relocated_symbols: relocate_symbols,
         reconnect_nets,
         drivers: BTreeMap::new(),
+        no_connect_additions,
     })
+}
+
+fn no_connects_on_relocated_symbols(
+    document: &SchDocument,
+    netlist: &Schematic,
+    locations: &BTreeSet<SymbolLocation>,
+) -> Result<BTreeSet<ConnectivityItemRef>> {
+    if locations.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    let physical = reduce_with_provenance(document, PinVisibility::IncludeHidden)?;
+    let pins = physical
+        .islands
+        .values()
+        .flat_map(|island| island.pin_terminals.iter())
+        .map(|(pin, terminal)| (pin, terminal, pin.no_connect_target()))
+        .collect::<Vec<_>>();
+    let expected_no_connects = crate::connectivity::not_connected_terminals(netlist);
+    Ok(document
+        .pages
+        .iter()
+        .flat_map(|page| {
+            let pins = &pins;
+            let expected_no_connects = &expected_no_connects;
+            page.items.iter().filter_map(move |item| match item {
+                SchItem::NoConnect(marker)
+                    if pins.iter().any(|(pin, _, target)| {
+                        locations.iter().any(|location| pin.is_on_symbol(location))
+                            && target.page_id == page.id
+                            && points_connect(target.at, marker.at)
+                    }) && !pins.iter().any(|(pin, terminal, target)| {
+                        !locations.iter().any(|location| pin.is_on_symbol(location))
+                            && expected_no_connects
+                                .iter()
+                                .any(|expected| terminal.matches(expected))
+                            && target.page_id == page.id
+                            && points_connect(target.at, marker.at)
+                    }) =>
+                {
+                    Some(ConnectivityItemRef::NoConnect {
+                        page_id: page.id.clone(),
+                        id: marker.id.clone(),
+                    })
+                }
+                _ => None,
+            })
+        })
+        .collect())
 }
 
 /// Verify a realized repair against the inspection it was planned from.
@@ -1177,7 +1291,9 @@ fn repair_problems(issue: &SchematicIssue) -> BTreeSet<RepairProblem> {
         | SchematicIssue::MissingSymbol { .. }
         | SchematicIssue::DuplicateSymbol { .. }
         | SchematicIssue::MismatchedSymbolId { .. }
-        | SchematicIssue::UnexpectedSymbol { .. } => BTreeSet::new(),
+        | SchematicIssue::UnexpectedSymbol { .. }
+        | SchematicIssue::MissingNoConnect { .. }
+        | SchematicIssue::UnexpectedNoConnect { .. } => BTreeSet::new(),
     }
 }
 

--- a/crates/pcb-kicad-sch/test-data/analysis/relocated_shared_nc.zen
+++ b/crates/pcb-kicad-sch/test-data/analysis/relocated_shared_nc.zen
@@ -1,0 +1,11 @@
+Project(name="RelocatedSharedNoConnect", path="kicad", layout=False)
+
+Resistor = Module("@stdlib/generics/Resistor.zen")
+
+LEFT = Net("LEFT")
+MID = Net("MID")
+RIGHT = Net("RIGHT")
+
+Resistor(name="R1", value="1kohms", package="0402", P1=LEFT, P2=NotConnected())
+Resistor(name="R2", value="2kohms", package="0402", P1=MID, P2=NotConnected())
+Resistor(name="R3", value="3kohms", package="0402", P1=RIGHT, P2=RIGHT)

--- a/crates/pcb-kicad-sch/test-data/multi_pad_nc/multi_pad.kicad_sym
+++ b/crates/pcb-kicad-sch/test-data/multi_pad_nc/multi_pad.kicad_sym
@@ -1,0 +1,13 @@
+(kicad_symbol_lib
+  (version 20251024)
+  (generator pcb)
+  (symbol "MULTI_PAD"
+    (symbol "MULTI_PAD_1_1"
+      (pin input line (at -5.08 2.54 0) (length 2.54)
+        (name "A") (number "1"))
+      (pin input line (at 5.08 2.54 180) (length 2.54)
+        (name "B") (number "2"))
+      (pin input line (at -5.08 -2.54 0) (length 2.54) hide
+        (name "A") (number "1"))
+      (pin input line (at 5.08 -2.54 180) (length 2.54)
+        (name "B") (number "4")))))

--- a/crates/pcb-kicad-sch/test-data/multi_pad_nc/multi_pad.zen
+++ b/crates/pcb-kicad-sch/test-data/multi_pad_nc/multi_pad.zen
@@ -1,0 +1,14 @@
+Project(name="MultiPadComponent", path="kicad", layout=False)
+
+A = io("A", Net)
+B = io("B", Net)
+
+Component(
+    name="MULTI_PAD",
+    footprint="Package_DIP:DIP-4_W7.62mm",
+    symbol=Symbol(library="multi_pad.kicad_sym"),
+    pins={
+        "A": A,
+        "B": B,
+    },
+)

--- a/crates/pcb-kicad-sch/test-data/multi_pad_nc/root.zen
+++ b/crates/pcb-kicad-sch/test-data/multi_pad_nc/root.zen
@@ -1,0 +1,8 @@
+Project(name="MultiPadNotConnected", path="kicad", layout=False)
+
+MultiPad = Module("multi_pad.zen")
+
+LEFT = Net("LEFT")
+RIGHT = Net("RIGHT")
+
+MultiPad(name="U1", A=LEFT, B=RIGHT)

--- a/crates/pcb-kicad-sch/tests/issue_repair.rs
+++ b/crates/pcb-kicad-sch/tests/issue_repair.rs
@@ -900,6 +900,24 @@ fn wired_not_connected_pins_are_cut_free_locally() {
         inspection.issues
     );
 
+    let mut overlapping = baseline.clone();
+    let a = common::pin_point(&overlapping, "R1.R", "2");
+    let b = common::pin_point(&overlapping, "R2.R", "2");
+    let symbol = managed_symbol_mut(&mut overlapping, "R2.R");
+    move_symbol(
+        symbol,
+        Point::new(symbol.at.x + a.x - b.x, symbol.at.y + a.y - b.y),
+    );
+    let inspection = inspect_schematic(&overlapping, &netlist).unwrap();
+    assert!(
+        inspection.issues.iter().any(|issue| matches!(
+            &issue.issue,
+            SchematicIssue::UnexpectedConnection { terminals, .. } if terminals.len() == 2
+        )),
+        "overlapping distinct NotConnected pins must report their connection: {:#?}",
+        inspection.issues
+    );
+
     let mut document = baseline.clone();
     let a = common::pin_point(&document, "R1.R", "2");
     let b = common::pin_point(&document, "R2.R", "2");

--- a/crates/pcb-kicad-sch/tests/issue_repair.rs
+++ b/crates/pcb-kicad-sch/tests/issue_repair.rs
@@ -76,6 +76,8 @@ fn issue_kind(issue: &SchematicIssue) -> &'static str {
         SchematicIssue::UnexpectedNet { .. } => "unexpected-net",
         SchematicIssue::Shorted { .. } => "short",
         SchematicIssue::UnexpectedConnection { .. } => "unexpected-connection",
+        SchematicIssue::MissingNoConnect { .. } => "missing-no-connect",
+        SchematicIssue::UnexpectedNoConnect { .. } => "unexpected-no-connect",
     }
 }
 
@@ -279,13 +281,18 @@ fn relocating_shorted_symbols_reconnects_their_other_nets() {
 
 #[test]
 fn directly_overlapping_component_pins_relocate_the_affected_symbols() {
-    let netlist = common::compile_fixture("analysis", "simple.zen");
+    let mut netlist = common::compile_fixture("analysis", "simple.zen");
+    let mut not_connected = netlist.nets.remove("RIGHT").unwrap();
+    not_connected.kind = "NotConnected".to_string();
+    not_connected.name.clear();
+    netlist.nets.insert(String::new(), not_connected);
     let mut document = plan_reconciliation(None, &netlist, "simple.kicad_sch")
         .unwrap()
         .apply(None)
         .unwrap();
     let target = common::pin_point(&document, "R1.R", "1");
     let source = common::pin_point(&document, "R2.R", "1");
+    let nc_source = common::pin_point(&document, "R2.R", "2");
     let symbol = managed_symbol_mut(&mut document, "R2.R");
     let new_at = Point::new(
         symbol.at.x + target.x - source.x,
@@ -293,6 +300,17 @@ fn directly_overlapping_component_pins_relocate_the_affected_symbols() {
     );
     move_symbol(symbol, new_at);
     let moved_id = symbol.id.clone();
+    let offset = Point::new(target.x - source.x, target.y - source.y);
+    let marker = document.pages[0]
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SchItem::NoConnect(marker) if marker.at == nc_source => Some(marker),
+            _ => None,
+        })
+        .expect("R2 no-connect marker");
+    marker.at = Point::new(marker.at.x + offset.x, marker.at.y + offset.y);
+    let marker_id = marker.id.clone();
     let inspection = inspect_schematic(&document, &netlist).unwrap();
     let issue = inspection
         .issues
@@ -310,6 +328,25 @@ fn directly_overlapping_component_pins_relocate_the_affected_symbols() {
             })
         })
         .unwrap_or_else(|| panic!("missing direct-pin issue: {:#?}", inspection.issues));
+
+    let intent = plan_connectivity_repair(
+        &document,
+        &netlist,
+        &inspection,
+        &BTreeSet::from([issue.key.clone()]),
+        &BTreeSet::new(),
+    )
+    .unwrap();
+    assert!(intent.removals().contains(
+        &pcb_kicad_sch::connectivity::ConnectivityItemRef::NoConnect {
+            page_id: document.pages[0].id.clone(),
+            id: marker_id,
+        }
+    ));
+    let edited = intent.apply_edits(&document).unwrap();
+    let relocated_nc = common::pin_point(&edited, "R2.R", "2");
+    assert_eq!(intent.no_connect_additions().len(), 1);
+    assert_eq!(intent.no_connect_additions()[0].at, relocated_nc);
 
     let plan = plan_repairs(
         &document,
@@ -345,6 +382,212 @@ fn directly_overlapping_component_pins_relocate_the_affected_symbols() {
         .apply(Some(&document))
         .unwrap(),
         repaired
+    );
+}
+
+#[test]
+fn relocation_preserves_a_no_connect_marker_shared_with_a_stationary_pin() {
+    let netlist = common::compile_fixture("analysis", "relocated_shared_nc.zen");
+    let mut document = plan_reconciliation(None, &netlist, "shared_nc.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    let old_stationary_nc = common::pin_point(&document, "R1.R", "2");
+    let old_stationary_signal = common::pin_point(&document, "R1.R", "1");
+    managed_symbol_mut(&mut document, "R1.R").rotation = Rotation::Deg90;
+    let stationary_nc = common::pin_point(&document, "R1.R", "2");
+    let stationary_signal = common::pin_point(&document, "R1.R", "1");
+    let stationary_marker = document.pages[0]
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SchItem::NoConnect(marker) if marker.at == old_stationary_nc => Some(marker),
+            _ => None,
+        })
+        .unwrap();
+    stationary_marker.at = stationary_nc;
+    for item in &mut document.pages[0].items {
+        if let SchItem::Label(label) = item
+            && label.at == old_stationary_signal
+        {
+            label.at = stationary_signal;
+        }
+    }
+    let moving_nc = common::pin_point(&document, "R2.R", "2");
+    let moving_signal = common::pin_point(&document, "R2.R", "1");
+    let blocker_signal = common::pin_point(&document, "R3.R", "1");
+
+    let moving_offset = Point::new(stationary_nc.x - moving_nc.x, stationary_nc.y - moving_nc.y);
+    let moving_symbol = managed_symbol_mut(&mut document, "R2.R");
+    move_symbol(
+        moving_symbol,
+        Point::new(
+            moving_symbol.at.x + moving_offset.x,
+            moving_symbol.at.y + moving_offset.y,
+        ),
+    );
+    let moved_signal = Point::new(
+        moving_signal.x + moving_offset.x,
+        moving_signal.y + moving_offset.y,
+    );
+    let blocker_symbol = managed_symbol_mut(&mut document, "R3.R");
+    move_symbol(
+        blocker_symbol,
+        Point::new(
+            blocker_symbol.at.x + moved_signal.x - blocker_signal.x,
+            blocker_symbol.at.y + moved_signal.y - blocker_signal.y,
+        ),
+    );
+    document.pages[0]
+        .items
+        .retain(|item| !matches!(item, SchItem::NoConnect(marker) if marker.at == moving_nc));
+    let shared_marker = document.pages[0]
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SchItem::NoConnect(marker) if marker.at == stationary_nc => Some(marker.clone()),
+            _ => None,
+        })
+        .unwrap();
+    let mut missing_shared_marker = document.clone();
+    missing_shared_marker.pages[0].items.retain(
+        |item| !matches!(item, SchItem::NoConnect(marker) if marker.id == shared_marker.id),
+    );
+
+    let inspection = inspect_schematic(&document, &netlist).unwrap();
+    let issue = inspection
+        .issues
+        .iter()
+        .find(|issue| {
+            matches!(
+                &issue.issue,
+                SchematicIssue::Shorted { net_names, .. }
+                    if net_names == &BTreeSet::from(["MID".to_string(), "RIGHT".to_string()])
+            )
+        })
+        .unwrap_or_else(|| panic!("missing direct-pin issue: {:#?}", inspection.issues));
+    let intent = plan_connectivity_repair(
+        &document,
+        &netlist,
+        &inspection,
+        &BTreeSet::from([issue.key.clone()]),
+        &BTreeSet::new(),
+    )
+    .unwrap();
+    assert!(
+        !intent.removals().contains(
+            &pcb_kicad_sch::connectivity::ConnectivityItemRef::NoConnect {
+                page_id: document.pages[0].id.clone(),
+                id: shared_marker.id.clone(),
+            }
+        ),
+        "relocations={:?} removals={:?}",
+        intent.relocated_symbols(),
+        intent.removals()
+    );
+    assert!(intent.no_connect_additions().iter().any(|target| {
+        target.symbol_id
+            == managed_symbols(&document)
+                .find(|symbol| symbol.field_value("Path") == Some("R2.R"))
+                .unwrap()
+                .id
+    }));
+    let repaired = plan_repairs(
+        &document,
+        &netlist,
+        &inspection,
+        BTreeSet::from([issue.key.clone()]),
+    )
+    .unwrap()
+    .apply(Some(&document))
+    .unwrap();
+    assert!(
+        repaired.pages[0]
+            .items
+            .iter()
+            .any(|item| matches!(item, SchItem::NoConnect(marker) if marker == &shared_marker))
+    );
+    assert!(
+        inspect_schematic(&repaired, &netlist)
+            .unwrap()
+            .issues
+            .is_empty()
+    );
+
+    let inspection = inspect_schematic(&missing_shared_marker, &netlist).unwrap();
+    let selected = inspection
+        .issues
+        .iter()
+        .map(|issue| issue.key.clone())
+        .collect::<BTreeSet<_>>();
+    let intent = plan_connectivity_repair(
+        &missing_shared_marker,
+        &netlist,
+        &inspection,
+        &selected,
+        &BTreeSet::new(),
+    )
+    .unwrap();
+    let edited = intent.apply_edits(&missing_shared_marker).unwrap();
+    let stationary_nc = common::pin_point(&edited, "R1.R", "2");
+    let relocated_nc = common::pin_point(&edited, "R2.R", "2");
+    let same_point = |left: Point, right: Point| {
+        (left.x - right.x).abs() < 1.0e-9 && (left.y - right.y).abs() < 1.0e-9
+    };
+    assert_eq!(intent.no_connect_additions().len(), 2);
+    assert!(
+        intent
+            .no_connect_additions()
+            .iter()
+            .any(|target| same_point(target.at, stationary_nc)),
+        "stationary={stationary_nc:?} relocated={relocated_nc:?} additions={:?} relocations={:?}",
+        intent.no_connect_additions(),
+        intent.relocated_symbols()
+    );
+    assert!(
+        intent
+            .no_connect_additions()
+            .iter()
+            .any(|target| same_point(target.at, relocated_nc)),
+        "stationary={stationary_nc:?} relocated={relocated_nc:?} additions={:?} relocations={:?}",
+        intent.no_connect_additions(),
+        intent.relocated_symbols()
+    );
+    let repaired = plan_repairs(&missing_shared_marker, &netlist, &inspection, selected)
+        .unwrap()
+        .apply(Some(&missing_shared_marker))
+        .unwrap();
+    let after = pcb_kicad_sch::verify_connectivity_repair(
+        &missing_shared_marker,
+        &inspection,
+        &netlist,
+        &intent,
+        &repaired,
+    )
+    .unwrap();
+    assert!(after.issues.is_empty());
+    for expected in [stationary_nc, relocated_nc] {
+        assert!(repaired.pages.iter().any(|page| {
+            page.items.iter().any(
+                |item| matches!(item, SchItem::NoConnect(marker) if same_point(marker.at, expected)),
+            )
+        }));
+    }
+
+    let reconciled = plan_reconciliation(
+        Some(&missing_shared_marker),
+        &netlist,
+        "shared_nc.kicad_sch",
+    )
+    .unwrap()
+    .apply(Some(&missing_shared_marker))
+    .unwrap();
+    assert_eq!(reconciled, repaired);
+    assert!(
+        inspect_schematic(&reconciled, &netlist)
+            .unwrap()
+            .issues
+            .is_empty()
     );
 }
 
@@ -710,6 +953,119 @@ fn wired_not_connected_pins_are_cut_free_locally() {
         2,
         "the local two-wire cut must preserve the other 18 branch segments"
     );
+}
+
+#[test]
+fn one_missing_no_connect_issue_repairs_all_uncovered_physical_pin_occurrences() {
+    let mut netlist = common::compile_fixture("multi_pad_nc", "root.zen");
+    let mut not_connected = netlist.nets.remove("LEFT").unwrap();
+    not_connected.kind = "NotConnected".to_string();
+    not_connected.name.clear();
+    netlist.nets.insert(String::new(), not_connected);
+    let baseline = plan_reconciliation(None, &netlist, "multi_pad_nc.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    let (page_index, symbol) = baseline
+        .pages
+        .iter()
+        .enumerate()
+        .find_map(|(page_index, page)| {
+            page.items.iter().find_map(|item| match item {
+                SchItem::Symbol(symbol) if symbol.field_value("Path") == Some("U1.MULTI_PAD") => {
+                    Some((page_index, symbol))
+                }
+                _ => None,
+            })
+        })
+        .unwrap();
+    let pins = baseline.pages[page_index].library.definitions[&symbol.lib_id]
+        .placed_pins(symbol)
+        .unwrap();
+    let visible = pins
+        .iter()
+        .find(|pin| pin.name == "A" && !pin.hidden)
+        .unwrap()
+        .point;
+    let hidden = pins
+        .iter()
+        .find(|pin| pin.name == "A" && pin.hidden)
+        .unwrap()
+        .point;
+    let markers = baseline.pages[page_index]
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            SchItem::NoConnect(marker) => Some(marker.at),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let same_point = |left: Point, right: Point| {
+        (left.x - right.x).abs() < 1.0e-9 && (left.y - right.y).abs() < 1.0e-9
+    };
+    assert_eq!(markers.len(), 2);
+    assert!(markers.iter().any(|point| same_point(*point, visible)));
+    assert!(markers.iter().any(|point| same_point(*point, hidden)));
+
+    let mut both_missing = baseline.clone();
+    both_missing.pages[page_index]
+        .items
+        .retain(|item| !matches!(item, SchItem::NoConnect(_)));
+    let inspection = inspect_schematic(&both_missing, &netlist).unwrap();
+    let missing = inspection
+        .issues
+        .iter()
+        .filter(|issue| matches!(issue.issue, SchematicIssue::MissingNoConnect { .. }))
+        .collect::<Vec<_>>();
+    assert_eq!(missing.len(), 1, "{:#?}", inspection.issues);
+    let selected = BTreeSet::from([missing[0].key.clone()]);
+    let intent = plan_connectivity_repair(
+        &both_missing,
+        &netlist,
+        &inspection,
+        &selected,
+        &BTreeSet::new(),
+    )
+    .unwrap();
+    let additions = intent
+        .no_connect_additions()
+        .iter()
+        .map(|target| target.at)
+        .collect::<Vec<_>>();
+    assert_eq!(additions.len(), 2);
+    assert!(additions.iter().any(|point| same_point(*point, visible)));
+    assert!(additions.iter().any(|point| same_point(*point, hidden)));
+    let repaired = plan_repairs(&both_missing, &netlist, &inspection, selected)
+        .unwrap()
+        .apply(Some(&both_missing))
+        .unwrap();
+    assert!(
+        inspect_schematic(&repaired, &netlist)
+            .unwrap()
+            .issues
+            .is_empty()
+    );
+
+    let mut hidden_missing = baseline;
+    hidden_missing.pages[page_index].items.retain(
+        |item| !matches!(item, SchItem::NoConnect(marker) if same_point(marker.at, hidden)),
+    );
+    let inspection = inspect_schematic(&hidden_missing, &netlist).unwrap();
+    let missing = inspection
+        .issues
+        .iter()
+        .find(|issue| matches!(issue.issue, SchematicIssue::MissingNoConnect { .. }))
+        .unwrap();
+    let intent = plan_connectivity_repair(
+        &hidden_missing,
+        &netlist,
+        &inspection,
+        &BTreeSet::from([missing.key.clone()]),
+        &BTreeSet::new(),
+    )
+    .unwrap();
+    assert_eq!(intent.no_connect_additions().len(), 1);
+    assert!(same_point(intent.no_connect_additions()[0].at, hidden));
 }
 
 /// Generated child pages live in their parent page's directory so the

--- a/crates/pcbc/tests/schematic_apply_common.rs
+++ b/crates/pcbc/tests/schematic_apply_common.rs
@@ -3,4 +3,4 @@
 #[path = "../../pcb-kicad-sch/tests/common/mod.rs"]
 mod kicad_sch_common;
 
-pub use kicad_sch_common::{compile_fixture, test_data_dir};
+pub use kicad_sch_common::{compile_fixture, pin_point, test_data_dir};

--- a/crates/pcbc/tests/schematic_apply_flow.rs
+++ b/crates/pcbc/tests/schematic_apply_flow.rs
@@ -6,6 +6,7 @@ use pcb_kicad_sch::{
     Label, LabelKind, LabelShape, LabelSpin, MirrorAxis, PinInstance, Point, Rotation, SchItem,
     SymbolDefinition, Wire,
     analysis::{SchematicIssue, inspect_schematic},
+    plan_connectivity_repair,
     reconcile::plan_repairs,
 };
 use pcb_sch::{ATTR_SCHEMATIC_PATH, ATTR_SYMBOL_FORMAT_VERSION, AttributeValue};
@@ -627,27 +628,154 @@ fn preserves_user_symbol_and_equivalent_label_geometry() {
 }
 
 #[test]
-fn accepts_an_isolated_not_connected_pin() {
+fn materializes_an_isolated_not_connected_pin_and_then_makes_no_changes() {
     let workspace = tempfile::tempdir().unwrap();
     let project_dir = workspace.path().join("hardware");
     let mut netlist = linked_fixture(&project_dir);
+    let connected_netlist = netlist.clone();
     let mut not_connected = netlist.nets.remove("RIGHT").unwrap();
     not_connected.kind = "NotConnected".to_string();
     not_connected.name.clear();
     netlist.nets.insert(String::new(), not_connected);
 
-    apply_linked_schematic(&netlist).unwrap().unwrap();
+    let created = apply_linked_schematic(&netlist).unwrap().unwrap();
 
-    let project = KicadProject::load(project_dir).unwrap();
+    let project = KicadProject::load(&project_dir).unwrap();
     let analysis = inspect_schematic(&project.document, &netlist)
         .unwrap()
         .analysis;
     assert!(analysis.is_equivalent(), "{:?}", analysis.issues());
+    let not_connected_pin = common::pin_point(&project.document, "R2.R", "2");
+    let marker_points = project.document.pages[0]
+        .items
+        .iter()
+        .filter_map(|item| match item {
+            SchItem::NoConnect(marker) => Some(marker.at),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(marker_points, vec![not_connected_pin]);
     assert!(
         !project.document.pages[0]
             .items
             .iter()
             .any(|item| matches!(item, SchItem::Label(label) if label.text == "RIGHT"))
+    );
+
+    let source = fs::read(&created.schematic_files[0]).unwrap();
+    assert!(String::from_utf8_lossy(&source).contains("(no_connect"));
+    let unchanged = apply_linked_schematic(&netlist).unwrap().unwrap();
+    assert!(!unchanged.changed);
+    assert_eq!(fs::read(&unchanged.schematic_files[0]).unwrap(), source);
+
+    let mut without_marker = KicadProject::load(&project_dir).unwrap();
+    let marker = without_marker.document.pages[0]
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SchItem::NoConnect(marker) => Some(marker),
+            _ => None,
+        })
+        .unwrap();
+    marker.id = pcb_kicad_sch::deterministic_uuid("user-owned-no-connect");
+    let user_source = without_marker.document.to_kicad_sch().unwrap();
+    fs::write(&created.schematic_files[0], &user_source).unwrap();
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    assert_eq!(
+        fs::read_to_string(&created.schematic_files[0]).unwrap(),
+        user_source
+    );
+
+    without_marker.document.pages[0]
+        .items
+        .retain(|item| !matches!(item, SchItem::NoConnect(_)));
+    fs::write(
+        &created.schematic_files[0],
+        without_marker.document.to_kicad_sch().unwrap(),
+    )
+    .unwrap();
+    let missing_inspection = inspect_schematic(&without_marker.document, &netlist).unwrap();
+    let missing_key = missing_inspection
+        .issues
+        .iter()
+        .find(|issue| matches!(issue.issue, SchematicIssue::MissingNoConnect { .. }))
+        .unwrap()
+        .key
+        .clone();
+    let intent = plan_connectivity_repair(
+        &without_marker.document,
+        &netlist,
+        &missing_inspection,
+        &BTreeSet::from([missing_key.clone()]),
+        &BTreeSet::new(),
+    )
+    .unwrap();
+    assert_eq!(intent.no_connect_additions().len(), 1);
+    assert_eq!(intent.no_connect_additions()[0].at, not_connected_pin);
+    let scoped = plan_repairs(
+        &without_marker.document,
+        &netlist,
+        &missing_inspection,
+        BTreeSet::from([missing_key]),
+    )
+    .unwrap()
+    .apply(Some(&without_marker.document))
+    .unwrap();
+    assert!(
+        scoped.pages[0].items.iter().any(
+            |item| matches!(item, SchItem::NoConnect(marker) if marker.at == not_connected_pin)
+        )
+    );
+    assert!(apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    let repaired_source = fs::read(&created.schematic_files[0]).unwrap();
+    assert!(String::from_utf8_lossy(&repaired_source).contains("(no_connect"));
+    let repaired = KicadProject::load(&project_dir).unwrap();
+    assert_eq!(
+        repaired.document.pages[0]
+            .items
+            .iter()
+            .filter(|item| matches!(item, SchItem::NoConnect(_)))
+            .count(),
+        1
+    );
+    assert!(!apply_linked_schematic(&netlist).unwrap().unwrap().changed);
+    assert_eq!(
+        fs::read(&created.schematic_files[0]).unwrap(),
+        repaired_source
+    );
+
+    let stale_inspection = inspect_schematic(&repaired.document, &connected_netlist).unwrap();
+    let stale = stale_inspection
+        .issues
+        .iter()
+        .find(|issue| matches!(issue.issue, SchematicIssue::UnexpectedNoConnect { .. }))
+        .unwrap();
+    let stale_intent = plan_connectivity_repair(
+        &repaired.document,
+        &connected_netlist,
+        &stale_inspection,
+        &BTreeSet::from([stale.key.clone()]),
+        &BTreeSet::new(),
+    )
+    .unwrap();
+    assert_eq!(stale_intent.removals(), &stale.items);
+    assert!(
+        apply_linked_schematic(&connected_netlist)
+            .unwrap()
+            .unwrap()
+            .changed
+    );
+    let reconnected = KicadProject::load(&project_dir).unwrap();
+    assert!(
+        !reconnected.document.pages[0].items.iter().any(
+            |item| matches!(item, SchItem::NoConnect(marker) if marker.at == not_connected_pin)
+        )
+    );
+    assert!(
+        !apply_linked_schematic(&connected_netlist)
+            .unwrap()
+            .unwrap()
+            .changed
     );
 }
 


### PR DESCRIPTION
## Summary

- model missing and unexpected Zener `NotConnected()` annotations as first-class schematic issues
- expose native no-connect additions through the shared connectivity repair intent used by complete apply and interactive consumers
- preserve correct existing markers and restore/remove markers idempotently across hidden pins, repeated physical occurrences, and symbol relocation

## Root cause

Expected electrical connectivity intentionally excludes `NotConnected()` terminals, while KiCad connectivity reduction treats a bare isolated pin and a marker-only island as electrically equivalent. Reconciliation therefore had no discrepancy to repair even though the native KiCad annotation was absent. Parsing and serialization of native markers already worked; annotation intent was missing from analysis and repair planning.

## Verification

- `cargo nextest run -p pcb-kicad-sch` (208 passed, 1 skipped)
- `cargo test --doc -p pcb-kicad-sch`
- `cargo nextest run -p pcbc --test integration apply` (25 passed)
- `cargo clippy -p pcb-kicad-sch -p pcbc --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- real KiCad 10 projects: fresh generation, deletion/restoration, hidden DNC, NC↔connected transitions, hierarchical repeated modules, native ERC, and repeat hash stability
- downstream Quiche suite against this API: 284 library tests plus binary, repro, and UI-shot suites passed

Linear: [ENG-1674](https://linear.app/diodeinc/issue/ENG-1674/generated-schematic-omits-intentional-no-connects)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes schematic analysis, repair planning, and apply output for connectivity and annotation intent; mistakes could add/remove wrong markers or miss illegal NotConnected shorts.
> 
> **Overview**
> Zener **`NotConnected()`** pins are now checked against native KiCad **`no_connect`** annotations, not only electrical isolation. Schematic inspection adds **`MissingNoConnect`** and **`UnexpectedNoConnect`** issues; repair planning exposes **`no_connect_additions`** on the shared connectivity intent and the composer writes deterministic markers at pin anchors.
> 
> Matching uses KiCad internal grid units via **`points_connect`**, with per-pin **`NoConnectTarget`** data from connectivity provenance. Repair removes markers on connected pins or stale locations after symbol moves, re-adds required markers (including hidden/stacked pads), and keeps a single marker when multiple pins share one point. **`is_open_not_connected_group`** now treats distinct **`NotConnected`** terminals that touch as a real connection rather than an acceptable open island.
> 
> Apply/reconcile paths materialize **`(no_connect)`** on first sync, stay idempotent when markers are correct, and can restore or strip them when netlist intent changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cdfaafcb22e29363debf675280903e2b42d1d47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->