### PR TITLE
Honor stacked and hidden intentional no-connect pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 - Report and repair missing Zener `NotConnected()` intent as native KiCad no-connect markers.
 - Preserve successful BOM matches when another line needs retrying.
 - Fix false missing-output errors after applying schematics.
+- Accept one KiCad no-connect marker for stacked intentional-open pins, including hidden pins, while preserving physical pad identities and rejecting connected or cross-page collisions.
 
 ### Removed
 

--- a/crates/pcb-kicad-sch/src/analysis.rs
+++ b/crates/pcb-kicad-sch/src/analysis.rs
@@ -340,6 +340,45 @@ pub fn inspect_schematic(
     })
 }
 
+// Stacked opens belong to one symbol anchor on one page, without a wire or driver.
+fn is_open_pin_stack(island: &PhysicalIsland) -> bool {
+    let mut pins = island.pins.iter().map(|pin| pin.no_connect_target());
+    let Some(first) = pins.next() else {
+        return false;
+    };
+    island.names.is_empty()
+        && island
+            .items
+            .iter()
+            .all(|item| matches!(item, ConnectivityItemRef::NoConnect { .. }))
+        && pins.all(|pin| {
+            pin.page_id == first.page_id
+                && pin.symbol_id == first.symbol_id
+                && points_connect(pin.at, first.at)
+        })
+}
+
+fn matches_physical_terminal(pin: &Terminal, expected: &Terminal) -> bool {
+    if let (
+        Terminal::ComponentPin {
+            component,
+            pin_numbers,
+            ..
+        },
+        Terminal::ComponentPin {
+            component: other,
+            pin_numbers: other_numbers,
+            ..
+        },
+    ) = (pin, expected)
+        && !pin_numbers.is_empty()
+        && !other_numbers.is_empty()
+    {
+        return component == other && !pin_numbers.is_disjoint(other_numbers);
+    }
+    pin.matches(expected)
+}
+
 pub(crate) fn inspect_no_connects(
     document: &SchDocument,
     netlist: &Schematic,
@@ -361,7 +400,7 @@ pub(crate) fn inspect_no_connects(
             .filter(|(_, pin_terminal)| {
                 terminals
                     .iter()
-                    .any(|terminal| pin_terminal.matches(terminal))
+                    .any(|terminal| matches_physical_terminal(pin_terminal, terminal))
             })
             .map(|(pin, _)| pin.no_connect_target())
             .collect::<Vec<_>>()
@@ -396,13 +435,10 @@ pub(crate) fn inspect_no_connects(
         )
         .collect::<Vec<_>>();
     issues.extend(markers.filter_map(|(page_id, marker)| {
-        let at_desired = desired
-            .iter()
-            .any(|target| target.page_id == *page_id && points_connect(target.at, marker.at));
         let at_connected = connected
             .iter()
             .any(|target| target.page_id == *page_id && points_connect(target.at, marker.at));
-        (at_connected && !at_desired).then(|| SchematicIssue::UnexpectedNoConnect {
+        at_connected.then(|| SchematicIssue::UnexpectedNoConnect {
             page_id: page_id.clone(),
             id: marker.id.clone(),
         })
@@ -696,17 +732,11 @@ fn is_open_not_connected_group(
     if !group.names.is_empty() || group.terminals.is_empty() {
         return false;
     }
-    // Multiple physical pins may realize one logical terminal (for example,
-    // stacked pins with the same name), but distinct NotConnected terminals
-    // touching directly are still an electrical connection. Require exactly
-    // one netlist terminal to account for the whole physical island.
-    let mut matching_not_connected = not_connected.iter().filter(|candidate| {
-        group
-            .terminals
+    if !group.terminals.iter().all(|terminal| {
+        not_connected
             .iter()
-            .all(|terminal| candidate.matches(terminal))
-    });
-    if matching_not_connected.next().is_none() || matching_not_connected.next().is_some() {
+            .any(|candidate| matches_physical_terminal(terminal, candidate))
+    }) {
         return false;
     }
     let mut origins = group.origins.iter();
@@ -716,12 +746,7 @@ fn is_open_not_connected_group(
     if origins.next().is_some() {
         return false;
     }
-    islands.get(island).is_some_and(|provenance| {
-        provenance
-            .items
-            .iter()
-            .all(|item| matches!(item, ConnectivityItemRef::NoConnect { .. }))
-    })
+    islands.get(island).is_some_and(is_open_pin_stack)
 }
 
 pub(crate) fn expected_reconcilable_connectivity(
@@ -1413,10 +1438,11 @@ mod tests {
 
     #[test]
     fn not_connected_terminal_rejects_an_attached_wire() {
+        use crate::connectivity::PhysicalPinRef;
         let terminal = Terminal::ComponentPin {
             component: ComponentIdentity::ManagedPath("U1".to_string()),
             pin_name: "NC".to_string(),
-            pin_numbers: BTreeSet::from(["1".to_string()]),
+            pin_numbers: BTreeSet::from(["1".to_string(), "2".to_string()]),
         };
         let island = IslandRef {
             page_id: "page".to_string(),
@@ -1427,7 +1453,16 @@ mod tests {
             terminals: BTreeSet::from([terminal.clone()]),
             origins: BTreeSet::from([ConnectionOrigin::KiCadIsland(island.clone())]),
         };
-        let mut islands = BTreeMap::from([(island, PhysicalIsland::default())]);
+        let mut islands = BTreeMap::from([(
+            island,
+            PhysicalIsland {
+                pins: BTreeSet::from([
+                    PhysicalPinRef::new("page", "U1", "1", Point::default()),
+                    PhysicalPinRef::new("page", "U1", "2", Point::default()),
+                ]),
+                ..PhysicalIsland::default()
+            },
+        )]);
         let mut not_connected = BTreeSet::from([terminal]);
 
         assert!(is_open_not_connected_group(
@@ -1453,6 +1488,12 @@ mod tests {
         };
         group.terminals.insert(other.clone());
         not_connected.insert(other);
+        islands
+            .values_mut()
+            .next()
+            .unwrap()
+            .pins
+            .insert(PhysicalPinRef::new("page", "U2", "2", Point::default()));
         assert!(!is_open_not_connected_group(
             &group,
             &islands,

--- a/crates/pcb-kicad-sch/tests/issue_repair.rs
+++ b/crates/pcb-kicad-sch/tests/issue_repair.rs
@@ -974,6 +974,169 @@ fn wired_not_connected_pins_are_cut_free_locally() {
 }
 
 #[test]
+fn stacked_distinct_no_connects_share_one_marker_and_preserve_conflicts() {
+    use pcb_sch::{AttributeValue, InstanceKind};
+
+    let mut netlist = common::compile_fixture("multi_pad_nc", "root.zen");
+    // Distinct logical A/B terminals, including a hidden occurrence, all share
+    // a displayed name and anchor. Pad identities, not names, identify intent.
+    for instance in netlist.instances.values_mut() {
+        if instance.kind == InstanceKind::Component {
+            instance.attributes.insert("__symbol_value".into(), AttributeValue::String(r#"
+                (symbol "MULTI_PAD" (symbol "MULTI_PAD_1_1"
+                  (pin no_connect line (at -5.08 2.54 0) (length 2.54) (name "NC") (number "1"))
+                  (pin no_connect line (at -5.08 2.54 0) (length 2.54) hide (name "NC") (number "2"))
+                  (pin no_connect line (at -5.08 2.54 0) (length 2.54) (name "NC") (number "4"))))
+            "#.into()));
+        }
+    }
+    for net in netlist.nets.values_mut() {
+        net.kind = "NotConnected".into();
+    }
+    let baseline = plan_reconciliation(None, &netlist, "stacked.kicad_sch")
+        .unwrap()
+        .apply(None)
+        .unwrap();
+    let markers = baseline
+        .pages
+        .iter()
+        .enumerate()
+        .flat_map(|(index, page)| {
+            page.items.iter().filter_map(move |item| match item {
+                SchItem::NoConnect(marker) => Some((index, marker.at)),
+                _ => None,
+            })
+        })
+        .collect::<Vec<_>>();
+    let [(page_index, at)] = markers.as_slice() else {
+        panic!("expected one marker, got {markers:?}");
+    };
+    let (page_index, at) = (*page_index, *at);
+    assert!(
+        inspect_schematic(&baseline, &netlist)
+            .unwrap()
+            .issues
+            .is_empty()
+    );
+    let second = plan_reconciliation(Some(&baseline), &netlist, "stacked.kicad_sch")
+        .unwrap()
+        .apply(Some(&baseline))
+        .unwrap();
+    assert_eq!(second, baseline);
+
+    let mut missing = baseline.clone();
+    for page in &mut missing.pages {
+        page.items
+            .retain(|item| !matches!(item, SchItem::NoConnect(_)));
+    }
+    let inspection = inspect_schematic(&missing, &netlist).unwrap();
+    assert_eq!(
+        inspection
+            .issues
+            .iter()
+            .filter_map(|issue| match &issue.issue {
+                SchematicIssue::MissingNoConnect { pin_number, .. } => Some(pin_number.as_str()),
+                _ => None,
+            })
+            .collect::<BTreeSet<_>>(),
+        BTreeSet::from(["1", "2", "4"]),
+        "include the hidden pin and distinguish duplicate display names"
+    );
+    let selected = inspection
+        .issues
+        .iter()
+        .filter(|issue| matches!(issue.issue, SchematicIssue::MissingNoConnect { .. }))
+        .map(|issue| issue.key.clone())
+        .collect();
+    let repair =
+        plan_connectivity_repair(&missing, &netlist, &inspection, &selected, &BTreeSet::new())
+            .unwrap();
+    assert_eq!(repair.no_connect_additions().len(), 1);
+
+    // A marker still conflicts with B even while it correctly covers A.
+    let mut mixed = netlist.clone();
+    mixed.nets.get_mut("RIGHT").unwrap().kind = "Net".into();
+    assert!(
+        inspect_schematic(&baseline, &mixed)
+            .unwrap()
+            .issues
+            .iter()
+            .any(|issue| matches!(issue.issue, SchematicIssue::UnexpectedNoConnect { .. }))
+    );
+
+    for attachment in [
+        SchItem::Wire(Wire {
+            id: "nc-wire".into(),
+            a: at,
+            b: Point::new(at.x + 2.54, at.y),
+            unsupported: Vec::new(),
+        }),
+        SchItem::Label(pcb_kicad_sch::Label::new("nc-label", "CONNECTED", at)),
+    ] {
+        let mut connected = baseline.clone();
+        connected.pages[page_index].items.push(attachment);
+        assert!(
+            inspect_schematic(&connected, &netlist)
+                .unwrap()
+                .issues
+                .iter()
+                .any(|issue| matches!(issue.issue, SchematicIssue::UnexpectedConnection { .. }))
+        );
+    }
+
+    // An identical symbol UUID and anchor in another file must not inherit NC.
+    let mut pages = baseline.clone();
+    let mut other = pages.pages[page_index].clone();
+    other.id = "other-page".into();
+    other.file_name = Some("other.kicad_sch".into());
+    other
+        .items
+        .retain(|item| !matches!(item, SchItem::NoConnect(_)));
+    pages.root_page_ids.push(other.id.clone());
+    pages.pages.push(other);
+    let missing = inspect_schematic(&pages, &netlist)
+        .unwrap()
+        .issues
+        .into_iter()
+        .filter_map(|issue| match issue.issue {
+            SchematicIssue::MissingNoConnect {
+                page_id,
+                pin_number,
+                ..
+            } => Some((page_id, pin_number)),
+            _ => None,
+        })
+        .collect::<BTreeSet<_>>();
+    assert_eq!(
+        missing,
+        ["1", "2", "4"]
+            .into_iter()
+            .map(|pin| ("other-page".into(), pin.into()))
+            .collect()
+    );
+
+    // Two different symbols touching at their NC pins remain a real short.
+    let mut overlap = baseline.clone();
+    let mut other = overlap.pages[page_index]
+        .items
+        .iter()
+        .find_map(|item| match item {
+            SchItem::Symbol(symbol) => Some(symbol.clone()),
+            _ => None,
+        })
+        .unwrap();
+    other.id = "different-symbol".into();
+    overlap.pages[page_index].items.push(SchItem::Symbol(other));
+    assert!(
+        inspect_schematic(&overlap, &netlist)
+            .unwrap()
+            .issues
+            .iter()
+            .any(|issue| matches!(issue.issue, SchematicIssue::UnexpectedConnection { .. }))
+    );
+}
+
+#[test]
 fn one_missing_no_connect_issue_repairs_all_uncovered_physical_pin_occurrences() {
     let mut netlist = common::compile_fixture("multi_pad_nc", "root.zen");
     let mut not_connected = netlist.nets.remove("LEFT").unwrap();


### PR DESCRIPTION
## Behavior

Accept one native no-connect marker for every expected intentional-open physical pin at the same symbol anchor on the same page, including hidden pins. Physical pad numbers take precedence over duplicate displayed names when matching NC intent.

Distinct expected NC terminals in a stack are not treated as a short. Wires, labels/named drivers, touching different symbols and mixed connected/NC expectations still conflict. Missing markers still produce per-physical-pin diagnostics, while repair needs only one marker at a shared anchor.

References: [ENG-1412](https://linear.app/diodeinc/issue/ENG-1412/stacked-no-connect-pins-make-freshness-impossible), [ENG-1682](https://linear.app/diodeinc/issue/ENG-1682/stacked-nc-pins-block-schematic-composition). Regression coverage also protects the page-isolation boundary described in [ENG-1728](https://linear.app/diodeinc/issue/ENG-1728/nc-marker-lookup-collides-across-schematic-sheets); this is not a claim to update the separate frontend or implement cross-sheet multi-unit import.

## Scope

Independent PR against `main`: shared `pcb-kicad-sch` analysis, regression coverage and changelog only. No dependency on cache-alias support. No importer rewrite, source-partition normalization, advisory parity change or importer cleanup. The importer-only marker query API is deliberately omitted because main has no consumer; importer adoption remains with the separate persistent-import work.

## Executed verification on this branch

- `cargo nextest run -p pcb-kicad-sch --run-ignored all --no-fail-fast`: **210 passed, none skipped**.
- `cargo nextest run -p pcbc -E 'test(schematic)' --no-fail-fast`: **38 passed** (366 unrelated tests filtered).
- `cargo clippy -p pcb-kicad-sch -p pcbc --all-targets -- -D warnings`: passed.
- `cargo build -p pcbc`, `cargo test --doc -p pcb-kicad-sch`, `cargo fmt --all -- --check`, `git diff --check`: passed. No snapshots changed.
- Disposable public-source experiment using the unchanged `PUSB3F96X_PASS` definition from [Antmicro Jetson AGX CSI adapter at the tested revision](https://github.com/antmicro/jetson-agx-csi-adapter/commit/c13f1ff8c8bd168d2ed7c2ac934024fc8acc939e): isolated all-open derivative with **10 independent NC terminals, five native markers and five native geometric partitions**. KiCad 10.0.6 exports preserve all ten physical pins and the five partitions through repeated apply; applies require no edits and source bytes remain unchanged. Before/after KiCad SVGs rendered in Chromium differ by **zero pixels**, inspected for intact symbols and markers.

The regression covers hidden/same-name distinct pins, one-marker repair, wired/labelled stacks, touching unrelated symbols, mixed intent, repeated UUID/coordinates on different pages, and repeated reconciliation.

Only repository fixtures and public Antmicro inputs were used. No Antmicro fixture or experiment script is added. The public experiment is an isolated symbol derivative, **not a full-board import result**. Full Antmicro imports still encounter main's existing parity/importer/unsupported-construct limitations; the separate Quiche frontend was not exercised.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes schematic connectivity and no-connect validation in pcb-kicad-sch, which affects reconciliation and repair; behavior is narrowly scoped but touches electrical intent matching.
> 
> **Overview**
> **Schematic no-connect handling** now treats multiple intentional-open pins at the **same symbol anchor on one page** as one stack: a **single** KiCad no-connect marker can satisfy every expected open pin there, including **hidden** pins, while **missing-marker** diagnostics still report each physical pad number.
> 
> Matching uses **pad-number overlap** (`matches_physical_terminal`) instead of looser terminal equality, and open stacks are recognized when the physical island is only no-connect items with pins sharing page, symbol, and anchor (`is_open_pin_stack`). **Unexpected no-connect** is raised only when a marker sits on a **connected** pin—not when it correctly covers a stacked NC anchor. Observed connectivity drops these open stacks so distinct NC terminals at one anchor are not treated as shorts.
> 
> Changelog updated; integration test covers one-marker reconciliation/repair, mixed connected/NC intent, wires/labels, cross-page isolation, and overlapping symbols.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab40e3750bda71d1a2674335e1e434131cb611f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->