### PR TITLE
ENG-248 Avoid redundant net names in imported boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Avoid redundant explicit net names in imported boards and sheet modules while preserving names that differ from their assigned identifiers.
 - Wire rotated and mirrored schematic symbol pins at KiCad's physical pin anchors.
 - Report and repair missing Zener `NotConnected()` intent as native KiCad no-connect markers.
 - Preserve successful BOM matches when another line needs retrying.

--- a/crates/pcbc/src/codegen/board.rs
+++ b/crates/pcbc/src/codegen/board.rs
@@ -184,7 +184,9 @@ fn render_imported_module_body(
             out.push_str(" = ");
             out.push_str(ctor);
             out.push('(');
-            out.push_str(&starlark::string(&net.name));
+            if net.name != net.ident {
+                out.push_str(&starlark::string(&net.name));
+            }
             out.push_str(")\n");
         }
         out.push('\n');

--- a/crates/pcbc/src/import/generate.rs
+++ b/crates/pcbc/src/import/generate.rs
@@ -2859,6 +2859,75 @@ mod tests {
     use std::path::PathBuf;
 
     #[test]
+    fn imported_net_names_are_inferred_only_when_identical() {
+        use crate::codegen::board::{
+            RenderImportedBoardArgs, render_imported_board, render_imported_sheet_module,
+        };
+
+        let names = [
+            ("SWITCH_INTERRUPT_N", ImportNetKind::Net),
+            ("GND", ImportNetKind::Ground),
+            ("VCC", ImportNetKind::Power),
+            ("+3V3", ImportNetKind::Power),
+            ("Signal.Name", ImportNetKind::Net),
+            ("Signal_Name", ImportNetKind::Net),
+            ("FOO-BAR", ImportNetKind::Net),
+            ("FOO_BAR", ImportNetKind::Net),
+        ];
+        let nets = names
+            .iter()
+            .map(|(name, _)| {
+                (
+                    KiCadNetName::from(name.to_string()),
+                    ImportNetData {
+                        ports: BTreeSet::new(),
+                    },
+                )
+            })
+            .collect();
+        let kinds = names
+            .into_iter()
+            .map(|(name, kind)| {
+                (
+                    KiCadNetName::from(name.to_string()),
+                    ImportNetKindClassification {
+                        kind,
+                        reasons: BTreeSet::new(),
+                    },
+                )
+            })
+            .collect();
+        let decls = build_net_decls(&nets, &BTreeSet::new(), &kinds);
+        let board = render_imported_board(RenderImportedBoardArgs {
+            board_name: "TestBoard",
+            copper_layers: 2,
+            design_rules: None,
+            stackup: None,
+            net_decls: &decls.decls,
+            module_decls: &[],
+            instance_calls: &[],
+        });
+        let sheet = render_imported_sheet_module("TestSheet", &[], &decls.decls, &[], &[]);
+        for source in [board, sheet] {
+            for expected in [
+                "SWITCH_INTERRUPT_N = Net()",
+                "GND = Ground()",
+                "VCC = Power()",
+                "NET_3V3 = Power(\"+3V3\")",
+                "SIGNAL_NAME = Net(\"Signal_Name\")",
+                "SIGNAL_NAME_2 = Net(\"Signal_Name_2\")",
+                "FOO_BAR = Net(\"FOO-BAR\")",
+                "FOO_BAR_2 = Net(\"FOO_BAR\")",
+            ] {
+                assert!(
+                    source.lines().any(|line| line == expected),
+                    "missing {expected:?} in:\n{source}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn imported_layout_uses_allocated_net_names() {
         let names = ["Signal.Name", "Signal_Name", "Signal_Name_2", "GND"];
         let nets = names


### PR DESCRIPTION
## Summary

Use assignment-inferred names for imported Net, Power, and Ground declarations only when the allocated identifier exactly equals the net name. Preserve explicit names for case differences, punctuation, and allocation collisions, in both root boards and sheet modules.

Related to [ENG-248](https://linear.app/diodeinc/issue/ENG-248/optional-name-in-nets-interfaces-io-and-config).

This is an importer follow-up to name inference. It does not change native KiCad footprint identity or layout synchronization, and does not rewrite existing boards.

## Verification

- Regression test failed before the fix and reproduced `SWITCH_INTERRUPT_N = Net("SWITCH_INTERRUPT_N")`.
- `cargo fmt --all -- --check` and `git diff origin/main...HEAD --check` passed.
- After rebasing onto origin/main: `cargo nextest run -p pcbc -p pcb-zen-core -E 'test(import::) | test(codegen::board::) | test(name_inference::)'` — 102 tests passed, including native KiCad project/standalone import integration tests.
- No snapshots changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Importer-only Starlark codegen output change with no runtime or layout sync behavior changes; covered by new unit tests.
> 
> **Overview**
> Imported KiCad boards and sheet modules now emit **assignment-inferred** `Net()`, `Power()`, and `Ground()` declarations when the allocated Starlark identifier matches the net name (e.g. `GND = Ground()` instead of `GND = Ground("GND")`).
> 
> When the identifier and name differ—sanitization, punctuation, case, or collision suffixes—the generator still passes an **explicit** string (e.g. `NET_3V3 = Power("+3V3")`, `FOO_BAR = Net("FOO-BAR")`).
> 
> A regression test locks expected lines for both root board and sheet module render paths. The unreleased changelog documents the fix under **Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e640175b804b7275c1f64c7c0bc2aaa9e46abc80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/diodeinc/pcb/pull/1279" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->