### PR TITLE
Fix IPC contour composition and scoped voids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Compose IPC-2581 shapes independently with local cutouts and ordered voids, preventing artificial slits and false DFM width violations.
 - Wire rotated and mirrored schematic symbol pins at KiCad's physical pin anchors.
 - Report and repair missing Zener `NotConnected()` intent as native KiCad no-connect markers.
 - Preserve successful BOM matches when another line needs retrying.

--- a/crates/ipc2581/src/parse.rs
+++ b/crates/ipc2581/src/parse.rs
@@ -1023,11 +1023,6 @@ impl<'a> Parser<'a> {
         let mut shapes = Vec::new();
 
         for child in self.element_children(node) {
-            if self.name(&child) == "UserSpecial" {
-                let UserPrimitive::UserSpecial(nested) = self.parse_user_special(&child, units)?;
-                shapes.extend(nested.shapes);
-                continue;
-            }
             if let Some(shape) = self.parse_user_shape(&child, units)? {
                 shapes.push(shape);
             }
@@ -1039,6 +1034,10 @@ impl<'a> Parser<'a> {
     fn parse_user_shape(&mut self, node: &Node, units: Units) -> Result<Option<UserShape>> {
         let tag_name = self.name(node);
         let shape = match tag_name {
+            // Preserve the scope of ordered VOID operations in nested primitives.
+            "UserSpecial" => Some(UserShapeType::UserPrimitive(
+                self.parse_user_special(node, units)?,
+            )),
             "Contour" => Some(UserShapeType::Contour(self.parse_contour(node, units)?)),
             "Circle" => Some(UserShapeType::Circle(Circle {
                 diameter: self.parse_f64_attr_with_units(node, "diameter", "Circle", units)?,

--- a/crates/ipc2581/src/types/primitives.rs
+++ b/crates/ipc2581/src/types/primitives.rs
@@ -373,6 +373,7 @@ pub enum UserShapeType {
     Arc(Arc),
     Polyline(Polyline),
     UserPrimitiveRef(Symbol),
+    UserPrimitive(UserPrimitive),
 }
 
 // FromStr implementations for shape enums

--- a/crates/pcb-ipc2581-tools/src/commands/board_array/eligibility.rs
+++ b/crates/pcb-ipc2581-tools/src/commands/board_array/eligibility.rs
@@ -349,6 +349,9 @@ fn validate_user_primitive(
 ) -> Result<()> {
     let UserPrimitive::UserSpecial(special) = primitive;
     for shape in &special.shapes {
+        if let UserShapeType::UserPrimitive(primitive) = &shape.shape {
+            validate_user_primitive(ipc, primitive, ancestors)?;
+        }
         if let UserShapeType::UserPrimitiveRef(id) = shape.shape {
             if ancestors.contains(&id) {
                 bail!(

--- a/crates/pcb-ipc2581-tools/src/gerber/export.rs
+++ b/crates/pcb-ipc2581-tools/src/gerber/export.rs
@@ -2915,11 +2915,100 @@ mod tests {
     }
 
     #[test]
+    fn gerber_export_preserves_overlapping_contours_and_local_cutouts() {
+        let resolution = Resolution::default();
+        let source = r#"<IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
+  <Content roleRef="owner"><FunctionMode mode="FABRICATION"/>
+    <StepRef name="board"/><LayerRef name="TOP"/>
+  </Content>
+  <Ecad><CadHeader units="MILLIMETER"/><CadData>
+    <Layer name="TOP" layerFunction="SIGNAL" side="TOP" polarity="POSITIVE"/>
+    <Step name="board" type="BOARD"><LayerFeature layerRef="TOP">
+      <Set net="VCC"><Features><UserSpecial>
+        <Contour>
+          <Polygon>
+            <PolyBegin x="0" y="0"/><PolyStepSegment x="6" y="0"/>
+            <PolyStepSegment x="6" y="4"/><PolyStepSegment x="0" y="4"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon>
+          <Cutout>
+            <PolyBegin x="1" y="1"/><PolyStepSegment x="3" y="1"/>
+            <PolyStepSegment x="3" y="3"/><PolyStepSegment x="1" y="3"/>
+            <PolyStepSegment x="1" y="1"/>
+          </Cutout>
+        </Contour>
+        <!-- Opposite winding; overlaps both the first polygon and its cutout. -->
+        <Contour><Polygon>
+          <PolyBegin x="8" y="2"/><PolyStepSegment x="2" y="2"/>
+          <PolyStepSegment x="2" y="5"/><PolyStepSegment x="8" y="5"/>
+          <PolyStepSegment x="8" y="2"/>
+        </Polygon></Contour>
+        <!-- A nested positive sibling is additional material, not a counter. -->
+        <Contour><Polygon>
+          <PolyBegin x="4" y="0.5"/><PolyStepSegment x="5" y="0.5"/>
+          <PolyStepSegment x="5" y="1.5"/><PolyStepSegment x="4" y="1.5"/>
+          <PolyStepSegment x="4" y="0.5"/>
+        </Polygon></Contour>
+      </UserSpecial></Features></Set>
+    </LayerFeature></Step>
+  </CadData></Ecad>
+</IPC-2581>"#;
+        for (function, filename) in [("SIGNAL", "F_Cu.gtl"), ("LEGEND", "F_SilkS.gto")] {
+            let ipc = ipc::Ipc2581::parse(&source.replace("SIGNAL", function)).unwrap();
+
+            // Check source import and both normalization paths before exporting.
+            let doc = pcb_ir::import::ipc2581::extract_layer(&ipc, "TOP", resolution).unwrap();
+            let image = |doc: &pcb_ir::import::ipc2581::GeometryDocument| {
+                pcb_ir::geom::ContourSet::from_painted_paths(
+                    &doc.arena,
+                    doc.features
+                        .iter()
+                        .flat_map(|f| f.paths.slice(&doc.arena.paths)),
+                    resolution,
+                )
+                .unwrap()
+            };
+            for (mut doc, rendering) in [(doc.clone(), false), (doc, true)] {
+                assert!((image(&doc).area() - 31.0).abs() < 1e-6);
+                if rendering {
+                    pcb_ir::dialects::ipc::process::compose_for_rendering(&mut doc, resolution)
+                        .unwrap();
+                } else {
+                    pcb_ir::dialects::ipc::process::normalize_for_artwork(&mut doc, resolution)
+                        .unwrap();
+                }
+                let region = image(&doc);
+                assert!((region.area() - 31.0).abs() < 1e-6);
+                assert!(!region.contains_point(pcb_ir::geom::Point::new(1.5, 2.5)));
+                assert!(region.contains_point(pcb_ir::geom::Point::new(2.5, 2.5)));
+                assert!(region.contains_point(pcb_ir::geom::Point::new(4.5, 1.0)));
+            }
+
+            let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
+            let layer = files.iter().find(|file| file.filename == filename).unwrap();
+            assert!(
+                !layer.contents.contains("%LPC*%"),
+                "cutouts must stay local"
+            );
+            let parsed = gerberx2::GerberX2::parse(&layer.contents).unwrap();
+            let geometry =
+                gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
+            let summary =
+                pcb_ir::dialects::artwork::compare::summarize(&geometry, resolution).unwrap();
+            // 24 - 4 + 18 - (8 - 1) = 31; the nested sibling adds no new area.
+            assert!(
+                (summary.area_mm2 - 31.0).abs() < 1e-6,
+                "area: {}",
+                summary.area_mm2
+            );
+        }
+    }
+
+    #[test]
     fn gerber_export_preserves_user_special_counter_holes() {
         let resolution = Resolution::default();
 
-        let ipc = ipc::Ipc2581::parse(
-            r#"<?xml version="1.0" encoding="UTF-8"?>
+        let source = r#"<?xml version="1.0" encoding="UTF-8"?>
 <IPC-2581 revision="C" xmlns="http://webstds.ipc.org/2581">
   <Content roleRef="owner">
     <FunctionMode mode="FABRICATION"/>
@@ -2943,15 +3032,13 @@ mod tests {
                     <PolyStepSegment x="0" y="4"/>
                     <PolyStepSegment x="0" y="0"/>
                   </Polygon>
-                </Contour>
-                <Contour>
-                  <Polygon>
+                  <Cutout>
                     <PolyBegin x="1" y="1"/>
                     <PolyStepSegment x="3" y="1"/>
                     <PolyStepSegment x="3" y="3"/>
                     <PolyStepSegment x="1" y="3"/>
                     <PolyStepSegment x="1" y="1"/>
-                  </Polygon>
+                  </Cutout>
                 </Contour>
               </UserSpecial>
             </Features>
@@ -2960,27 +3047,52 @@ mod tests {
       </Step>
     </CadData>
   </Ecad>
-</IPC-2581>"#,
-        )
-        .unwrap();
-        let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
+</IPC-2581>"#;
+        // KiCad's Fracture() joins a hole to its outer ring with a retraced
+        // bridge. Knockout text can also leave a separate positive counter island.
+        let mut fractured = source.to_owned();
+        let start = fractured.find("<Contour>").unwrap();
+        let end = fractured.find("</Contour>").unwrap() + "</Contour>".len();
+        fractured.replace_range(
+            start..end,
+            r#"
+          <Contour><Polygon>
+            <PolyBegin x="0" y="0"/><PolyStepSegment x="4" y="0"/>
+            <PolyStepSegment x="4" y="4"/><PolyStepSegment x="0" y="4"/>
+            <PolyStepSegment x="0" y="0"/><PolyStepSegment x="1" y="1"/>
+            <PolyStepSegment x="1" y="3"/><PolyStepSegment x="3" y="3"/>
+            <PolyStepSegment x="3" y="1"/><PolyStepSegment x="1" y="1"/>
+            <PolyStepSegment x="0" y="0"/>
+          </Polygon></Contour>
+          <Contour><Polygon>
+            <PolyBegin x="1.5" y="1.5"/><PolyStepSegment x="2" y="1.5"/>
+            <PolyStepSegment x="2" y="2"/><PolyStepSegment x="1.5" y="2"/>
+            <PolyStepSegment x="1.5" y="1.5"/>
+          </Polygon></Contour>"#,
+        );
+        for (source, expected_area) in [(source, 12.0), (fractured.as_str(), 12.25)] {
+            let ipc = ipc::Ipc2581::parse(source).unwrap();
+            let files = gerber_files(&ipc, ArtworkScope::Board).unwrap();
 
-        let silk = files
-            .iter()
-            .find(|file| file.filename == "F_SilkS.gto")
-            .unwrap();
-        assert!(
-            !silk.contents.contains("%LPC*%"),
-            "positive compound region holes should not export as layer-global clear regions"
-        );
-        let parsed = gerberx2::GerberX2::parse(&silk.contents).unwrap();
-        let geometry = gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
-        let summary = pcb_ir::dialects::artwork::compare::summarize(&geometry, resolution).unwrap();
-        assert!(
-            (summary.area_mm2 - 12.0).abs() < 1e-6,
-            "compound region should preserve its counter hole; area was {}",
-            summary.area_mm2
-        );
+            let silk = files
+                .iter()
+                .find(|file| file.filename == "F_SilkS.gto")
+                .unwrap();
+            assert!(
+                !silk.contents.contains("%LPC*%"),
+                "positive compound region holes should not export as layer-global clear regions"
+            );
+            let parsed = gerberx2::GerberX2::parse(&silk.contents).unwrap();
+            let geometry =
+                gerberx2::geometry::extract_document(&parsed, resolution.accuracy).unwrap();
+            let summary =
+                pcb_ir::dialects::artwork::compare::summarize(&geometry, resolution).unwrap();
+            assert!(
+                (summary.area_mm2 - expected_area).abs() < 1e-6,
+                "compound region should preserve its counter hole; area was {}",
+                summary.area_mm2
+            );
+        }
     }
 
     #[test]

--- a/crates/pcb-ir/src/dialects/ipc/process.rs
+++ b/crates/pcb-ir/src/dialects/ipc/process.rs
@@ -529,7 +529,9 @@ where
     Ok(())
 }
 
-/// Merge a feature's identically painted paths into one compound path.
+/// Merge a feature's identically stroked paths into one compound path.
+/// Independent fills must keep their path boundaries: concatenation can cancel
+/// overlaps under both even-odd and nonzero winding rules.
 pub fn compose_feature_paths<S, L>(doc: &mut Document<S, L>) {
     for feature_index in 0..doc.features.len() {
         let span = doc.features[feature_index].paths;
@@ -539,7 +541,7 @@ pub fn compose_feature_paths<S, L>(doc: &mut Document<S, L>) {
 
         let paths = span.slice(&doc.arena.paths);
         let paint = paths[0].paint;
-        if !paths.iter().all(|path| path.paint == paint) {
+        if !matches!(paint, Paint::Stroke(_)) || !paths.iter().all(|path| path.paint == paint) {
             continue;
         }
 
@@ -1009,31 +1011,21 @@ fn layer_cutout_sets<S, L>(
         .collect())
 }
 
-/// The regularized filled image of a feature's fill paths, grouped by fill
-/// rule before the final union.
+/// Union each fill path's independently evaluated image, retaining local holes.
 fn feature_filled_region<S, L>(
     doc: &Document<S, L>,
     feature: &Feature<S>,
     resolution: Resolution,
 ) -> Result<ContourSet, AccuracyError> {
-    let mut groups: HashMap<FillRule, Vec<ContourBuf>> = HashMap::new();
-    for path in feature.paths.slice(&doc.arena.paths) {
-        if let Some(rule) = path.fill_rule() {
-            groups
-                .entry(rule)
-                .or_default()
-                .extend(doc.arena.path_contours(path));
-        }
-    }
-
-    let mut composer = region::PaintComposer::new(resolution);
-    for (fill_rule, contours) in groups {
-        composer.push(
-            Polarity::Dark,
-            ContourSet::from_contours(&contours, fill_rule, resolution.strict())?,
-        );
-    }
-    composer.finish()
+    ContourSet::from_painted_paths(
+        &doc.arena,
+        feature
+            .paths
+            .slice(&doc.arena.paths)
+            .iter()
+            .filter(|path| path.is_filled()),
+        resolution,
+    )
 }
 
 /// Bounds of a set's own feature span, for sets with no linked features.
@@ -1063,6 +1055,28 @@ mod tests {
     use crate::geom::{LineCap, Point, StrokeStyle};
 
     type TestDoc = Document<u32, ()>;
+
+    #[test]
+    fn preserves_independent_overlapping_fill_paths() {
+        let resolution = Resolution::default();
+        for rule in [FillRule::EvenOdd, FillRule::NonZero] {
+            let mut doc = TestDoc::new();
+            doc.push_path(Paint::Fill { rule }, [rect_contour(0.0, 0.0, 6.0, 4.0)]);
+            // Opposite winding: neither parity nor winding may cancel the overlap.
+            doc.push_path(Paint::Fill { rule }, [rect_contour(8.0, 2.0, 2.0, 5.0)]);
+            doc.features.push(Feature {
+                paths: Span::new(0, 2),
+                ..copper_trace_feature()
+            });
+
+            let image = feature_filled_region(&doc, &doc.features[0], resolution).unwrap();
+            assert!((image.area() - 34.0).abs() < 1e-9);
+            normalize_preserving(&mut doc);
+            let image = feature_filled_region(&doc, &doc.features[0], resolution).unwrap();
+            assert!((image.area() - 34.0).abs() < 1e-9);
+            assert!(image.contains_point(Point::new(3.0, 3.0)));
+        }
+    }
 
     #[test]
     fn composes_compatible_stroked_feature_paths() {

--- a/crates/pcb-ir/src/import/ipc2581.rs
+++ b/crates/pcb-ir/src/import/ipc2581.rs
@@ -3,9 +3,9 @@ use std::collections::{BTreeSet, HashMap};
 
 use anyhow::{Context, Result, bail};
 use ipc2581::types::{
-    FillDesc, FillProperty, HoleShape as IpcHoleShape, LayerFunction, LineEnd, LineProperty,
-    PadUse, PlatingStatus, Polarity, PolyStep, SlotShape, StandardPrimitive, UserPrimitive,
-    UserShapeType, Xform,
+    FillProperty, HoleShape as IpcHoleShape, LayerFunction, LineEnd, LineProperty, PadUse,
+    PlatingStatus, Polarity, PolyStep, SlotShape, StandardPrimitive, UserPrimitive, UserShapeType,
+    Xform,
     ecad::{Layer, SetFeature, Step, StepRepeat, StepType},
 };
 use ipc2581::{Interner, Ipc2581, Symbol};
@@ -238,6 +238,7 @@ struct LayoutInstanceSpec {
 
 struct ExtractContext<'a> {
     strings: &'a Interner,
+    resolution: Resolution,
     padstacks: HashMap<Symbol, &'a ipc2581::types::PadStackDef>,
     line_descs: HashMap<Symbol, ipc2581::types::LineDesc>,
     fill_descs: HashMap<Symbol, ipc2581::types::FillDesc>,
@@ -1508,6 +1509,7 @@ pub fn extract_step_layer_local(
     let content = ipc.content();
     let context = ExtractContext {
         strings: ipc.interner(),
+        resolution,
         padstacks: step
             .padstack_defs
             .iter()
@@ -2417,7 +2419,7 @@ fn extract_pad(
                 ));
                 return Ok(None);
             };
-            lower_user_primitive(context, doc, primitive, placement.transform)
+            lower_user_primitive(context, doc, primitive, placement.transform)?
         }
     };
     let path_count = doc.arena.paths.len() as u32 - path_start;
@@ -2536,7 +2538,7 @@ fn extract_feature_primitive(
                 return Ok(Vec::new());
             };
             (
-                lower_user_primitive(context, doc, primitive, transform),
+                lower_user_primitive(context, doc, primitive, transform)?,
                 PrimitiveRef::User(primitive_ref.id),
             )
         }
@@ -2567,7 +2569,7 @@ fn extract_inline_user_primitive(
     let transform =
         Affine2::placement(Point::new(primitive.x, primitive.y), 0.0, Mirror::NONE, 1.0);
     let path_start = doc.arena.paths.len() as u32;
-    let paint = lower_user_primitive(context, doc, &primitive.primitive, transform);
+    let paint = lower_user_primitive(context, doc, &primitive.primitive, transform)?;
     primitive_features_from_paths(
         doc,
         primitive_path_feature(net, polarity, source, transform, path_start, paint, None),
@@ -3350,23 +3352,15 @@ fn lower_user_primitive(
     doc: &mut GeometryDocument,
     primitive: &UserPrimitive,
     transform: Affine2,
-) -> PrimitivePaint {
+) -> Result<PrimitivePaint> {
     match primitive {
         UserPrimitive::UserSpecial(user_special) => {
             let mut paint = PrimitivePaint::Fill;
-            let mut pending_contours = Vec::new();
-            let mut pending_fill_key = user_fill_key(None);
+            let primitive_start = doc.arena.paths.len();
+            // IPC-2581C §3.5.11.2: UserSpecial combines independent shapes.
+            // A Contour's Polygon and Cutouts stay together (§3.5.9.3); sibling
+            // contours are additive, including KiCad zone fills and text islands.
             for shape in &user_special.shapes {
-                if user_shape_is_filled_contour(shape) {
-                    let fill_key = user_fill_key(shape.fill_desc);
-                    if !pending_contours.is_empty() && pending_fill_key != fill_key {
-                        flush_user_contours(doc, &mut pending_contours);
-                    }
-                    pending_fill_key = fill_key;
-                    push_user_shape_contours(&mut pending_contours, &shape.shape, transform);
-                    continue;
-                }
-                flush_user_contours(doc, &mut pending_contours);
                 let path_start = doc.arena.paths.len() as u32;
                 let mut nested_paint = None;
                 match &shape.shape {
@@ -3454,18 +3448,27 @@ fn lower_user_primitive(
                             line_desc,
                         );
                     }
+                    UserShapeType::UserPrimitive(primitive) => {
+                        nested_paint =
+                            Some(lower_user_primitive(context, doc, primitive, transform)?);
+                    }
                     UserShapeType::UserPrimitiveRef(primitive_ref) => {
                         if let Some(primitive) = context.user_primitives.get(primitive_ref).copied()
                         {
                             nested_paint =
-                                Some(lower_user_primitive(context, doc, primitive, transform));
+                                Some(lower_user_primitive(context, doc, primitive, transform)?);
                         } else {
                             make_paths_unpainted(doc, path_start);
                         }
                     }
                 }
 
-                match shape.fill_desc {
+                let fill_desc = shape.fill_desc.or_else(|| {
+                    shape
+                        .fill_desc_ref
+                        .and_then(|id| context.fill_descs.get(&id).copied())
+                });
+                match fill_desc {
                     Some(fill_desc) if fill_desc.fill_property == FillProperty::Hollow => {
                         if let Some(line_desc) = user_shape_line_desc(context, shape) {
                             make_paths_stroked(
@@ -3481,7 +3484,12 @@ fn lower_user_primitive(
                         paint = PrimitivePaint::Hollow;
                     }
                     Some(fill_desc) if fill_desc.fill_property == FillProperty::Void => {
-                        paint = PrimitivePaint::Void;
+                        subtract_user_void(
+                            doc,
+                            primitive_start,
+                            path_start as usize,
+                            context.resolution,
+                        )?;
                     }
                     Some(_) => {}
                     None => {
@@ -3491,54 +3499,52 @@ fn lower_user_primitive(
                     }
                 }
             }
-            flush_user_contours(doc, &mut pending_contours);
-            paint
+            Ok(paint)
         }
     }
 }
 
-/// Grouping key for consecutive filled user-shape contours: contours sharing a
-/// source fill description are merged into one even-odd compound path.
-fn user_fill_key(fill_desc: Option<FillDesc>) -> (FillProperty, Option<f64>, Option<f64>) {
-    match fill_desc {
-        Some(desc) if matches!(desc.fill_property, FillProperty::Hatch | FillProperty::Mesh) => {
-            (desc.fill_property, desc.angle1, desc.angle2)
+/// IPC-2581C §3.5.6.1: VOID clears only preceding filled shapes in its own
+/// UserSpecial, never strokes, later islands, or neighboring primitives.
+fn subtract_user_void(
+    doc: &mut GeometryDocument,
+    primitive_start: usize,
+    void_start: usize,
+    resolution: Resolution,
+) -> Result<()> {
+    let cutters = ContourSet::from_painted_paths(
+        &doc.arena,
+        doc.arena.paths[void_start..]
+            .iter()
+            .filter(|path| path.is_filled()),
+        resolution.strict(),
+    )?;
+    doc.arena.paths.truncate(void_start);
+    for index in primitive_start..void_start {
+        let path = doc.arena.paths[index];
+        let Some(rule) = path.fill_rule() else {
+            continue;
+        };
+        if !path.bbox.intersects(cutters.bbox) {
+            continue;
         }
-        Some(desc) => (desc.fill_property, None, None),
-        None => (FillProperty::Fill, None, None),
+        let subject =
+            ContourSet::from_contours(&doc.arena.path_contours(&path), rule, resolution.strict())?;
+        let result = subject.difference(&cutters)?;
+        let (contours, bbox) = doc.arena.push_contours(result.to_contours());
+        doc.arena.paths[index] = Path {
+            contours,
+            bbox,
+            paint: if result.is_empty() {
+                Paint::None
+            } else {
+                Paint::Fill {
+                    rule: FillRule::NonZero,
+                }
+            },
+        };
     }
-}
-
-fn user_shape_is_filled_contour(shape: &ipc2581::types::UserShape) -> bool {
-    matches!(
-        shape.fill_desc.map(|desc| desc.fill_property),
-        None | Some(FillProperty::Fill | FillProperty::Hatch | FillProperty::Mesh)
-    ) && matches!(
-        &shape.shape,
-        UserShapeType::Polygon(_) | UserShapeType::Contour(_)
-    )
-}
-
-fn push_user_shape_contours(out: &mut Vec<ContourBuf>, shape: &UserShapeType, transform: Affine2) {
-    match shape {
-        UserShapeType::Polygon(polygon) => {
-            out.push(polygon_contour(polygon).transformed(transform))
-        }
-        UserShapeType::Contour(contour) => push_contour_payloads(out, contour, transform),
-        _ => {}
-    }
-}
-
-fn flush_user_contours(doc: &mut GeometryDocument, contours: &mut Vec<ContourBuf>) {
-    if contours.is_empty() {
-        return;
-    }
-    doc.push_path(
-        Paint::Fill {
-            rule: FillRule::EvenOdd,
-        },
-        std::mem::take(contours),
-    );
+    Ok(())
 }
 
 fn user_shape_line_desc(
@@ -4138,6 +4144,7 @@ mod tests {
         .unwrap();
         let context = ExtractContext {
             strings: ipc.interner(),
+            resolution: Resolution::default(),
             padstacks: HashMap::new(),
             line_descs: HashMap::new(),
             fill_descs: HashMap::new(),
@@ -4178,6 +4185,7 @@ mod tests {
         .unwrap();
         let context = ExtractContext {
             strings: ipc.interner(),
+            resolution: Resolution::default(),
             padstacks: HashMap::new(),
             line_descs: HashMap::new(),
             fill_descs: HashMap::new(),
@@ -4266,6 +4274,7 @@ mod tests {
         let feature = extract_feature_polyline(
             &ExtractContext {
                 strings: ipc.interner(),
+                resolution: Resolution::default(),
                 padstacks: HashMap::new(),
                 line_descs: HashMap::new(),
                 fill_descs: HashMap::new(),
@@ -4316,13 +4325,15 @@ mod tests {
         .unwrap();
         let context = ExtractContext {
             strings: ipc.interner(),
+            resolution: Resolution::default(),
             padstacks: HashMap::new(),
             line_descs: HashMap::new(),
             fill_descs: HashMap::new(),
             standard_primitives: HashMap::new(),
             user_primitives: HashMap::new(),
         };
-        let paint = lower_user_primitive(&context, &mut doc, &primitive, Affine2::identity());
+        let paint =
+            lower_user_primitive(&context, &mut doc, &primitive, Affine2::identity()).unwrap();
 
         assert_eq!(paint, PrimitivePaint::Hollow);
         assert_eq!(doc.arena.paths.len(), 1);
@@ -4353,6 +4364,7 @@ mod tests {
         let entry = ipc.content().dictionary_line_desc.entries[0].clone();
         let context = ExtractContext {
             strings: ipc.interner(),
+            resolution: Resolution::default(),
             padstacks: HashMap::new(),
             line_descs: HashMap::from([(entry.id, entry.line_desc)]),
             fill_descs: HashMap::new(),
@@ -4389,7 +4401,8 @@ mod tests {
             ],
         });
 
-        let paint = lower_user_primitive(&context, &mut doc, &primitive, Affine2::identity());
+        let paint =
+            lower_user_primitive(&context, &mut doc, &primitive, Affine2::identity()).unwrap();
 
         assert_eq!(paint, PrimitivePaint::Fill);
         assert_eq!(doc.arena.paths.len(), 2);
@@ -4411,6 +4424,7 @@ mod tests {
         .unwrap();
         let context = ExtractContext {
             strings: ipc.interner(),
+            resolution: Resolution::default(),
             padstacks: HashMap::new(),
             line_descs: HashMap::new(),
             fill_descs: HashMap::new(),
@@ -4464,6 +4478,7 @@ mod tests {
         .unwrap();
         let context = ExtractContext {
             strings: ipc.interner(),
+            resolution: Resolution::default(),
             padstacks: HashMap::new(),
             line_descs: HashMap::new(),
             fill_descs: HashMap::new(),
@@ -4472,28 +4487,16 @@ mod tests {
         };
         let primitive = ipc2581::types::ecad::FeatureUserPrimitive {
             primitive: UserPrimitive::UserSpecial(ipc2581::types::UserSpecial {
-                shapes: vec![
-                    ipc2581::types::UserShape {
-                        shape: UserShapeType::Contour(ipc2581::types::Contour {
-                            polygon: rect_polygon(0.0, 0.0, 2.0, 2.0),
-                            cutouts: Vec::new(),
-                        }),
-                        line_desc: None,
-                        line_desc_ref: None,
-                        fill_desc: None,
-                        fill_desc_ref: None,
-                    },
-                    ipc2581::types::UserShape {
-                        shape: UserShapeType::Contour(ipc2581::types::Contour {
-                            polygon: rect_polygon(0.5, 0.5, 1.5, 1.5),
-                            cutouts: Vec::new(),
-                        }),
-                        line_desc: None,
-                        line_desc_ref: None,
-                        fill_desc: None,
-                        fill_desc_ref: None,
-                    },
-                ],
+                shapes: vec![ipc2581::types::UserShape {
+                    shape: UserShapeType::Contour(ipc2581::types::Contour {
+                        polygon: rect_polygon(0.0, 0.0, 2.0, 2.0),
+                        cutouts: vec![rect_polygon(0.5, 0.5, 1.5, 1.5)],
+                    }),
+                    line_desc: None,
+                    line_desc_ref: None,
+                    fill_desc: None,
+                    fill_desc_ref: None,
+                }],
             }),
             x: 10.0,
             y: 20.0,
@@ -4517,6 +4520,86 @@ mod tests {
         assert_eq!(doc.arena.paths[0].contours.count, 2);
         assert_eq!(doc.arena.paths[0].bbox.min, Point::new(10.0, 20.0));
         assert_eq!(doc.arena.paths[0].bbox.max, Point::new(12.0, 22.0));
+        let image =
+            ContourSet::from_painted_paths(&doc.arena, &doc.arena.paths, Resolution::default())
+                .unwrap();
+        assert!((image.area() - 3.0).abs() < 1e-9);
+        assert!(!image.contains_point(Point::new(11.0, 21.0)));
+    }
+
+    #[test]
+    fn user_special_voids_clear_only_preceding_fills_in_their_own_scope() {
+        let contour = |x0, y0, x1, y1, style: &str| {
+            format!(
+                "<Contour><Polygon><PolyBegin x='{x0}' y='{y0}'/>
+             <PolyStepSegment x='{x1}' y='{y0}'/><PolyStepSegment x='{x1}' y='{y1}'/>
+             <PolyStepSegment x='{x0}' y='{y1}'/><PolyStepSegment x='{x0}' y='{y0}'/>
+             {style}</Polygon></Contour>"
+            )
+        };
+        let nested = format!(
+            "<UserSpecial>{}
+             <Line startX='1.2' startY='3.6' endX='4.8' endY='3.6'>
+               <LineDesc lineWidth='0.1' lineEnd='NONE'/>
+             </Line>{}{}</UserSpecial>",
+            contour(0.0, 0.0, 8.0, 6.0, ""),
+            contour(1.0, 1.0, 5.0, 4.0, "<FillDescRef id='void'/>"),
+            contour(2.0, 2.0, 3.0, 3.0, ""),
+        );
+        // Both direct nesting and dictionary references must establish a scope.
+        for child in [&nested, "<UserPrimitiveRef id='nested'/>"] {
+            let ipc = Ipc2581::parse(&format!(
+                "<IPC-2581 revision='C' xmlns='http://webstds.ipc.org/2581'>
+                 <Content roleRef='owner'><FunctionMode mode='FABRICATION'/>
+                   <StepRef name='board'/><LayerRef name='TOP'/>
+                   <DictionaryFillDesc units='MILLIMETER'>
+                     <EntryFillDesc id='void'><FillDesc fillProperty='VOID'/></EntryFillDesc>
+                   </DictionaryFillDesc>
+                   <DictionaryUser units='MILLIMETER'><EntryUser id='nested'>{nested}</EntryUser></DictionaryUser>
+                 </Content><Ecad><CadHeader units='MILLIMETER'/><CadData>
+                 <Layer name='TOP' layerFunction='SIGNAL' side='TOP' polarity='POSITIVE'/>
+                 <Step name='board' type='BOARD'><LayerFeature layerRef='TOP'><Set>
+                   <Features><UserSpecial>{}</UserSpecial></Features>
+                   <Features><UserSpecial>{}{child}</UserSpecial></Features>
+                 </Set></LayerFeature></Step></CadData></Ecad></IPC-2581>",
+                contour(1.1, 1.1, 1.4, 1.4, ""),
+                contour(1.5, 1.1, 1.8, 1.4, ""),
+            )).unwrap();
+            let resolution = Resolution::default();
+            let mut doc = extract_layer(&ipc, "TOP", resolution).unwrap();
+            process::normalize_for_artwork(&mut doc, resolution).unwrap();
+            let image = ContourSet::from_painted_paths(
+                &doc.arena,
+                doc.features
+                    .iter()
+                    .flat_map(|feature| feature.paths.slice(&doc.arena.paths))
+                    .filter(|path| path.is_filled()),
+                resolution,
+            )
+            .unwrap();
+            // Plate minus void, plus later island and two independent earlier squares.
+            assert!(
+                (image.area() - 37.18).abs() < 1e-6,
+                "area: {}",
+                image.area()
+            );
+            for point in [
+                Point::new(1.2, 1.2),
+                Point::new(1.6, 1.2),
+                Point::new(2.5, 2.5),
+            ] {
+                assert!(image.contains_point(point));
+            }
+            assert!(!image.contains_point(Point::new(4.0, 2.0)));
+            let strokes = doc
+                .features
+                .iter()
+                .flat_map(|feature| feature.paths.slice(&doc.arena.paths))
+                .filter(|path| path.is_stroked())
+                .collect::<Vec<_>>();
+            assert_eq!(strokes.len(), 1);
+            assert!((strokes[0].bbox.width() - 3.7).abs() < 1e-9);
+        }
     }
 
     #[test]
@@ -4527,6 +4610,7 @@ mod tests {
         .unwrap();
         let context = ExtractContext {
             strings: ipc.interner(),
+            resolution: Resolution::default(),
             padstacks: HashMap::new(),
             line_descs: HashMap::new(),
             fill_descs: HashMap::new(),

--- a/crates/pcb-ir/src/import/ipc2581/assembly.rs
+++ b/crates/pcb-ir/src/import/ipc2581/assembly.rs
@@ -661,6 +661,7 @@ fn geometry_reference(
 fn package_shape_context(design: &ImportedDesign) -> super::ExtractContext<'_> {
     super::ExtractContext {
         strings: &design.strings,
+        resolution: crate::geom::Resolution::default(),
         padstacks: HashMap::new(),
         line_descs: design
             .content


### PR DESCRIPTION
## Summary

Fix IPC-2581 contour composition so overlapping positive shapes remain additive rather than canceling material under a shared fill rule.

- Preserve each `Contour` and its local `Cutout` holes as an independent filled path on every layer.
- Stop normalization from concatenating independent fills or pooling them by fill rule.
- Preserve nested `UserSpecial` scopes and apply explicit `VOID` shapes only to preceding fills within their scope, leaving strokes and later islands intact.
- Resolve user-shape fill-description references and retain recursive board-array eligibility checks.

These semantics follow IPC-2581C sections 3.5.9.3, 3.5.11.2, and 3.5.6.1. Regression fixtures cover overlapping shapes with opposite winding, local cutouts, nested positive shapes, scoped void ordering, and KiCad-style fractured counters. Synthetic counter tests now express holes using explicit cutouts rather than inferring holes from positive sibling nesting.

## Validation

- `cargo nextest run -p ipc2581 -p pcb-ir -p pcb-ipc2581-tools -p gerberx2` — 743 passed.
- `cargo test --doc -p ipc2581 -p pcb-ir -p pcb-ipc2581-tools -p gerberx2` — 2 passed, 1 ignored.
- `cargo clippy --profile test -p ipc2581 -p pcb-ir -p pcb-ipc2581-tools --all-targets -- -D warnings` — passed.
- `cargo build -p pcbc --profile test` — passed.
- Formatting and `git diff --check` — passed.
- No snapshot changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core IPC-2581 import, region union, and Gerber export semantics for silkscreen, mask, and copper—areas that feed DFM and fabrication output—but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **IPC-2581 `UserSpecial` geometry** so overlapping positive fills stay additive and holes/voids stay local instead of merging into one compound path or layer-global clears.
> 
> **Parsing and import:** Nested `UserSpecial` nodes are kept as scoped `UserPrimitive` shapes (not flattened). Each sibling shape becomes its own path; contour cutouts stay on that contour. `FillDesc` **VOID** subtracts only from **preceding fills in the same `UserSpecial`**, via `subtract_user_void`, without touching strokes or later islands. Fill-description refs resolve through the extract context.
> 
> **Normalization / export:** `compose_feature_paths` merges **stroked** paths only—filled paths are no longer concatenated (which canceled overlaps under even-odd/nonzero rules). `feature_filled_region` unions each fill path’s image independently with `ContourSet::from_painted_paths`. Board-array eligibility recursively validates nested user primitives.
> 
> Regression tests cover overlapping/opposite-winding contours, local cutouts, scoped void ordering, fractured KiCad counters, and Gerber area without `%LPC*%` for local holes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f36282c08128373ec563f7e70b96e95b74fb757. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->