### PR TITLE
Preserve KiCad embedded symbol cache aliases during apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Preserve KiCad embedded symbol cache aliases during schematic apply without dangling references or collapsing distinct definitions.
 - Avoid redundant explicit net names in imported boards and sheet modules while preserving names that differ from their assigned identifiers.
 - Compose IPC-2581 shapes independently with local cutouts and ordered voids, preventing artificial slits and false DFM width violations.
 - Wire rotated and mirrored schematic symbol pins at KiCad's physical pin anchors.

--- a/crates/pcb-kicad-sch/src/analysis.rs
+++ b/crates/pcb-kicad-sch/src/analysis.rs
@@ -783,7 +783,7 @@ fn managed_terminals_by_visibility(
             let definition = page
                 .library
                 .definitions
-                .get(&placed.lib_id)
+                .get(placed.library_key())
                 .with_context(|| {
                     format!(
                         "managed symbol {} has no cached definition {}",
@@ -1652,6 +1652,7 @@ mod tests {
         Symbol {
             id,
             lib_id: "power:GND".to_string(),
+            lib_name: None,
             unit: 1,
             body_style: 1,
             at,

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -433,11 +433,20 @@ fn project_component_slot(
     }
 
     let previous = selected.map(|selected| &selected.symbol);
+    let at = previous.map(|symbol| symbol.at).unwrap_or_default();
+    let rotation = match previous {
+        Some(symbol) => symbol.rotation,
+        None => initial_component_rotation(netlist, slot, &definition, net_symbol_specs)?,
+    };
+    let mirror = previous.and_then(|symbol| symbol.mirror);
+    // Derive fields and library identity from the authoritative definition, never a cache key.
+    let mut symbol =
+        build_component_symbol(instance, slot, &definition, at, rotation, mirror, previous)?;
+
     // A native save may give an instance its own presentation without changing
     // the library identity. Keep that presentation unless the symbol is replaced
     // or its electrical interface needs repair. Missing base entries are normal.
     let mut definition = definition;
-    let library_id = definition.lib_id.clone();
     if let Some(previous) = previous
         && previous.lib_name.is_some()
         && definition.lib_id == previous.lib_id
@@ -450,15 +459,6 @@ fn project_component_slot(
     {
         definition = cached.clone();
     }
-    let at = previous.map(|symbol| symbol.at).unwrap_or_default();
-    let rotation = match previous {
-        Some(symbol) => symbol.rotation,
-        None => initial_component_rotation(netlist, slot, &definition, net_symbol_specs)?,
-    };
-    let mirror = previous.and_then(|symbol| symbol.mirror);
-    let mut symbol =
-        build_component_symbol(instance, slot, &definition, at, rotation, mirror, previous)?;
-    symbol.lib_id = library_id;
     cache_symbol_definition(&mut document.pages[page_index], &mut symbol, &definition)?;
     if let Some(selected) = selected {
         let selected_page_id = document.pages[selected.page_index].id.clone();

--- a/crates/pcb-kicad-sch/src/compose.rs
+++ b/crates/pcb-kicad-sch/src/compose.rs
@@ -433,18 +433,33 @@ fn project_component_slot(
     }
 
     let previous = selected.map(|selected| &selected.symbol);
+    // A native save may give an instance its own presentation without changing
+    // the library identity. Keep that presentation unless the symbol is replaced
+    // or its electrical interface needs repair. Missing base entries are normal.
+    let mut definition = definition;
+    let library_id = definition.lib_id.clone();
+    if let Some(previous) = previous
+        && previous.lib_name.is_some()
+        && definition.lib_id == previous.lib_id
+        && let Some(cached) = document.pages[page_index]
+            .library
+            .definitions
+            .get(previous.library_key())
+        && symbol::ParsedSymbolDefinition::parse(cached)?
+            .same_pin_interface(&symbol::ParsedSymbolDefinition::parse(&definition)?)
+    {
+        definition = cached.clone();
+    }
     let at = previous.map(|symbol| symbol.at).unwrap_or_default();
     let rotation = match previous {
         Some(symbol) => symbol.rotation,
         None => initial_component_rotation(netlist, slot, &definition, net_symbol_specs)?,
     };
     let mirror = previous.and_then(|symbol| symbol.mirror);
-    let symbol =
+    let mut symbol =
         build_component_symbol(instance, slot, &definition, at, rotation, mirror, previous)?;
-    document.pages[page_index]
-        .library
-        .definitions
-        .insert(definition.lib_id.clone(), definition);
+    symbol.lib_id = library_id;
+    cache_symbol_definition(&mut document.pages[page_index], &mut symbol, &definition)?;
     if let Some(selected) = selected {
         let selected_page_id = document.pages[selected.page_index].id.clone();
         let mut replacement = Some(symbol);
@@ -490,6 +505,7 @@ fn initial_component_rotation(
     let unplaced = Symbol {
         id: String::new(),
         lib_id: definition.lib_id.clone(),
+        lib_name: None,
         unit: slot.unit(),
         body_style: 1,
         at: Point::default(),
@@ -657,11 +673,12 @@ fn placed_symbols_from_document(
         let definition = document.pages[candidate.page_index]
             .library
             .definitions
-            .get(&candidate.symbol.lib_id)
+            .get(candidate.symbol.library_key())
             .with_context(|| {
                 format!(
                     "managed symbol {} has no cached definition {}",
-                    candidate.symbol.id, candidate.symbol.lib_id
+                    candidate.symbol.id,
+                    candidate.symbol.library_key()
                 )
             })?
             .clone();
@@ -687,7 +704,7 @@ fn power_symbol_locations(document: &SchDocument) -> Result<BTreeSet<SymbolLocat
             let SchItem::Symbol(symbol) = item else {
                 continue;
             };
-            let Some(definition) = page.library.definitions.get(&symbol.lib_id) else {
+            let Some(definition) = page.library.definitions.get(symbol.library_key()) else {
                 continue;
             };
             if symbol::ParsedSymbolDefinition::parse(definition)?
@@ -1482,7 +1499,7 @@ fn occupy_page_items_except(
     for item in &page.items {
         match item {
             SchItem::Symbol(symbol) if !excluded_symbol_ids.contains(&symbol.id) => {
-                let Some(definition) = page.library.definitions.get(&symbol.lib_id) else {
+                let Some(definition) = page.library.definitions.get(symbol.library_key()) else {
                     continue;
                 };
                 if let Some(bounds) = field_autoplace::symbol_visual_bounds(symbol, definition)? {
@@ -1680,6 +1697,7 @@ fn build_component_symbol(
     let mut symbol = Symbol {
         id: slot.symbol_id(),
         lib_id: definition.lib_id.clone(),
+        lib_name: None,
         unit: slot.unit(),
         body_style: previous.map(|symbol| symbol.body_style).unwrap_or(1),
         at,
@@ -2129,11 +2147,12 @@ fn relocate_symbol(
     let definition = document.pages[page_index]
         .library
         .definitions
-        .get(&symbol.lib_id)
+        .get(symbol.library_key())
         .with_context(|| {
             format!(
                 "schematic symbol '{}' has no cached definition '{}'",
-                symbol.id, symbol.lib_id
+                symbol.id,
+                symbol.library_key()
             )
         })?;
     let mut packer = GridPacker::for_page(&document.pages[page_index].paper)?;
@@ -2820,7 +2839,7 @@ fn net_symbol_stub_collides(
             SchItem::NoConnect(no_connect) => existing_points.push(no_connect.at),
             SchItem::Sheet(sheet) => existing_points.extend(sheet.pins.iter().map(|pin| pin.at)),
             SchItem::Symbol(symbol) => {
-                if let Some(definition) = page.library.definitions.get(&symbol.lib_id) {
+                if let Some(definition) = page.library.definitions.get(symbol.library_key()) {
                     existing_points.extend(
                         definition
                             .placed_pins(symbol)?
@@ -3222,6 +3241,7 @@ fn build_net_symbol(
     let mut symbol = Symbol {
         id,
         lib_id: spec.definition.lib_id.clone(),
+        lib_name: None,
         unit: spec.unit,
         body_style: 1,
         at: Point::default(),
@@ -3416,7 +3436,7 @@ fn upsert_wire(document: &mut SchDocument, page_index: usize, mut wire: Wire) {
 fn insert_net_symbol(
     document: &mut SchDocument,
     page_index: usize,
-    symbol: Symbol,
+    mut symbol: Symbol,
     definition: &SymbolDefinition,
 ) -> Result<()> {
     if contains_id(document, &symbol.id) {
@@ -3426,21 +3446,39 @@ fn insert_net_symbol(
         );
     }
     let page = &mut document.pages[page_index];
-    match page.library.definitions.get(&definition.lib_id) {
-        Some(existing) if existing != definition => bail!(
-            "page '{}' already has a different definition for net symbol '{}'",
-            page.id,
-            definition.lib_id
-        ),
-        Some(_) => {}
-        None => {
-            page.library
-                .definitions
-                .insert(definition.lib_id.clone(), definition.clone());
-        }
-    }
+    cache_symbol_definition(page, &mut symbol, definition)?;
     page.items.push(SchItem::Symbol(symbol));
     Ok(())
+}
+
+/// Install a definition without changing another instance's cached geometry.
+fn cache_symbol_definition(
+    page: &mut SchPage,
+    symbol: &mut Symbol,
+    definition: &SymbolDefinition,
+) -> Result<()> {
+    let mut cached = definition.clone();
+    for suffix in 1.. {
+        match page.library.definitions.get(&cached.lib_id) {
+            Some(existing)
+                if existing != &cached
+                    && page.items.iter().any(|item| {
+                        matches!(item, SchItem::Symbol(other)
+                    if other.id != symbol.id && other.library_key() == cached.lib_id)
+                    }) =>
+            {
+                cached = definition.renamed(&format!("{}_{}", definition.lib_id, suffix))?;
+            }
+            _ => {
+                symbol.lib_name = (cached.lib_id != symbol.lib_id).then(|| cached.lib_id.clone());
+                page.library
+                    .definitions
+                    .insert(cached.lib_id.clone(), cached);
+                return Ok(());
+            }
+        }
+    }
+    unreachable!()
 }
 
 fn prune_unused_symbol_definitions(document: &mut SchDocument) {
@@ -3449,7 +3487,7 @@ fn prune_unused_symbol_definitions(document: &mut SchDocument) {
             .items
             .iter()
             .filter_map(|item| match item {
-                SchItem::Symbol(symbol) => Some(symbol.lib_id.as_str()),
+                SchItem::Symbol(symbol) => Some(symbol.library_key()),
                 _ => None,
             })
             .collect::<BTreeSet<_>>();
@@ -4009,6 +4047,7 @@ mod tests {
         let symbol = Symbol {
             id: slot.symbol_id(),
             lib_id: definition.lib_id.clone(),
+            lib_name: None,
             unit: 1,
             body_style: 1,
             at: Point::default(),

--- a/crates/pcb-kicad-sch/src/connectivity/kicad.rs
+++ b/crates/pcb-kicad-sch/src/connectivity/kicad.rs
@@ -600,17 +600,18 @@ fn cached_symbol_definition<'a>(
     placed: &Symbol,
     parsed: &'a mut BTreeMap<String, symbol::ParsedSymbolDefinition>,
 ) -> Result<&'a symbol::ParsedSymbolDefinition> {
-    match parsed.entry(placed.lib_id.clone()) {
+    match parsed.entry(placed.library_key().to_owned()) {
         std::collections::btree_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
         std::collections::btree_map::Entry::Vacant(entry) => {
             let definition = page
                 .library
                 .definitions
-                .get(&placed.lib_id)
+                .get(placed.library_key())
                 .with_context(|| {
                     format!(
                         "symbol {} on page instance {page_instance_id} has no cached definition {}",
-                        placed.id, placed.lib_id
+                        placed.id,
+                        placed.library_key()
                     )
                 })?;
             Ok(entry.insert(symbol::ParsedSymbolDefinition::parse(definition)?))

--- a/crates/pcb-kicad-sch/src/field_autoplace.rs
+++ b/crates/pcb-kicad-sch/src/field_autoplace.rs
@@ -926,6 +926,7 @@ mod tests {
         Symbol {
             id: "symbol".to_string(),
             lib_id: "Test:IC".to_string(),
+            lib_name: None,
             unit: 1,
             body_style: 1,
             at,

--- a/crates/pcb-kicad-sch/src/kicad.rs
+++ b/crates/pcb-kicad-sch/src/kicad.rs
@@ -101,6 +101,35 @@ impl SymbolDefinition {
         )
     }
 
+    /// Rename the library/cache key and unit-section prefixes, preserving all content.
+    pub fn renamed(&self, name: &str) -> Result<Self> {
+        let mut definition = self.clone();
+        let items = definition
+            .sexpr
+            .as_list_mut()
+            .context("expected symbol list")?;
+        items[1] = Sexpr::string(name);
+        let stem = name.rsplit(':').next().unwrap_or(name);
+        for child in &mut items[2..] {
+            let Some(section) = child.as_list_mut() else {
+                continue;
+            };
+            if section.first().and_then(Sexpr::as_sym) != Some("symbol") {
+                continue;
+            }
+            let old = section
+                .get(1)
+                .and_then(Sexpr::as_atom)
+                .context("missing section name")?;
+            let mut suffix = old.rsplitn(3, '_');
+            let style = suffix.next().context("missing section body style")?;
+            let unit = suffix.next().context("missing section unit")?;
+            section[1] = Sexpr::string(format!("{stem}_{unit}_{style}"));
+        }
+        definition.lib_id = name.to_owned();
+        Ok(definition)
+    }
+
     pub(crate) fn default_fields(&self) -> Result<BTreeMap<String, SymbolField>> {
         let items = SexprList::from_sexpr(&self.sexpr)
             .with_context(|| format!("symbol '{}' definition is not a list", self.lib_id))?;
@@ -365,6 +394,7 @@ fn symbol_definition_from_symbol_items(
 fn parse_symbol(items: SexprList<'_>) -> Result<Symbol> {
     let mut id = None;
     let mut lib_id = None;
+    let mut lib_name = None;
     let mut unit = None;
     let mut body_style = 1;
     let mut at = None;
@@ -387,6 +417,9 @@ fn parse_symbol(items: SexprList<'_>) -> Result<Symbol> {
         match list.tag() {
             Some("lib_id") => {
                 lib_id = list.string(1);
+            }
+            Some("lib_name") => {
+                lib_name = Some(list.string(1).context("symbol lib_name is not a string")?);
             }
             Some("at") => {
                 at = Some(parse_at(list)?);
@@ -446,6 +479,7 @@ fn parse_symbol(items: SexprList<'_>) -> Result<Symbol> {
     Ok(Symbol {
         id: id.ok_or_else(|| anyhow!("symbol {lib_id} missing uuid"))?,
         lib_id,
+        lib_name,
         unit: unit.context("symbol missing unit")?,
         body_style,
         at,
@@ -1217,6 +1251,13 @@ fn symbol_to_sexpr(symbol: &Symbol) -> Sexpr {
             Sexpr::int(symbol.body_style as i64),
         ]),
     ];
+
+    if let Some(lib_name) = &symbol.lib_name {
+        items.push(Sexpr::list(vec![
+            Sexpr::symbol("lib_name"),
+            Sexpr::string(lib_name),
+        ]));
+    }
 
     if let Some(axis) = symbol.mirror {
         items.push(Sexpr::list(vec![

--- a/crates/pcb-kicad-sch/src/model.rs
+++ b/crates/pcb-kicad-sch/src/model.rs
@@ -238,6 +238,9 @@ pub struct SheetPin {
 pub struct Symbol {
     pub id: Id,
     pub lib_id: LibId,
+    /// Page-local embedded definition override; `lib_id` remains the library identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lib_name: Option<String>,
     pub unit: u32,
     pub body_style: u32,
     pub at: Point,
@@ -259,6 +262,10 @@ pub struct Symbol {
 }
 
 impl Symbol {
+    pub fn library_key(&self) -> &str {
+        self.lib_name.as_deref().unwrap_or(&self.lib_id)
+    }
+
     pub fn reference(&self) -> Option<&str> {
         self.field_value("Reference")
     }

--- a/crates/pcb-kicad-sch/src/net_symbols.rs
+++ b/crates/pcb-kicad-sch/src/net_symbols.rs
@@ -44,6 +44,7 @@ pub(crate) fn specs(netlist: &Schematic) -> Result<BTreeMap<String, NetSymbolSpe
             let unplaced = Symbol {
                 id: String::new(),
                 lib_id: definition.lib_id.clone(),
+                lib_name: None,
                 unit: *unit,
                 body_style: 1,
                 at: Point::default(),

--- a/crates/pcb-kicad-sch/src/repair.rs
+++ b/crates/pcb-kicad-sch/src/repair.rs
@@ -748,7 +748,8 @@ fn orphaned_junctions(
                 SchItem::Label(label) => remaining_points.push(label.at),
                 SchItem::NoConnect(no_connect) => remaining_points.push(no_connect.at),
                 SchItem::Symbol(symbol) => {
-                    if let Some(definition) = remaining_page.library.definitions.get(&symbol.lib_id)
+                    if let Some(definition) =
+                        remaining_page.library.definitions.get(symbol.library_key())
                         && let Ok(pins) = definition.placed_pins(symbol)
                     {
                         remaining_points.extend(pins.into_iter().map(|pin| pin.point));
@@ -1676,6 +1677,7 @@ mod tests {
         Symbol {
             id: "part".to_string(),
             lib_id: "Test:Part".to_string(),
+            lib_name: None,
             unit: 1,
             body_style: 1,
             at,

--- a/crates/pcb-kicad-sch/src/symbol.rs
+++ b/crates/pcb-kicad-sch/src/symbol.rs
@@ -128,6 +128,36 @@ impl ParsedSymbolDefinition {
         &self.unit_indices
     }
 
+    /// Compare every unit/style's electrical interface, excluding presentation.
+    pub(crate) fn same_pin_interface(&self, other: &Self) -> bool {
+        let pins = |definition: &Self| {
+            let mut pins = definition
+                .sections
+                .iter()
+                .flat_map(|section| {
+                    section.pins.iter().map(|pin| {
+                        (
+                            section.unit,
+                            section.body_style,
+                            pin.name.clone(),
+                            pin.numbers.clone(),
+                            pin.electrical_type.clone(),
+                            pin.hidden,
+                            pin.alternates.clone(),
+                        )
+                    })
+                })
+                .collect::<Vec<_>>();
+            pins.sort();
+            pins
+        };
+        self.unit_indices == other.unit_indices
+            && self.power_scope == other.power_scope
+            && self.duplicate_pin_numbers_are_jumpers == other.duplicate_pin_numbers_are_jumpers
+            && self.jumper_pin_groups == other.jumper_pin_groups
+            && pins(self) == pins(other)
+    }
+
     pub fn duplicate_pin_numbers_are_jumpers(&self) -> bool {
         self.duplicate_pin_numbers_are_jumpers
     }
@@ -591,6 +621,7 @@ mod tests {
         let symbol = Symbol {
             id: "symbol".into(),
             lib_id: "Device:Multi".into(),
+            lib_name: None,
             unit: 2,
             body_style: 1,
             at: Point::new(10.0, 20.0),
@@ -626,6 +657,7 @@ mod tests {
         let mut symbol = Symbol {
             id: "symbol".into(),
             lib_id: "Test:Symbol".into(),
+            lib_name: None,
             unit: 1,
             body_style: 1,
             at: Point::new(10.0, 20.0),

--- a/crates/pcb-kicad-sch/src/symbol.rs
+++ b/crates/pcb-kicad-sch/src/symbol.rs
@@ -140,6 +140,7 @@ impl ParsedSymbolDefinition {
                             section.unit,
                             section.body_style,
                             pin.name.clone(),
+                            pin.number.clone(),
                             pin.numbers.clone(),
                             pin.electrical_type.clone(),
                             pin.hidden,

--- a/crates/pcb-kicad-sch/tests/common/kicad_builder.rs
+++ b/crates/pcb-kicad-sch/tests/common/kicad_builder.rs
@@ -200,6 +200,7 @@ impl KicadBuilder {
         self.push(SchItem::Symbol(Symbol {
             id,
             lib_id: lib_id.to_string(),
+            lib_name: None,
             unit: 1,
             body_style: 1,
             at,

--- a/crates/pcb-kicad-sch/tests/symbol_aliases.rs
+++ b/crates/pcb-kicad-sch/tests/symbol_aliases.rs
@@ -54,7 +54,22 @@ fn cache_alias_lookup_is_distinct_from_library_identity() {
 
 #[test]
 fn save_apply_reopen_preserves_distinct_native_alias_presentation() {
-    let netlist = common::compile_fixture("analysis", "simple.zen");
+    let mut netlist = common::compile_fixture("analysis", "simple.zen");
+    for instance in netlist.instances.values_mut() {
+        match instance.reference_designator.as_deref() {
+            Some("R1") => {
+                instance.attributes.remove("Value");
+                instance.attributes.remove("value");
+            }
+            Some("R2") => {
+                instance.attributes.insert(
+                    "Value".into(),
+                    AttributeValue::String("explicit value".into()),
+                );
+            }
+            _ => {}
+        }
+    }
     let document = plan_reconciliation(None, &netlist, "Alias.kicad_sch")
         .unwrap()
         .apply(None)
@@ -95,6 +110,14 @@ fn save_apply_reopen_preserves_distinct_native_alias_presentation() {
         assert!(plan.inspection_after().analysis.is_equivalent());
         let applied = plan.apply(Some(&saved)).unwrap();
         assert_eq!(managed(&applied, "R1.R").lib_id, base_id);
+        assert_eq!(
+            managed(&applied, "R1.R").field_value("Value"),
+            Some(base_id.as_str())
+        );
+        assert_eq!(
+            managed(&applied, "R2.R").field_value("Value"),
+            Some("explicit value")
+        );
         assert_eq!(applied.pages[0].library.definitions["Native_1"], alias);
         if keep_base {
             assert_eq!(applied.pages[0].library.definitions[&base_id], base);

--- a/crates/pcb-kicad-sch/tests/symbol_aliases.rs
+++ b/crates/pcb-kicad-sch/tests/symbol_aliases.rs
@@ -1,0 +1,385 @@
+mod common;
+
+use std::collections::BTreeSet;
+
+use common::kicad_builder::{KicadBuilder, TestPin};
+use pcb_kicad_sch::{
+    SchDocument, SchItem, Symbol, SymbolDefinition, connectivity::ConnectivityGraph,
+    patch_page_source, reconcile::plan_reconciliation,
+};
+use pcb_sch::AttributeValue;
+use pcb_sexpr::{
+    Sexpr,
+    formatter::{FormatMode, format_tree},
+};
+
+#[test]
+fn cache_alias_lookup_is_distinct_from_library_identity() {
+    let mut builder = KicadBuilder::new();
+    builder
+        .define_symbol("Test:Part", &[TestPin::passive("1", (0.0, 0.0))])
+        .define_symbol("Part_1", &[TestPin::passive("7", (5.0, 0.0))])
+        .component("Test:Part", Some("BASE"), (0.0, 0.0))
+        .local_label("BASE_NET", (0.0, 0.0))
+        .component("Test:Part", Some("ALIAS"), (10.0, 0.0))
+        .local_label("ALIAS_NET", (15.0, 0.0));
+    let mut document = builder.build();
+    managed_mut(&mut document, "ALIAS").lib_name = Some("Part_1".into());
+    let source = document.to_kicad_sch().unwrap();
+    let mut reopened = SchDocument::from_kicad_sch(&source).unwrap();
+    let alias = managed(&reopened, "ALIAS");
+    assert_eq!(alias.lib_id, "Test:Part");
+    assert_eq!(alias.library_key(), "Part_1");
+    let graph = ConnectivityGraph::from_kicad(&reopened).unwrap();
+    for (name, number) in [("BASE_NET", "1"), ("ALIAS_NET", "7")] {
+        let group = graph
+            .groups
+            .iter()
+            .find(|group| group.names.contains(name))
+            .unwrap();
+        assert_eq!(group.terminals.len(), 1);
+        assert!(group.terminals.iter().all(|terminal| matches!(terminal,
+            pcb_kicad_sch::connectivity::Terminal::ComponentPin { pin_numbers, .. }
+                if pin_numbers == &BTreeSet::from([number.to_owned()]))));
+    }
+    reopened.pages[0].library.definitions.remove("Part_1");
+    assert!(
+        ConnectivityGraph::from_kicad(&reopened)
+            .unwrap_err()
+            .to_string()
+            .contains("no cached definition Part_1"),
+        "must not fall back to the base definition"
+    );
+}
+
+#[test]
+fn save_apply_reopen_preserves_distinct_native_alias_presentation() {
+    let netlist = common::compile_fixture("analysis", "simple.zen");
+    let document = plan_reconciliation(None, &netlist, "Alias.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    for keep_base in [true, false] {
+        let mut saved = document.clone();
+        let base_id = managed(&saved, "R1.R").lib_id.clone();
+        let base = saved.pages[0].library.definitions[&base_id].clone();
+        let alias = with_name(&base, "Native_1");
+        let mut alias = alias;
+        let section = alias
+            .sexpr
+            .as_list_mut()
+            .unwrap()
+            .iter_mut()
+            .filter_map(Sexpr::as_list_mut)
+            .find(|items| items.first().and_then(Sexpr::as_sym) == Some("symbol"))
+            .unwrap();
+        section.push(
+            pcb_sexpr::parse(
+                r#"(circle (center 0 0) (radius 3.81)
+            (stroke (width 0.254) (type default)) (fill (type none)))"#,
+            )
+            .unwrap(),
+        );
+        managed_mut(&mut saved, "R1.R").lib_name = Some(alias.lib_id.clone());
+        if !keep_base {
+            managed_mut(&mut saved, "R2.R").lib_name = Some(alias.lib_id.clone());
+            saved.pages[0].library.definitions.remove(&base_id);
+        }
+        saved.pages[0]
+            .library
+            .definitions
+            .insert(alias.lib_id.clone(), alias.clone());
+        let source = saved.to_kicad_sch().unwrap();
+        let saved = SchDocument::from_kicad_sch(&source).unwrap();
+        let plan = plan_reconciliation(Some(&saved), &netlist, "Alias.kicad_sch").unwrap();
+        assert!(plan.inspection_after().analysis.is_equivalent());
+        let applied = plan.apply(Some(&saved)).unwrap();
+        assert_eq!(managed(&applied, "R1.R").lib_id, base_id);
+        assert_eq!(applied.pages[0].library.definitions["Native_1"], alias);
+        if keep_base {
+            assert_eq!(applied.pages[0].library.definitions[&base_id], base);
+        }
+        let output = patch_page_source(&source, &applied.pages[0])
+            .unwrap()
+            .unwrap_or(source);
+        let reopened = SchDocument::from_kicad_sch(&output).unwrap();
+        let second = plan_reconciliation(Some(&reopened), &netlist, "Alias.kicad_sch").unwrap();
+        assert!(second.is_empty(), "{:#?}", second.edits());
+        assert!(
+            patch_page_source(&output, &second.apply(Some(&reopened)).unwrap().pages[0])
+                .unwrap()
+                .is_none(),
+            "second apply must be byte unchanged"
+        );
+    }
+}
+
+#[test]
+fn refreshing_one_shared_alias_does_not_change_the_other_instance() {
+    for use_alias in [false, true] {
+        let mut netlist = common::compile_fixture("analysis", "simple.zen");
+        let mut saved = plan_reconciliation(None, &netlist, "Alias.kicad_sch")
+            .unwrap()
+            .apply(None)
+            .unwrap();
+        let base_id = managed(&saved, "R1.R").lib_id.clone();
+        let base = saved.pages[0].library.definitions[&base_id].clone();
+        let alias = with_name(&base, if use_alias { "Native_1" } else { &base_id });
+        for path in ["R1.R", "R2.R"] {
+            managed_mut(&mut saved, path).lib_name = use_alias.then(|| alias.lib_id.clone());
+        }
+        saved.pages[0].library.definitions.clear();
+        saved.pages[0]
+            .library
+            .definitions
+            .insert(alias.lib_id.clone(), alias.clone());
+
+        // Same library identity, but an authoritative replacement changes a pin's name.
+        // Equal physical numbers alone must not preserve the old electrical interface.
+        let raw = format_tree(&base.sexpr, FormatMode::Normal);
+        let old_name = alias.placed_pins(managed(&saved, "R1.R")).unwrap()[0]
+            .name
+            .clone();
+        let replacement = raw.replace(&format!("(name \"{old_name}\""), "(name \"CHANGED\"");
+        assert_ne!(raw, replacement);
+        let instance = netlist
+            .instances
+            .values_mut()
+            .find(|instance| instance.reference_designator.as_deref() == Some("R1"))
+            .unwrap();
+        instance
+            .attributes
+            .insert("__symbol_value".into(), AttributeValue::String(replacement));
+        let plan = plan_reconciliation(Some(&saved), &netlist, "Alias.kicad_sch").unwrap();
+        let applied = plan.apply(Some(&saved)).unwrap();
+        let first = managed(&applied, "R1.R");
+        let second = managed(&applied, "R2.R");
+        assert_eq!(first.lib_id, base_id);
+        assert_ne!(first.library_key(), second.library_key());
+        assert_eq!(
+            applied.pages[0].library.definitions[second.library_key()],
+            alias
+        );
+        assert!(
+            applied.pages[0].library.definitions[first.library_key()]
+                .placed_pins(first)
+                .unwrap()
+                .iter()
+                .any(|pin| pin.name == "CHANGED")
+        );
+        let source = applied.to_kicad_sch().unwrap();
+        let reopened = SchDocument::from_kicad_sch(&source).unwrap();
+        let second = plan_reconciliation(Some(&reopened), &netlist, "Alias.kicad_sch").unwrap();
+        assert!(second.is_empty(), "{:#?}", second.edits());
+    }
+}
+
+#[test]
+fn stale_alias_pin_or_unit_interfaces_are_refreshed() {
+    let netlist = common::compile_fixture("analysis", "simple.zen");
+    let document = plan_reconciliation(None, &netlist, "Alias.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    let base_id = managed(&document, "R1.R").lib_id.clone();
+    let base = document.pages[0].library.definitions[&base_id].clone();
+    for extra_unit in [false, true] {
+        let mut saved = document.clone();
+        let mut alias = with_name(&base, "Native_1");
+        if extra_unit {
+            alias.sexpr.as_list_mut().unwrap().push(
+                pcb_sexpr::parse(
+                    r#"(symbol "Native_1_2_1" (pin passive line (at 0 0 0)
+                    (length 0) (name "BAD") (number "99")))"#,
+                )
+                .unwrap(),
+            );
+        } else {
+            let raw = format_tree(&alias.sexpr, FormatMode::Normal);
+            let changed = raw.replace("(number \"1\"", "(number \"99\"");
+            assert_ne!(raw, changed);
+            alias = SymbolDefinition::from_kicad_symbol_sexpr(&changed).unwrap();
+        }
+        managed_mut(&mut saved, "R1.R").lib_name = Some(alias.lib_id.clone());
+        saved.pages[0]
+            .library
+            .definitions
+            .insert(alias.lib_id.clone(), alias);
+        let plan = plan_reconciliation(Some(&saved), &netlist, "Alias.kicad_sch").unwrap();
+        let applied = plan.apply(Some(&saved)).unwrap();
+        let symbol = managed(&applied, "R1.R");
+        assert_eq!(symbol.lib_id, base_id);
+        assert_eq!(
+            applied.pages[0].library.definitions[symbol.library_key()],
+            base
+        );
+        assert!(
+            !applied.pages[0]
+                .library
+                .definitions
+                .contains_key("Native_1")
+        );
+        assert!(
+            plan_reconciliation(Some(&applied), &netlist, "Alias.kicad_sch")
+                .unwrap()
+                .is_empty()
+        );
+    }
+}
+
+#[test]
+fn explicit_library_replacement_is_not_mistaken_for_a_cache_rename() {
+    let mut netlist = common::compile_fixture("analysis", "simple.zen");
+    let mut saved = plan_reconciliation(None, &netlist, "Alias.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    let base_id = managed(&saved, "R1.R").lib_id.clone();
+    let base = saved.pages[0].library.definitions[&base_id].clone();
+    let alias = with_name(&base, "Native_1");
+    managed_mut(&mut saved, "R1.R").lib_name = Some(alias.lib_id.clone());
+    saved.pages[0]
+        .library
+        .definitions
+        .insert(alias.lib_id.clone(), alias);
+    let replacement = with_name(&base, "Other:Resistor");
+    netlist
+        .instances
+        .values_mut()
+        .find(|instance| instance.reference_designator.as_deref() == Some("R1"))
+        .unwrap()
+        .attributes
+        .insert(
+            "__symbol_value".into(),
+            AttributeValue::String(format_tree(&replacement.sexpr, FormatMode::Normal)),
+        );
+    let applied = plan_reconciliation(Some(&saved), &netlist, "Alias.kicad_sch")
+        .unwrap()
+        .apply(Some(&saved))
+        .unwrap();
+    assert_eq!(managed(&applied, "R1.R").lib_id, "Other:Resistor");
+    assert_eq!(managed(&applied, "R2.R").lib_id, base_id);
+    assert!(
+        plan_reconciliation(Some(&applied), &netlist, "Alias.kicad_sch")
+            .unwrap()
+            .is_empty()
+    );
+}
+
+#[test]
+#[ignore = "requires KiCad 10 CLI"]
+fn native_netlist_export_preserves_alias_pin_partitions_after_two_applies() {
+    let netlist = common::compile_fixture("analysis", "simple.zen");
+    let mut document = plan_reconciliation(None, &netlist, "Alias.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    let base_id = managed(&document, "R1.R").lib_id.clone();
+    let alias = with_name(&document.pages[0].library.definitions[&base_id], "Native_1");
+    managed_mut(&mut document, "R1.R").lib_name = Some(alias.lib_id.clone());
+    document.pages[0]
+        .library
+        .definitions
+        .insert(alias.lib_id.clone(), alias);
+    let directory = tempfile::tempdir().unwrap();
+    let file = directory.path().join("Alias.kicad_sch");
+    let output = directory.path().join("Alias.net");
+    let expected: BTreeSet<BTreeSet<(String, String)>> = [
+        vec![("R1", "1")],
+        vec![("R1", "2"), ("R2", "1")],
+        vec![("R2", "2")],
+    ]
+    .into_iter()
+    .map(|pins| {
+        pins.into_iter()
+            .map(|(reference, pin)| (reference.to_owned(), pin.to_owned()))
+            .collect()
+    })
+    .collect();
+    let mut source = document.to_kicad_sch().unwrap();
+    for apply in 0..3 {
+        std::fs::write(&file, &source).unwrap();
+        let exported = std::process::Command::new("kicad-cli")
+            .args([
+                "sch",
+                "export",
+                "netlist",
+                "--format",
+                "kicadsexpr",
+                "--output",
+            ])
+            .arg(&output)
+            .arg(&file)
+            .output()
+            .unwrap();
+        assert!(
+            exported.status.success(),
+            "{}",
+            String::from_utf8_lossy(&exported.stderr)
+        );
+        let native = pcb_sexpr::parse(&std::fs::read_to_string(&output).unwrap()).unwrap();
+        let partitions = native
+            .find_list("nets")
+            .unwrap()
+            .iter()
+            .filter_map(Sexpr::as_list)
+            .filter(|items| items.first().and_then(Sexpr::as_sym) == Some("net"))
+            .map(|net| {
+                net.iter()
+                    .filter_map(Sexpr::as_list)
+                    .filter(|items| items.first().and_then(Sexpr::as_sym) == Some("node"))
+                    .map(|node| {
+                        (
+                            pcb_sexpr::kicad::string_prop(node, "ref").unwrap(),
+                            pcb_sexpr::kicad::string_prop(node, "pin").unwrap(),
+                        )
+                    })
+                    .collect::<BTreeSet<_>>()
+            })
+            .collect::<BTreeSet<_>>();
+        assert_eq!(partitions, expected, "native export after {apply} applies");
+        let reopened = SchDocument::from_kicad_sch(&source).unwrap();
+        let applied = plan_reconciliation(Some(&reopened), &netlist, "Alias.kicad_sch")
+            .unwrap()
+            .apply(Some(&reopened))
+            .unwrap();
+        let patch = patch_page_source(&source, &applied.pages[0]).unwrap();
+        if apply > 0 {
+            assert!(patch.is_none(), "second apply changes source bytes");
+        }
+        source = patch.unwrap_or(source);
+    }
+}
+
+fn managed<'a>(document: &'a SchDocument, path: &str) -> &'a Symbol {
+    document.pages[0]
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SchItem::Symbol(symbol) if symbol.field_value("Path") == Some(path) => Some(symbol),
+            _ => None,
+        })
+        .unwrap()
+}
+
+fn managed_mut<'a>(document: &'a mut SchDocument, path: &str) -> &'a mut Symbol {
+    document.pages[0]
+        .items
+        .iter_mut()
+        .find_map(|item| match item {
+            SchItem::Symbol(symbol) if symbol.field_value("Path") == Some(path) => Some(symbol),
+            _ => None,
+        })
+        .unwrap()
+}
+
+fn with_name(definition: &SymbolDefinition, name: &str) -> SymbolDefinition {
+    let stem = definition.lib_id.rsplit(':').next().unwrap();
+    let source = format_tree(&definition.sexpr, FormatMode::Normal)
+        .replace(
+            &format!("\"{}\"", definition.lib_id),
+            &format!("\"{name}\""),
+        )
+        .replace(&format!("\"{stem}_"), &format!("\"{name}_"));
+    SymbolDefinition::from_kicad_symbol_sexpr(&source).unwrap()
+}

--- a/crates/pcb-kicad-sch/tests/symbol_aliases.rs
+++ b/crates/pcb-kicad-sch/tests/symbol_aliases.rs
@@ -206,10 +206,22 @@ fn stale_alias_pin_or_unit_interfaces_are_refreshed() {
         .unwrap();
     let base_id = managed(&document, "R1.R").lib_id.clone();
     let base = document.pages[0].library.definitions[&base_id].clone();
-    for extra_unit in [false, true] {
+    // Equivalent expanded numbers still need identical raw pin-instance keys.
+    for replacement_number in [Some("99"), Some("[1]"), Some("[1-1]"), None] {
         let mut saved = document.clone();
         let mut alias = with_name(&base, "Native_1");
-        if extra_unit {
+        if let Some(number) = replacement_number {
+            let raw = format_tree(&alias.sexpr, FormatMode::Normal);
+            let changed = raw.replace("(number \"1\"", &format!("(number \"{number}\""));
+            assert_ne!(raw, changed);
+            alias = SymbolDefinition::from_kicad_symbol_sexpr(&changed).unwrap();
+            managed_mut(&mut saved, "R1.R")
+                .pins
+                .iter_mut()
+                .find(|pin| pin.number == "1")
+                .unwrap()
+                .number = number.into();
+        } else {
             alias.sexpr.as_list_mut().unwrap().push(
                 pcb_sexpr::parse(
                     r#"(symbol "Native_1_2_1" (pin passive line (at 0 0 0)
@@ -217,11 +229,6 @@ fn stale_alias_pin_or_unit_interfaces_are_refreshed() {
                 )
                 .unwrap(),
             );
-        } else {
-            let raw = format_tree(&alias.sexpr, FormatMode::Normal);
-            let changed = raw.replace("(number \"1\"", "(number \"99\"");
-            assert_ne!(raw, changed);
-            alias = SymbolDefinition::from_kicad_symbol_sexpr(&changed).unwrap();
         }
         managed_mut(&mut saved, "R1.R").lib_name = Some(alias.lib_id.clone());
         saved.pages[0]
@@ -233,6 +240,20 @@ fn stale_alias_pin_or_unit_interfaces_are_refreshed() {
         let symbol = managed(&applied, "R1.R");
         assert_eq!(symbol.lib_id, base_id);
         assert_eq!(
+            symbol
+                .pins
+                .iter()
+                .map(|pin| &pin.number)
+                .collect::<BTreeSet<_>>(),
+            applied.pages[0].library.definitions[symbol.library_key()]
+                .placed_pins(symbol)
+                .unwrap()
+                .iter()
+                .map(|pin| &pin.number)
+                .collect::<BTreeSet<_>>(),
+            "pin instances must reference raw numbers in the retained definition"
+        );
+        assert_eq!(
             applied.pages[0].library.definitions[symbol.library_key()],
             base
         );
@@ -242,10 +263,15 @@ fn stale_alias_pin_or_unit_interfaces_are_refreshed() {
                 .definitions
                 .contains_key("Native_1")
         );
+        let source = applied.to_kicad_sch().unwrap();
+        let reopened = SchDocument::from_kicad_sch(&source).unwrap();
+        let second = plan_reconciliation(Some(&reopened), &netlist, "Alias.kicad_sch").unwrap();
+        assert!(second.is_empty());
         assert!(
-            plan_reconciliation(Some(&applied), &netlist, "Alias.kicad_sch")
+            patch_page_source(&source, &second.apply(Some(&reopened)).unwrap().pages[0])
                 .unwrap()
-                .is_empty()
+                .is_none(),
+            "second apply must be byte unchanged"
         );
     }
 }


### PR DESCRIPTION
## Behavior

Preserve resolvable KiCad embedded cache overrides through schematic apply/reopen. `lib_name` selects the page-local cached definition; `lib_id` remains the library identity. Missing overrides do not silently fall back to a different base symbol.

Keep native alias presentation when the library identity and complete unit/style electrical interface agree. Explicit replacements or interface changes use the authoritative definition. Cache insertion protects other instances, allocates/reuses collision-free names and prunes by actual cache identity.

References: [ENG-1396](https://linear.app/diodeinc/issue/ENG-1396/schematic-apply-leaves-dangling-lib-name-aliases), [ENG-1736](https://linear.app/diodeinc/issue/ENG-1736/pcb-apply-schematic-drops-kicad-1-lib-symbols-but-keeps-lib-name-refs).

## Scope

Independent PR against `main`, limited to `pcb-kicad-sch`, regressions and changelog. The analysis/repair changes only update cache lookups and constructors for the typed alias field. No stacked-NC behavior changes, importer rewrite, advisory parity change or importer cleanup is included. The legacy importer is unchanged; its page-local cache extraction changes remain with the separate persistent-import work.

## Executed verification on this branch

- `cargo nextest run -p pcb-kicad-sch --run-ignored all --no-fail-fast`: **215 passed, none skipped**, including KiCad 10.0.6 exports before/after repeated applies and exact physical-pin partitions.
- `cargo nextest run -p pcbc -E 'test(schematic)' --no-fail-fast`: **38 passed** (366 unrelated tests filtered).
- `cargo clippy -p pcb-kicad-sch -p pcbc --all-targets -- -D warnings`: passed.
- `cargo build -p pcbc`, `cargo test --doc -p pcb-kicad-sch`, `cargo fmt --all -- --check`, `git diff --check`: passed. No snapshots changed.
- Disposable public-source experiment with `R_0R_0402_1` from [Antmicro D1600E PSU breakout at the tested revision](https://github.com/antmicro/d1600e-psu-breakout/commit/3802831dcd6c9c6e278216771e92ca7fe3f9ae41): isolated alias-only cache retains its exact definition and both native physical-pin partitions; second apply is byte-unchanged. Before/after KiCad SVGs rendered in Chromium differ by **zero pixels**, inspected for intact symbol/anchors and hidden metadata.

Regression cases include asymmetric base/alias pins, absent aliases, aliases with/without base cache entries, a shared cache with one instance refreshed, changed physical pin or other-unit interface, explicit library replacement, and source-patch idempotence.

Only repository fixtures and public Antmicro inputs were used. No Antmicro fixture or experiment script is added. The public experiment is an isolated symbol derivative, **not a full-board import result**. Native saves are represented through their `lib_name`/cache data; a real GUI save and the separate Quiche frontend were not exercised.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches schematic reconciliation, embedded library caching, and connectivity lookups—core paths for net correctness—but behavior is narrowly scoped with extensive alias regression coverage.
> 
> **Overview**
> KiCad page-local symbol cache overrides (`lib_name`) are now first-class: **`lib_id` stays the library identity** while **`library_key()`** (alias or base id) drives embedded-definition lookup across compose, connectivity, analysis, and repair.
> 
> Schematic apply **round-trips native aliases** instead of dropping cache entries or silently falling back to the base symbol. When reconciliation runs, it **keeps an existing alias definition** if the library identity and full electrical pin interface still match; otherwise it installs the authoritative definition via **`cache_symbol_definition`**, which **renames colliding caches** so other instances keep their geometry. **`lib_name` is parsed and serialized** in KiCad sch format, and pruning tracks actual cache keys.
> 
> Adds **`same_pin_interface`**, **`SymbolDefinition::renamed`**, and regression tests in **`symbol_aliases.rs`** (including KiCad netlist export when CLI is available).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 221a9193089682d147ced8d2c90e70e1bf2aeacf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->